### PR TITLE
feat: add Ollama provider (local + cloud)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,14 @@ ROUTER9_API_KEY=
 CLIPROXY_API_KEY=
 # CLIPROXY_BASE_URL=http://localhost:8317/v1
 
+# Ollama — local daemon (https://ollama.com)
+# No real API key needed (defaults to "ollama" placeholder; the daemon
+# ignores it). Cloud models are reached through the same daemon by
+# suffixing the model name with "-cloud" after running `ollama signin`.
+# OLLAMA_BASE_URL defaults to http://localhost:11434/v1.
+# OLLAMA_API_KEY=ollama
+# OLLAMA_BASE_URL=http://localhost:11434/v1
+
 # Vertex AI — requires a GCP project (no separate API key)
 # Run: gcloud auth application-default login
 # GOOGLE_CLOUD_PROJECT=

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Brand assets live in [`documents/assets/brand`](documents/assets/brand/) for doc
 
 **See exactly what the agent is doing.** Built-in OTel dashboard — token usage, latency, trace waterfall. No third-party SaaS, all local.
 
-**Pick your model, no lock-in.** 12 providers — Gemini, OpenAI, OpenRouter, Bedrock, Grok, DeepSeek, and more. Switch with one line in your agent config.
+**Pick your model, no lock-in.** 14 providers — Gemini, OpenAI, OpenRouter, Bedrock, Grok, DeepSeek, Ollama, and more. Switch with one line in your agent config.
 
 ---
 
@@ -120,6 +120,7 @@ Switch models with a single line in your agent's `.md` config file. Every provid
 | OpenAI Codex | `codex:gpt-5.5` | `openagentd auth codex` |
 | 9Router (local) | `router9:cc/claude-sonnet-4-5` | `ROUTER9_BASE_URL` |
 | CLIProxyAPI (local) | `cliproxy:gemini-2.5-pro` | `CLIPROXY_BASE_URL` |
+| Ollama (local + cloud) | `ollama:llama3.2` · `ollama:kimi-k2.6-cloud` | none (cloud: `ollama signin`) |
 
 Set a `fallback_model` in your agent config for automatic failover on rate limits or 5xx errors.
 

--- a/app/agent/providers/capabilities.py
+++ b/app/agent/providers/capabilities.py
@@ -119,6 +119,10 @@ _PREFIX_FALLBACKS: list[tuple[str, ModelCapabilities]] = [
     ("openrouter:", ModelCapabilities(input=ModelInputCapabilities(vision=False))),
     # NVIDIA NIM: too varied — text only unless more specific
     ("nvidia:", ModelCapabilities(input=ModelInputCapabilities(vision=False))),
+    # Ollama: catalog spans text-only (Llama, Qwen, DeepSeek) and vision
+    # (Llava, Llama 3.2-vision, qwen3-vl). Conservative default — list
+    # exact vision models in capabilities.yaml when needed.
+    ("ollama:", ModelCapabilities(input=ModelInputCapabilities(vision=False))),
     # 9Router: aggregator proxy fronts many vision-capable models (Claude,
     # Gemini, GPT-4o, etc.); default vision=true and let exact entries opt out.
     ("router9:", ModelCapabilities(input=ModelInputCapabilities(vision=True))),

--- a/app/agent/providers/factory.py
+++ b/app/agent/providers/factory.py
@@ -28,6 +28,7 @@ from app.agent.providers.copilot import CopilotProvider
 from app.agent.providers.deepseek import DeepSeekProvider
 from app.agent.providers.geminicli import GeminiCLIProvider
 from app.agent.providers.googlegenai import GoogleGenAIProvider
+from app.agent.providers.ollama import OllamaProvider
 from app.agent.providers.openai import OpenAIProvider
 from app.agent.providers.vertexai import VertexAIProvider
 from app.agent.providers.xai import XAIProvider
@@ -43,6 +44,7 @@ SUPPORTED_PROVIDERS: tuple[str, ...] = (
     "geminicli",
     "googlegenai",
     "nvidia",
+    "ollama",
     "openai",
     "openrouter",
     "router9",
@@ -201,6 +203,21 @@ def build_provider(
                     s.DEEPSEEK_API_KEY, "DEEPSEEK_API_KEY", "DeepSeek"
                 ),
                 model=model,
+                model_kwargs=kwargs,
+            )
+        case "ollama":
+            # Local Ollama daemon. OLLAMA_API_KEY defaults to "ollama" so
+            # the OpenAI SDK's required Authorization header is satisfied;
+            # the daemon ignores it. Override OLLAMA_BASE_URL when the
+            # daemon runs on another host/port. Cloud models are reachable
+            # through the same daemon with the "-cloud" suffix once the
+            # user has run "ollama signin".
+            return OllamaProvider(
+                api_key=require_api_key(s.OLLAMA_API_KEY, "OLLAMA_API_KEY", "Ollama"),
+                model=model,
+                base_url=os.getenv("OLLAMA_BASE_URL")
+                or s.OLLAMA_BASE_URL
+                or "http://localhost:11434/v1",
                 model_kwargs=kwargs,
             )
         case "zai":

--- a/app/agent/providers/ollama/__init__.py
+++ b/app/agent/providers/ollama/__init__.py
@@ -1,0 +1,3 @@
+from .ollama import OllamaProvider
+
+__all__ = ["OllamaProvider"]

--- a/app/agent/providers/ollama/ollama.py
+++ b/app/agent/providers/ollama/ollama.py
@@ -1,0 +1,86 @@
+"""Ollama provider — OpenAI-compatible API.
+
+Ollama exposes an OpenAI-compatible ``/v1/chat/completions`` endpoint on
+the local daemon at ``http://localhost:11434/v1``. This single endpoint
+serves both locally-pulled models *and* hosted Ollama Cloud models —
+cloud models are routed transparently when the model name carries the
+``-cloud`` suffix (e.g. ``kimi-k2.6-cloud``) and the user has signed in
+via ``ollama signin``.
+
+There is no separate cloud HTTPS endpoint. ``ollama.com`` exposes only
+its native (non-OpenAI) API at ``/api/chat``; the OpenAI compatibility
+layer lives only on the local daemon.
+
+Endpoint:  http://localhost:11434/v1 (override via ``OLLAMA_BASE_URL``)
+Auth:      None — ``OLLAMA_API_KEY`` defaults to a placeholder so the
+           OpenAI SDK's mandatory ``Authorization`` header is satisfied.
+Docs:      https://docs.ollama.com/api/openai
+Cloud:     https://docs.ollama.com/cloud (run ``ollama signin`` first)
+
+Usage::
+
+    model: ollama:llama3.2
+    model: ollama:qwen2.5-coder:7b
+    model: ollama:kimi-k2.6-cloud      # routed to Ollama Cloud
+    model: ollama:gpt-oss:120b-cloud   # routed to Ollama Cloud
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic.types import SecretStr
+
+from app.agent.providers.openai import OpenAIProvider
+
+OLLAMA_LOCAL_API_BASE = "http://localhost:11434/v1"
+
+
+class OllamaProvider(OpenAIProvider):
+    """Ollama provider (OpenAI-compatible).
+
+    Defaults to the standard local daemon at ``http://localhost:11434/v1``.
+    Pass ``base_url`` to point at a remote Ollama instance. Cloud models
+    are accessed through the same daemon by appending ``-cloud`` to the
+    model name (e.g. ``kimi-k2.6-cloud``); run ``ollama signin`` once to
+    authenticate.
+
+    Args:
+        api_key: Ignored by the daemon, but the OpenAI SDK requires
+            *some* value. Defaults to ``"ollama"`` if blank.
+        model: Model name as listed by ``ollama list`` (e.g. ``"llama3.2"``,
+            ``"qwen2.5-coder:7b"``, ``"kimi-k2.6-cloud"``).
+        base_url: Override the default local URL.
+        temperature: Sampling temperature (0-2).
+        top_p: Nucleus sampling probability mass cutoff.
+        max_tokens: Hard cap on completion tokens.
+        model_kwargs: Extra request body fields passed as-is.
+    """
+
+    def __init__(
+        self,
+        api_key: str | SecretStr = "ollama",
+        model: str = "",
+        base_url: str = OLLAMA_LOCAL_API_BASE,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        # The daemon requires no auth, but the OpenAI client mandates a
+        # non-empty Authorization header. Fall back to "ollama" when the
+        # caller passed an empty string.
+        resolved_key = (
+            api_key.get_secret_value() if isinstance(api_key, SecretStr) else api_key
+        )
+        if not resolved_key:
+            resolved_key = "ollama"
+        super().__init__(
+            api_key=resolved_key,
+            model=model,
+            base_url=base_url,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            model_kwargs=model_kwargs,
+        )

--- a/app/cli/commands/doctor.py
+++ b/app/cli/commands/doctor.py
@@ -30,8 +30,10 @@ _LLM_API_KEY_VARS: tuple[str, ...] = (
 
 #: Providers that authenticate via OAuth or ADC — no API key required.
 #: Doctor should not fail or warn when these are the configured provider.
+#: ``ollama`` is here too: the local daemon ignores auth and the
+#: settings layer ships a placeholder key by default.
 _OAUTH_PROVIDERS: frozenset[str] = frozenset(
-    {"copilot", "codex", "vertexai", "cliproxy", "router9"}
+    {"copilot", "codex", "vertexai", "cliproxy", "router9", "ollama"}
 )
 
 

--- a/app/cli/commands/init.py
+++ b/app/cli/commands/init.py
@@ -25,6 +25,7 @@ _PROVIDER_KEY_VAR: dict[str, str] = {
     "deepseek": "DEEPSEEK_API_KEY",
     "router9": "ROUTER9_API_KEY",
     "cliproxy": "CLIPROXY_API_KEY",
+    "ollama": "OLLAMA_API_KEY",
 }
 
 #: Provider → curated model list (last entry = "custom" sentinel added at runtime)
@@ -138,6 +139,24 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-opus-4-6",
         "claude-haiku-4-5-20251001",
     ],
+    "ollama": [
+        # Locally pulled models (run `ollama pull <model>` first)
+        "llama3.2",
+        "llama3.2:1b",
+        "qwen2.5-coder",
+        "qwen2.5-coder:7b",
+        "deepseek-r1",
+        "gemma3",
+        "mistral",
+        "llava",
+        # Cloud models — routed via local daemon after `ollama signin`
+        "kimi-k2.6-cloud",
+        "deepseek-v4-pro-cloud",
+        "deepseek-v4-flash-cloud",
+        "glm-5.1-cloud",
+        "qwen3.5-cloud",
+        "gpt-oss:120b-cloud",
+    ],
 }
 
 
@@ -171,6 +190,7 @@ def cmd_init(args: argparse.Namespace) -> None:  # noqa: C901
         "deepseek     — DeepSeek (deepseek-v4, deepseek-r1)",
         "router9      — 9Router local proxy (40+ providers, OpenAI-compatible)",
         "cliproxy     — CLIProxyAPI local proxy (Gemini/Codex/Claude OAuth)",
+        "ollama       — Ollama local daemon (no API key; cloud via -cloud suffix)",
     ]
     idx = _menu("Choose your LLM provider:", provider_labels)
     provider = providers[idx]
@@ -197,6 +217,15 @@ def cmd_init(args: argparse.Namespace) -> None:  # noqa: C901
     elif provider == "codex":
         print(f"  {_dim('ℹ')}  No API key needed — authenticate via OAuth after setup.")
         print(f"     Run: {_bold('openagentd auth codex')}")
+    elif provider == "ollama":
+        print(
+            f"  {_dim('ℹ')}  Ollama needs no API key — make sure the daemon is running "
+            f"({_bold('ollama serve')})."
+        )
+        print(
+            f"     For cloud models (suffix {_bold('-cloud')}), run "
+            f"{_bold('ollama signin')} first."
+        )
     elif provider == "vertexai":
         gcp_project = _ask("Google Cloud project ID:")
         loc_input = _ask("Cloud location [global]:")
@@ -249,6 +278,10 @@ def cmd_init(args: argparse.Namespace) -> None:  # noqa: C901
         new_comments["CLIPROXY_API_KEY"] = (
             "# CLIPROXY_BASE_URL=http://localhost:8317/v1"
         )
+    elif provider == "ollama":
+        # Local daemon — defaults (placeholder key + localhost URL) cover it.
+        # Nothing to write; users override OLLAMA_BASE_URL manually if needed.
+        pass
     elif provider == "vertexai":
         new_creds["GOOGLE_CLOUD_PROJECT"] = gcp_project
         new_creds["GOOGLE_CLOUD_LOCATION"] = gcp_location

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -103,6 +103,17 @@ class Settings(BaseSettings):
     )
     CLIPROXY_BASE_URL: str = "http://localhost:8317/v1"
 
+    # Ollama (local daemon) — OpenAI-compatible endpoint at
+    # http://localhost:11434/v1 by default. The daemon ignores auth, but
+    # the OpenAI client requires a non-empty Authorization header — so
+    # OLLAMA_API_KEY defaults to "ollama" (Ollama's documented placeholder).
+    # Cloud models are reached through the same daemon by suffixing the
+    # model name with "-cloud" after running "ollama signin".
+    OLLAMA_API_KEY: SecretStr = Field(
+        default=SecretStr("ollama"), description="Used for local Ollama provider"
+    )
+    OLLAMA_BASE_URL: str = "http://localhost:11434/v1"
+
     # Vertex AI API key (Google Cloud key, NOT an AI Studio key)
     # Obtain from: https://console.cloud.google.com/expressmode
     VERTEXAI_API_KEY: SecretStr | None = None

--- a/documents/docs/configuration.md
+++ b/documents/docs/configuration.md
@@ -52,6 +52,8 @@ What lives where:
 | `ROUTER9_BASE_URL` | `http://localhost:20128/v1` | OpenAI-compatible base URL of your 9Router instance |
 | `CLIPROXY_API_KEY` | — | Required for `cliproxy` provider ([CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) local proxy). Use whatever your proxy enforces (any value if auth is disabled). |
 | `CLIPROXY_BASE_URL` | `http://localhost:8317/v1` | OpenAI-compatible base URL of your CLIProxyAPI instance |
+| `OLLAMA_API_KEY` | `ollama` | Used for the `ollama` provider. The daemon ignores auth, but the OpenAI client requires a non-empty header — leave the default unless you front Ollama with a custom auth proxy. |
+| `OLLAMA_BASE_URL` | `http://localhost:11434/v1` | OpenAI-compatible base URL of your Ollama daemon |
 | `NINJA_API_KEY` | — | Quote of the Day via [API Ninjas](https://api-ninjas.com) (free tier: 3 000 calls/month) |
 | — | — | `copilot` provider: run `openagentd auth copilot` (no env var needed) |
 | — | — | `codex` provider: run `openagentd auth codex` (no env var needed) |
@@ -139,6 +141,9 @@ model: bedrock:anthropic.claude-sonnet-4-6         # AWS Bedrock (in-region)
 model: bedrock:amazon.nova-pro-v1:0                # AWS Bedrock Nova
 model: router9:cc/claude-sonnet-4-5-20250929  # 9Router local proxy (set ROUTER9_API_KEY)
 model: cliproxy:gemini-2.5-pro            # CLIProxyAPI local proxy (set CLIPROXY_API_KEY)
+model: ollama:llama3.2                    # Ollama local daemon (no API key needed)
+model: ollama:qwen2.5-coder:7b            # Any model pulled with `ollama pull`
+model: ollama:kimi-k2.6-cloud             # Ollama Cloud (run `ollama signin` first)
 ```
 
 #### Local proxy providers (`router9`, `cliproxy`)
@@ -167,6 +172,67 @@ for the pattern).
 
 If `cliproxy` is run without auth, any non-empty `CLIPROXY_API_KEY` works (the
 header is required by the OpenAI client).
+
+#### Ollama provider
+
+Talks to the local Ollama daemon at `http://localhost:11434/v1` over its
+[OpenAI-compatible API](https://docs.ollama.com/api/openai). The daemon
+ignores auth, so `OLLAMA_API_KEY` defaults to the `"ollama"` placeholder
+(only there to satisfy the OpenAI SDK's mandatory `Authorization` header).
+
+**Setup:**
+
+```bash
+ollama serve                # daemon (usually already running)
+ollama pull llama3.2        # pull any model
+```
+
+```yaml
+model: ollama:llama3.2
+model: ollama:qwen2.5-coder:7b   # tags (`:7b`) work — passed through verbatim
+model: ollama:llava              # vision-capable; opt in via capabilities.yaml
+```
+
+The model name after `ollama:` is passed verbatim to the daemon — use
+exactly what `ollama list` shows, including any tag.
+
+**Cloud models.** Ollama Cloud runs *through* the same local daemon —
+there is no separate HTTPS endpoint. After running `ollama signin` once,
+any model name with the `-cloud` suffix is transparently routed to
+[ollama.com](https://ollama.com):
+
+```yaml
+model: ollama:kimi-k2.6-cloud
+model: ollama:deepseek-v4-pro-cloud
+model: ollama:glm-5.1-cloud
+model: ollama:gpt-oss:120b-cloud
+```
+
+See the live cloud catalog at [ollama.com/search?c=cloud](https://ollama.com/search?c=cloud).
+
+**Remote daemon.** To point at a daemon on another machine, override the
+base URL:
+
+```bash
+# .env
+OLLAMA_BASE_URL=http://gpu-box.local:11434/v1
+```
+
+**Capability defaults:** vision is `false` for the `ollama:` prefix (the
+catalog spans text-only Llama/Qwen/DeepSeek and vision-capable
+Llava/qwen3-vl). Add an entry to `app/agent/providers/capabilities.yaml`
+for any specific vision-capable model you use:
+
+```yaml
+"ollama:llava":
+  input:
+    vision: true
+"ollama:qwen3-vl:8b":
+  input:
+    vision: true
+```
+
+---
 
 #### OpenAI Codex provider
 

--- a/manual/AGENTS.md
+++ b/manual/AGENTS.md
@@ -155,6 +155,7 @@ Hit LLM provider APIs directly — **no server required**, uses API keys from `.
 | `try_providers/try_vertexai.py` | Test Vertex AI provider | `--model`, `--level`, `--tools`, `--real-tools` |
 | `try_providers/try_zai.py` | Test ZAI provider | `--model`, `--level`, `--tools`, `--real-tools` |
 | `try_providers/try_geminicli.py` | Test GeminiCLI provider (OAuth, no API key) | `--model`, `--level`, `--tools`, `--real-tools` |
+| `try_providers/try_ollama.py` | Test Ollama provider (local daemon; cloud via `-cloud` suffix after `ollama signin`) | `--model`, `--tools`, `--real-tools`, `--no-stream`, `--simple` |
 
 ```bash
 uv run python -m manual.try_providers.try_openai
@@ -165,6 +166,8 @@ uv run python -m manual.try_providers.try_googlegenai --real-tools
 uv run python -m manual.try_providers.try_vertexai --simple
 uv run python -m manual.try_providers.try_zai --simple
 uv run python -m manual.try_providers.try_geminicli --simple
+uv run python -m manual.try_providers.try_ollama --simple
+uv run python -m manual.try_providers.try_ollama --model kimi-k2.6-cloud --simple
 ```
 
 ---

--- a/manual/try_providers/try_ollama.py
+++ b/manual/try_providers/try_ollama.py
@@ -1,0 +1,84 @@
+"""Test Ollama provider directly — streaming, chat, and tools.
+
+Talks to the local Ollama daemon (default ``http://localhost:11434/v1``).
+The daemon ignores auth, so no API key is required; ``OLLAMA_API_KEY``
+defaults to the documented ``"ollama"`` placeholder. Set
+``OLLAMA_BASE_URL`` to point at a daemon on another host.
+
+Cloud models work through the same daemon by appending ``-cloud`` to the
+model name (e.g. ``--model kimi-k2.6-cloud``); run ``ollama signin``
+first.
+
+Usage:
+  uv run python -m manual.try_providers.try_ollama
+  uv run python -m manual.try_providers.try_ollama --model qwen2.5-coder:7b
+  uv run python -m manual.try_providers.try_ollama --model kimi-k2.6-cloud
+  uv run python -m manual.try_providers.try_ollama --tools
+  uv run python -m manual.try_providers.try_ollama --real-tools
+  uv run python -m manual.try_providers.try_ollama --no-stream
+  uv run python -m manual.try_providers.try_ollama --simple
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from app.agent.providers.ollama import OllamaProvider
+from app.core.config import settings
+from manual.try_providers._common import (
+    REASONING_PROMPT,
+    SIMPLE_PROMPT,
+    run_chat,
+    run_stream,
+)
+from manual.try_providers._tools_common import (
+    PROMPT_WITH_TOOLS,
+    SIMPLE_TEST_TOOLS,
+    get_real_tool_defs,
+    run_stream_with_tools,
+)
+
+
+async def main():
+    p = argparse.ArgumentParser(description="Test Ollama provider")
+    p.add_argument(
+        "--model",
+        default="llama3.2",
+        help="Model (default: llama3.2; append '-cloud' for cloud models)",
+    )
+    p.add_argument("--tools", action="store_true", help="Test with simple tools")
+    p.add_argument(
+        "--real-tools",
+        action="store_true",
+        help="Test with actual agent tool schemas (includes memory tools)",
+    )
+    p.add_argument("--no-stream", action="store_true", help="Non-streaming chat()")
+    p.add_argument(
+        "--simple", action="store_true", help="Use simple prompt instead of reasoning"
+    )
+    args = p.parse_args()
+
+    api_key = settings.OLLAMA_API_KEY.get_secret_value()
+    base_url = settings.OLLAMA_BASE_URL
+
+    provider = OllamaProvider(api_key=api_key, model=args.model, base_url=base_url)
+
+    prompt = SIMPLE_PROMPT if args.simple else REASONING_PROMPT
+    label = f"ollama model={args.model} base_url={base_url}"
+
+    if args.tools or args.real_tools:
+        tools = get_real_tool_defs() if args.real_tools else SIMPLE_TEST_TOOLS
+        label += " real-tools" if args.real_tools else " simple-tools"
+        await run_stream_with_tools(provider, PROMPT_WITH_TOOLS, tools, label=label)
+    elif args.no_stream:
+        await run_chat(provider, prompt, label=label)
+    else:
+        await run_stream(provider, prompt, label=label)
+
+    print(f"\n{'=' * 60}")
+    print("done")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/seed/skills/self-healing/SKILL.md
+++ b/seed/skills/self-healing/SKILL.md
@@ -144,9 +144,11 @@ key var (matches `openagentd init`):
 | `router9` | `ROUTER9_API_KEY` |
 | `cliproxy` | `CLIPROXY_API_KEY` |
 
-Providers with managed credentials (`copilot`, `codex`, `vertexai`)
-authenticate via their own CLI / ADC and have no env var to check —
-skip this step for them.
+Providers with managed credentials (`copilot`, `codex`, `vertexai`,
+`ollama`) have no env var to check — `copilot` / `codex` use their
+own CLI, `vertexai` uses ADC, and `ollama` talks to the local
+daemon (or to Ollama Cloud after `ollama signin`). Skip this step
+for them.
 
 ### Relative tweaks ("a bit", "more", "less")
 
@@ -190,7 +192,7 @@ Only these keys are valid. Reject any request to invent new ones.
 
 | Field | Values |
 |-------|--------|
-| `model` | `provider:model` — e.g. `googlegenai:gemini-3.1-flash`, `openai:gpt-5.5`, `zai:glm-5-turbo`, `openrouter:...`, `copilot:...`, `codex:...`, `vertexai:...`, `nvidia:...`, `xai:grok-4.20` |
+| `model` | `provider:model` — e.g. `googlegenai:gemini-3.1-flash`, `openai:gpt-5.5`, `zai:glm-5-turbo`, `openrouter:...`, `copilot:...`, `codex:...`, `vertexai:...`, `nvidia:...`, `xai:grok-4.20`, `ollama:llama3.2`, `ollama:kimi-k2.6-cloud` |
 | `fallback_model` | same format as `model` |
 | `temperature` | float, typically `0.0`–`1.0` |
 | `thinking_level` | `none` \| `low` \| `medium` \| `high` |

--- a/tests/agent/providers/ollama/test_ollama.py
+++ b/tests/agent/providers/ollama/test_ollama.py
@@ -1,0 +1,249 @@
+"""Tests for the Ollama provider.
+
+Covers:
+- OllamaProvider: inherits OpenAIProvider, sets correct base_url
+- OllamaProvider: empty API key falls back to "ollama" placeholder (daemon ignores auth)
+- OllamaProvider: cloud-suffixed model names pass through verbatim
+- Factory: ollama branch reads settings, respects OLLAMA_BASE_URL override
+- Capabilities: ollama: prefix fallback → vision=False
+- Settings: OLLAMA_API_KEY (placeholder default), OLLAMA_BASE_URL
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agent.providers.capabilities import get_capabilities
+from app.agent.providers.ollama import OllamaProvider
+from app.agent.providers.ollama.ollama import OLLAMA_LOCAL_API_BASE
+from app.agent.providers.openai import OpenAIProvider
+
+
+# ============================================================================
+# Class hierarchy
+# ============================================================================
+
+
+class TestOllamaProviderInheritance:
+    """OllamaProvider must subclass OpenAIProvider."""
+
+    def test_is_subclass_of_openai_provider(self):
+        assert issubclass(OllamaProvider, OpenAIProvider)
+
+    def test_local_api_base_constant(self):
+        assert OLLAMA_LOCAL_API_BASE == "http://localhost:11434/v1"
+
+
+# ============================================================================
+# OllamaProvider — __init__
+# ============================================================================
+
+
+class TestOllamaProviderInit:
+    """OllamaProvider wires the local URL by default and tolerates empty keys."""
+
+    def _make_provider(self, **kwargs) -> OllamaProvider:
+        with patch("app.agent.providers.openai.openai.CompletionsHandler"):
+            with patch("app.agent.providers.openai.openai.ResponsesHandler"):
+                return OllamaProvider(model="llama3.2", **kwargs)
+
+    def test_default_base_url_is_local(self):
+        p = self._make_provider()
+        assert p.base_url == OLLAMA_LOCAL_API_BASE
+
+    def test_default_api_key_is_placeholder(self):
+        p = self._make_provider()
+        assert p.api_key == "ollama"
+
+    def test_empty_api_key_falls_back_to_placeholder(self):
+        # The daemon ignores auth, but OpenAIProvider rejects empty keys —
+        # OllamaProvider must substitute the documented placeholder.
+        p = self._make_provider(api_key="")
+        assert p.api_key == "ollama"
+
+    def test_explicit_api_key_is_respected(self):
+        p = self._make_provider(api_key="custom-key")
+        assert p.api_key == "custom-key"
+
+    def test_custom_base_url_overrides_default(self):
+        p = self._make_provider(base_url="http://gpu-box:11434/v1")
+        assert p.base_url == "http://gpu-box:11434/v1"
+
+    def test_model_stored(self):
+        p = self._make_provider()
+        assert p.model == "llama3.2"
+
+    def test_model_with_tag(self):
+        with patch("app.agent.providers.openai.openai.CompletionsHandler"):
+            with patch("app.agent.providers.openai.openai.ResponsesHandler"):
+                p = OllamaProvider(model="qwen2.5-coder:7b")
+        assert p.model == "qwen2.5-coder:7b"
+
+    def test_cloud_suffixed_model_is_passed_through_verbatim(self):
+        # Cloud models are routed through the local daemon by appending
+        # "-cloud" to the model name; the provider must not transform it.
+        with patch("app.agent.providers.openai.openai.CompletionsHandler"):
+            with patch("app.agent.providers.openai.openai.ResponsesHandler"):
+                p = OllamaProvider(model="kimi-k2.6-cloud")
+        assert p.model == "kimi-k2.6-cloud"
+
+    def test_temperature_forwarded(self):
+        p = self._make_provider(temperature=0.5)
+        assert p.temperature == 0.5
+
+    def test_top_p_forwarded(self):
+        p = self._make_provider(top_p=0.9)
+        assert p.top_p == 0.9
+
+    def test_max_tokens_forwarded(self):
+        p = self._make_provider(max_tokens=1024)
+        assert p.max_tokens == 1024
+
+    def test_model_kwargs_forwarded(self):
+        p = self._make_provider(model_kwargs={"extra_param": "value"})
+        assert p.model_kwargs.get("extra_param") == "value"
+
+
+# ============================================================================
+# Provider factory — ollama branch
+# ============================================================================
+
+
+class TestOllamaProviderFactory:
+    """build_provider routes ollama: → OllamaProvider with the configured URL."""
+
+    def test_factory_builds_provider_with_default_base_url(self):
+        from app.agent.providers.factory import build_provider
+
+        with patch(
+            "app.agent.providers.factory.OllamaProvider", return_value=MagicMock()
+        ) as MockOllama:
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.OLLAMA_API_KEY = MagicMock()
+                mock_settings.OLLAMA_API_KEY.get_secret_value.return_value = "ollama"
+                mock_settings.OLLAMA_BASE_URL = "http://localhost:11434/v1"
+                build_provider("ollama:llama3.2")
+
+            MockOllama.assert_called_once()
+            call_kwargs = MockOllama.call_args.kwargs
+            assert call_kwargs.get("api_key") == "ollama"
+            assert call_kwargs.get("model") == "llama3.2"
+            assert call_kwargs.get("base_url") == "http://localhost:11434/v1"
+
+    def test_factory_strips_provider_prefix_from_model_with_tag(self):
+        # Model names can contain ':' (e.g. 'qwen2.5-coder:7b'); the factory
+        # must split on the *first* ':' only.
+        from app.agent.providers.factory import build_provider
+
+        with patch(
+            "app.agent.providers.factory.OllamaProvider", return_value=MagicMock()
+        ) as MockOllama:
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.OLLAMA_API_KEY = MagicMock()
+                mock_settings.OLLAMA_API_KEY.get_secret_value.return_value = "ollama"
+                mock_settings.OLLAMA_BASE_URL = "http://localhost:11434/v1"
+                build_provider("ollama:qwen2.5-coder:7b")
+
+            assert MockOllama.call_args.kwargs.get("model") == "qwen2.5-coder:7b"
+
+    def test_factory_passes_cloud_suffixed_model_verbatim(self):
+        # Cloud models reach the daemon as e.g. "kimi-k2.6-cloud" — same
+        # routing as local models, the suffix stays in the model name.
+        from app.agent.providers.factory import build_provider
+
+        with patch(
+            "app.agent.providers.factory.OllamaProvider", return_value=MagicMock()
+        ) as MockOllama:
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.OLLAMA_API_KEY = MagicMock()
+                mock_settings.OLLAMA_API_KEY.get_secret_value.return_value = "ollama"
+                mock_settings.OLLAMA_BASE_URL = "http://localhost:11434/v1"
+                build_provider("ollama:kimi-k2.6-cloud")
+
+            assert MockOllama.call_args.kwargs.get("model") == "kimi-k2.6-cloud"
+
+    def test_factory_respects_ollama_base_url_env_override(self, monkeypatch):
+        from app.agent.providers.factory import build_provider
+
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box:11434/v1")
+        with patch(
+            "app.agent.providers.factory.OllamaProvider", return_value=MagicMock()
+        ) as MockOllama:
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.OLLAMA_API_KEY = MagicMock()
+                mock_settings.OLLAMA_API_KEY.get_secret_value.return_value = "ollama"
+                mock_settings.OLLAMA_BASE_URL = "http://localhost:11434/v1"
+                build_provider("ollama:llama3.2")
+
+            assert (
+                MockOllama.call_args.kwargs.get("base_url") == "http://gpu-box:11434/v1"
+            )
+
+    def test_factory_lists_ollama_in_supported_providers(self):
+        from app.agent.providers.factory import SUPPORTED_PROVIDERS
+
+        assert "ollama" in SUPPORTED_PROVIDERS
+
+    def test_factory_unsupported_provider_error_mentions_ollama(self):
+        from app.agent.providers.factory import build_provider
+
+        with pytest.raises(ValueError, match="ollama"):
+            build_provider("totally_unknown:model")
+
+
+# ============================================================================
+# Capabilities — ollama: prefix fallback
+# ============================================================================
+
+
+class TestOllamaCapabilities:
+    """ollama: prefix defaults to vision=False (catalog is too varied)."""
+
+    def test_ollama_prefix_vision_false(self):
+        caps = get_capabilities("ollama:llama3.2")
+        assert caps.input.vision is False
+
+    def test_ollama_prefix_output_text_true(self):
+        caps = get_capabilities("ollama:llama3.2")
+        assert caps.output.text is True
+
+    def test_ollama_prefix_output_image_false(self):
+        caps = get_capabilities("ollama:llama3.2")
+        assert caps.output.image is False
+
+    def test_ollama_prefix_case_insensitive(self):
+        caps_lower = get_capabilities("ollama:llama3.2")
+        caps_upper = get_capabilities("OLLAMA:llama3.2")
+        assert caps_lower == caps_upper
+
+
+# ============================================================================
+# Settings — OLLAMA_API_KEY / OLLAMA_BASE_URL
+# ============================================================================
+
+
+class TestOllamaSettings:
+    """Ollama-related fields exist in Settings with documented defaults."""
+
+    def test_ollama_api_key_defaults_to_placeholder(self, monkeypatch):
+        from app.core.config import Settings
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        s = Settings()
+        assert s.OLLAMA_API_KEY.get_secret_value() == "ollama"
+
+    def test_ollama_base_url_default_is_localhost(self, monkeypatch):
+        from app.core.config import Settings
+
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        s = Settings()
+        assert s.OLLAMA_BASE_URL == "http://localhost:11434/v1"
+
+    def test_ollama_api_key_accepts_string_via_env(self, monkeypatch):
+        from app.core.config import Settings
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "custom-key")
+        s = Settings()
+        assert s.OLLAMA_API_KEY.get_secret_value() == "custom-key"


### PR DESCRIPTION
## Summary

Adds an `ollama:` provider that talks to the local Ollama daemon over its OpenAI-compatible `/v1` API. Cloud models are routed transparently through the same daemon when the model name carries a `-cloud` suffix (run `ollama signin` once to authenticate) — there is no separate `ollama.com/v1` endpoint exposed by Ollama.

## What's new

- **Provider:** `ollama:llama3.2`, `ollama:qwen2.5-coder:7b`, `ollama:kimi-k2.6-cloud`, etc.
- **Zero-config local:** `OLLAMA_API_KEY` defaults to the documented `"ollama"` placeholder; daemon ignores auth.
- **Override:** `OLLAMA_BASE_URL` for daemons on another host (e.g. `http://gpu-box:11434/v1`).
- **Factory + capabilities:** `ollama` added to `SUPPORTED_PROVIDERS`; `ollama:` prefix capability fallback (`vision=false` — catalog is too varied; opt specific vision models like `llava`/`qwen3-vl` in via `capabilities.yaml`).
- **CLI integration:** `openagentd init` prompts (with `-cloud` model examples); `openagentd doctor` recognizes `ollama` as a managed-credential provider (no API key required).

## Files

- New: `app/agent/providers/ollama/{__init__.py, ollama.py}`, `tests/agent/providers/ollama/test_ollama.py`, `manual/try_providers/try_ollama.py`
- Edited: `factory.py`, `capabilities.py`, `core/config.py`, CLI `init.py` + `doctor.py`, `.env.example`, `README.md`, `configuration.md`, self-healing skill, `manual/AGENTS.md`

## Tests

27 new tests in `tests/agent/providers/ollama/test_ollama.py` covering inheritance, init (placeholder fallback, base URL override, cloud-suffix passthrough), factory routing, capabilities, and settings. Full suite still green (\`2807 passed\`).

## Out of scope

No native (non-OpenAI) \`https://ollama.com/api/chat\` client — the local daemon is the official OpenAI-compatible surface, and cloud models work through it via \`-cloud\` suffix.