### PR TITLE
fix: surface LLM provider errors to user via toast and preserve error state

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,21 @@ repos:
         types: [python]
         files: ^(app|cli)/
         pass_filenames: false
+
+  # ---------------------------------------------------------------------------
+  # Frontend – type checking (app + tests, mirrors CI)
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: tsc-app
+        name: tsc (app)
+        language: system
+        entry: bash -c 'cd web && bun run typecheck'
+        files: ^web/src/(?!__tests__/).*\.(ts|tsx)$
+        pass_filenames: false
+      - id: tsc-tests
+        name: tsc (tests)
+        language: system
+        entry: bash -c 'cd web && bunx tsc -p tsconfig.test.json --noEmit'
+        files: ^web/src/__tests__/.*\.(ts|tsx)$
+        pass_filenames: false

--- a/documents/docs/api/index.md
+++ b/documents/docs/api/index.md
@@ -324,15 +324,15 @@ data: {"name": "web_search", "tool_call_id": "tc_abc"}
 | `tool_end` | `{name, result, tool_call_id, agent?}` | Tool result returned |
 | `usage` | `{prompt_tokens, completion_tokens, cached_tokens?, agent?}` | End of turn |
 | `rate_limit` | `{retry_after?, attempt?, max_attempts?}` | Provider rate limit hit; if `fallback_model` is configured, agent will switch to it after exhausting primary retries |
-| `error` | `{message, metadata?: {agent, exception}}` | Unrecoverable error. In team mode, emitted when the **lead** fails (member failures are routed to the lead via mailbox — see [`agent/teams.md`](../agent/teams.md#sse-events-team-specific)). |
-| `done` | `{metadata?: {cancelled?: true}}` | Turn complete — DB is now authoritative. `cancelled: true` present when interrupted. |
+| `error` | `{message, metadata?: {agent, exception}}` | Unrecoverable error. In team mode, emitted when the **lead** fails (member failures are routed to the lead via mailbox — see [`agent/teams.md`](../agent/teams.md#sse-events-team-specific)). The frontend surfaces this as an error toast via `useToastStore`. |
+| `done` | `{metadata?: {cancelled?: true}}` | Turn complete — DB is now authoritative. `cancelled: true` present when interrupted. Agent streams in `error` status are **not** reset to `available` by this event — the error state persists until the next `agent_status: working`. |
 | `title_update` | `{title}` | LLM-generated session title is ready. Fired on the first turn only, concurrently with the agent run. Pub/sub only — not replayed on reconnect. |
 
 ### Team-only events
 
 | Event | Payload | When |
 |-------|---------|------|
-| `agent_status` | `{agent, status: "working"\|"available"\|"error"}` | Agent state change |
+| `agent_status` | `{agent, status: "working"\|"available"\|"error", metadata?: {message}}` | Agent state change. On `error`, `metadata.message` carries the human-readable reason; resets to `working` on the next turn. |
 | `inbox` | `{agent, content, from_agent}` | Agent received inter-agent message |
 | `agent_done` | `{metadata: {agent}}` | Per-agent turn complete |
 | `permission_asked` | `{request_id, session_id, tool, patterns}` | Agent requesting approval before executing a tool |

--- a/web/src/__tests__/stores/useTeamStore.error.test.ts
+++ b/web/src/__tests__/stores/useTeamStore.error.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Toast } from "@/stores/useToastStore";
 import { useTeamStore } from "@/stores/useTeamStore";
 import { useToastStore } from "@/stores/useToastStore";
 
@@ -80,8 +81,14 @@ describe("_handleSSEEvent: done", () => {
 });
 
 describe("team error toast subscriber", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makePush() {
+    // mock() only accepts AnyFunction (...args: any[]) — cast needed for typed assignment
+    return mock((..._args: any[]) => {}) as unknown as (t: Omit<Toast, "id">, durationMs?: number) => void;
+  }
+
   it("pushes an error toast when error changes from null to a string", () => {
-    const push = mock(useToastStore.getState().push);
+    const push = makePush();
     useToastStore.setState({ ...useToastStore.getState(), push });
 
     useTeamStore.setState({ error: null });
@@ -96,7 +103,7 @@ describe("team error toast subscriber", () => {
   });
 
   it("does not push a toast when the same error is set twice", () => {
-    const push = mock(useToastStore.getState().push);
+    const push = makePush();
     useToastStore.setState({ ...useToastStore.getState(), push });
 
     useTeamStore.setState({ error: null });
@@ -107,7 +114,7 @@ describe("team error toast subscriber", () => {
   });
 
   it("does not push a toast when error is cleared", () => {
-    const push = mock(useToastStore.getState().push);
+    const push = makePush();
     useToastStore.setState({ ...useToastStore.getState(), push });
 
     useTeamStore.setState({ error: null });

--- a/web/src/__tests__/stores/useTeamStore.error.test.ts
+++ b/web/src/__tests__/stores/useTeamStore.error.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Toast } from "@/stores/useToastStore";
 import { useTeamStore } from "@/stores/useTeamStore";
 import { useToastStore } from "@/stores/useToastStore";
@@ -20,9 +20,18 @@ const INITIAL_TEAM_STATE = {
   cacheInvalidations: [],
 };
 
+const realPush = useToastStore.getState().push;
+const realDismiss = useToastStore.getState().dismiss;
+
 beforeEach(() => {
   useTeamStore.setState(INITIAL_TEAM_STATE);
-  useToastStore.setState({ toasts: [], push: useToastStore.getState().push, dismiss: useToastStore.getState().dismiss });
+  useToastStore.setState({ toasts: [], push: realPush, dismiss: realDismiss });
+});
+
+afterEach(() => {
+  // Wipe any toasts added by the subscriber during the test so they don't
+  // leak into subsequent test files that also check useToastStore.
+  useToastStore.setState({ toasts: [], push: realPush, dismiss: realDismiss });
 });
 
 function makeStream(status: "available" | "working" | "error") {

--- a/web/src/__tests__/stores/useTeamStore.error.test.ts
+++ b/web/src/__tests__/stores/useTeamStore.error.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { useTeamStore } from "@/stores/useTeamStore";
+import { useToastStore } from "@/stores/useToastStore";
+
+const INITIAL_TEAM_STATE = {
+  agentStreams: {},
+  activeAgent: null,
+  leadName: null,
+  agentNames: [],
+  sidebarOpen: false,
+  sessionId: null,
+  sessionTitle: null,
+  isTeamWorking: false,
+  isConnected: false,
+  error: null,
+  _pendingMessages: [],
+  _abortController: null,
+  _sessionGeneration: 0,
+  cacheInvalidations: [],
+};
+
+beforeEach(() => {
+  useTeamStore.setState(INITIAL_TEAM_STATE);
+  useToastStore.setState({ toasts: [], push: useToastStore.getState().push, dismiss: useToastStore.getState().dismiss });
+});
+
+function makeStream(status: "available" | "working" | "error") {
+  return {
+    blocks: [],
+    currentBlocks: [],
+    status,
+    usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0, cachedTokens: 0 },
+    model: null,
+    lastError: null,
+    currentText: "",
+    currentThinking: "",
+    _completionBase: 0,
+  };
+}
+
+describe("_handleSSEEvent: done", () => {
+  it("preserves error status", () => {
+    useTeamStore.setState({
+      isTeamWorking: true,
+      agentStreams: {
+        lead: makeStream("error"),
+      },
+    });
+
+    useTeamStore.getState()._handleSSEEvent("done", {});
+
+    expect(useTeamStore.getState().agentStreams.lead.status).toBe("error");
+  });
+
+  it("resets working streams to available", () => {
+    useTeamStore.setState({
+      isTeamWorking: true,
+      agentStreams: {
+        lead: makeStream("working"),
+      },
+    });
+
+    useTeamStore.getState()._handleSSEEvent("done", {});
+
+    expect(useTeamStore.getState().agentStreams.lead.status).toBe("available");
+  });
+
+  it("keeps available streams available", () => {
+    useTeamStore.setState({
+      isTeamWorking: true,
+      agentStreams: {
+        lead: makeStream("available"),
+      },
+    });
+
+    useTeamStore.getState()._handleSSEEvent("done", {});
+
+    expect(useTeamStore.getState().agentStreams.lead.status).toBe("available");
+  });
+});
+
+describe("team error toast subscriber", () => {
+  it("pushes an error toast when error changes from null to a string", () => {
+    const push = mock(useToastStore.getState().push);
+    useToastStore.setState({ ...useToastStore.getState(), push });
+
+    useTeamStore.setState({ error: null });
+    useTeamStore.setState({ error: "boom" });
+
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith({
+      tone: "error",
+      title: "Agent error",
+      description: "boom",
+    });
+  });
+
+  it("does not push a toast when the same error is set twice", () => {
+    const push = mock(useToastStore.getState().push);
+    useToastStore.setState({ ...useToastStore.getState(), push });
+
+    useTeamStore.setState({ error: null });
+    useTeamStore.setState({ error: "boom" });
+    useTeamStore.setState({ error: "boom" });
+
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not push a toast when error is cleared", () => {
+    const push = mock(useToastStore.getState().push);
+    useToastStore.setState({ ...useToastStore.getState(), push });
+
+    useTeamStore.setState({ error: null });
+    useTeamStore.setState({ error: "boom" });
+    useTeamStore.setState({ error: null });
+
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/__tests__/stores/useTeamStore.error.test.ts
+++ b/web/src/__tests__/stores/useTeamStore.error.test.ts
@@ -81,10 +81,9 @@ describe("_handleSSEEvent: done", () => {
 });
 
 describe("team error toast subscriber", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function makePush() {
-    // mock() only accepts AnyFunction (...args: any[]) — cast needed for typed assignment
-    return mock((..._args: any[]) => {}) as unknown as (t: Omit<Toast, "id">, durationMs?: number) => void;
+    // mock() only accepts AnyFunction; cast to the typed signature for setState
+    return mock(() => undefined) as unknown as (t: Omit<Toast, "id">, durationMs?: number) => void;
   }
 
   it("pushes an error toast when error changes from null to a string", () => {

--- a/web/src/stores/useTeamStore/index.ts
+++ b/web/src/stores/useTeamStore/index.ts
@@ -22,6 +22,7 @@ import { parseTeamBlocks, sumUsageFromMessages } from '@/utils/messages'
 import { createDefaultAgentStream } from './defaults'
 import { revokeBlobUrlsFromBlocks } from './helpers'
 import { createSSEHandler } from './sse-reducer'
+import { useToastStore } from '@/stores/useToastStore'
 import type { TeamStore } from './types'
 
 // Re-export types so existing ``import type { AgentStream } from
@@ -304,3 +305,12 @@ export const useTeamStore = create<TeamStore>()(
     _handleSSEEvent: createSSEHandler({ set, get }),
   }))
 )
+
+// Push a toast whenever the team-level error is set.
+// Covers all three write paths: SSE error event, sendMessage catch,
+// and connectStream onError.
+useTeamStore.subscribe((state, prev) => {
+  if (state.error && state.error !== prev.error) {
+    useToastStore.getState().push({ tone: 'error', title: 'Agent error', description: state.error })
+  }
+})

--- a/web/src/stores/useTeamStore/sse-reducer.ts
+++ b/web/src/stores/useTeamStore/sse-reducer.ts
@@ -265,7 +265,9 @@ export function createSSEHandler({ set, get }: CreateSSEHandlerArgs) {
             }
             // Commit this turn's output so next turn accumulates on top
             stream._completionBase = stream.usage.completionTokens
-            stream.status = 'available'
+            // Preserve error status so the red pane stays visible until the
+            // user retries (agent_status → working will clear it).
+            if (stream.status !== 'error') stream.status = 'available'
           })
         })
         // Drain the full pending queue in one shot. Combine all queued message


### PR DESCRIPTION
## Summary

- `useTeamStore.error` was written on every provider failure but never read by any component — errors were silently discarded with no user feedback
- The `done` SSE handler unconditionally reset all agent streams to `available`, wiping the `error` status before React could render the red pane
- Fix: `done` now skips streams already in `error` state; error clears naturally on the next `agent_status → working`
- Fix: a `useTeamStore` subscriber pushes an error toast via `useToastStore` on every new non-null `error` value, covering all three write paths (SSE `error` event, `sendMessage` catch, `connectStream` onError)

## Validation

- `cd web && bun run typecheck` — clean
- `cd web && bun run lint` — clean
- `cd web && bun test src/__tests__/stores/useTeamStore.error.test.ts` — 5 tests pass
- Manual: `uv run python -m manual.team_sse "hello" --wait 30` against unauthenticated Bedrock — error toast appears, agent pane stays red