### PR TITLE
feat: warm paper styling system + component restyle + spec rewrite

### DIFF
--- a/documents/styling-specs/applications.md
+++ b/documents/styling-specs/applications.md
@@ -13,13 +13,13 @@ Component examples using OpenAgentd paper tokens. All examples work in both mode
 
 ## Agent chips (signature component)
 
-The agent chip is the most-used custom component in the product. It identifies which agent is talking, which role is selected in the topbar, and what kind of work is queued. The chip is a soft pastel pill with an edge dot and a darker text color — the three colors come from `--accent-{role}-soft`, `--accent-{role}` (edge), and `--accent-{role}-text`.
+The agent chip is the most-used custom component in the product. It identifies which agent is talking, which role is selected in the topbar, and what kind of work is queued. The chip is a soft-pastel rounded tag (`--radius-md`, *not* a full pill) with an edge dot and a darker text color — the three colors come from `--accent-{role}-soft`, `--accent-{role}` (edge), and `--accent-{role}-text`. Full pills are reserved for genuinely circular shapes (the edge dot itself, status indicators, avatars).
 
 ### The four canonical roles
 
 ```tsx
 // openagentd (router)
-<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
                    bg-(--accent-green-soft) text-(--accent-green-text)
                    text-sm font-medium
                    hover:font-semibold transition-all duration-150">
@@ -28,7 +28,7 @@ The agent chip is the most-used custom component in the product. It identifies w
 </button>
 
 // executor
-<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
                    bg-(--accent-blue-soft) text-(--accent-blue-text)
                    text-sm font-medium
                    hover:font-semibold transition-all duration-150">
@@ -37,7 +37,7 @@ The agent chip is the most-used custom component in the product. It identifies w
 </button>
 
 // consultant
-<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
                    bg-(--accent-orange-soft) text-(--accent-orange-text)
                    text-sm font-medium
                    hover:font-semibold transition-all duration-150">
@@ -46,7 +46,7 @@ The agent chip is the most-used custom component in the product. It identifies w
 </button>
 
 // explorer
-<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
                    bg-(--accent-pink-soft) text-(--color-text)
                    text-sm font-medium
                    hover:font-semibold transition-all duration-150">
@@ -68,7 +68,7 @@ The topbar role toggle uses chips for *all* states — selection is communicated
 ```tsx
 <button
   className={`
-    inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+    inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
     bg-(--accent-green-soft) text-(--accent-green-text)
     text-sm transition-all duration-150
     ${selected
@@ -529,7 +529,7 @@ function ThemeToggle() {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className="inline-flex gap-0.5 bg-(--bg-card) border border-(--border-card) rounded-full p-0.5"
+      className="inline-flex gap-0.5 bg-(--bg-card) border border-(--border-card) rounded-md p-0.5"
     >
       {(['system', 'light', 'dark'] as const).map((mode) => {
         const Icon = mode === 'system' ? Monitor : mode === 'light' ? Sun : Moon;
@@ -542,7 +542,7 @@ function ThemeToggle() {
             aria-label={`${mode} theme`}
             onClick={() => setTheme(mode)}
             className={`
-              flex items-center justify-center w-7 h-7 rounded-full transition-all duration-150
+              flex items-center justify-center w-7 h-7 rounded-md transition-all duration-150
               ${selected
                 ? 'bg-(--bg-send) text-(--color-text-on-accent)'
                 : 'text-(--color-text-muted) hover:text-(--color-text)'}
@@ -620,7 +620,7 @@ Remove the cursor the moment streaming ends or a tool call starts. A blinking cu
 
 ## Input bar (floating composer)
 
-The input bar is a **paper pill** floating above the conversation — `--bg-card` with a soft border and `--shadow-depth`. It is draggable via a top-edge grip; position is persisted to `localStorage` (`oa-input-position`); a double-click on the grip resets to bottom-center.
+The input bar is a **paper capsule** floating above the conversation — `--bg-card` with a soft border and `--shadow-depth`. It is draggable via a top-edge grip; position is persisted to `localStorage` (`oa-input-position`); a double-click on the grip resets to bottom-center.
 
 ### Surface
 
@@ -635,7 +635,7 @@ The input bar is a **paper pill** floating above the conversation — `--bg-card
 </div>
 ```
 
-The pill uses `--radius-2xl` (24px) — the largest radius in the system. It reads as a *physical writing instrument*, not a toolbar.
+The capsule uses `--radius-2xl` (24px) — the largest radius in the system. It reads as a *physical writing instrument*, not a toolbar.
 
 ### States
 
@@ -646,16 +646,16 @@ The pencil documents distinct input bar states; each maps to a small visual cue 
 | **Empty** | Placeholder text, send button at reduced opacity |
 | **Typing** | Send button at full opacity, character counter (if relevant) |
 | **Streaming** | Send button replaced with a stop icon; thin border accent in the active agent's chip color |
-| **Queue armed** | Small "Queue" pill prefixed with `+1 message · enqueued`, edge in `--accent-orange` |
-| **With attachments** | Attachment chips render adjacent to the pill (above or below per `filesBelow` rule) |
+| **Queue armed** | Small "Queue" badge prefixed with `+1 message · enqueued`, edge in `--accent-orange` |
+| **With attachments** | Attachment chips render adjacent to the bar (above or below per `filesBelow` rule) |
 | **Collapsed** | Compressed height when sidebar is collapsed; same surface, less padding |
 
 ### Attachment previews
 
-File-attachment chips (images rendered as thumbnails, other files as `FileCard`) live in a row adjacent to the input pill. Three rules keep the composer usable:
+File-attachment chips (images rendered as thumbnails, other files as `FileCard`) live in a row adjacent to the input bar. Three rules keep the composer usable:
 
 1. **Direction is position-dependent** — `FloatingInputBar` computes a `filesBelow` boolean and passes it to `InputBar`:
-   - **Default: `true`** — previews render *below* the input pill.
+   - **Default: `true`** — previews render *below* the input bar.
    - **Flips to `false`** only when the panel is docked far from the bottom (`bounds.bottom - panel.bottom ≥ 140px`).
    - Recomputed on mount, `window` resize, drag end, and double-click reset.
 2. **Single row with horizontal scroll, never vertical wrap** — `flex flex-nowrap w-max` inside an `overflow-x-auto` container.
@@ -663,7 +663,7 @@ File-attachment chips (images rendered as thumbnails, other files as `FileCard`)
 
 ### Drag handle
 
-The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that `InputBar` can position it relative to the input pill (not the outer panel). The handle uses `absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2` to sit straddling the pill's top edge.
+The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that `InputBar` can position it relative to the input bar (not the outer panel). The handle uses `absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2` to sit straddling the bar's top edge.
 
 ```tsx
 <InputBar
@@ -776,7 +776,7 @@ When messages are enqueued behind a streaming response, a small banner appears a
 <div
   className="flex items-center gap-2 px-3 py-1.5
              bg-(--accent-orange-soft) text-(--accent-orange-text)
-             rounded-full text-sm font-medium
+             rounded-md text-sm font-medium
              border border-(--accent-orange)/30"
   role="status"
   aria-live="polite"
@@ -789,7 +789,7 @@ When messages are enqueued behind a streaming response, a small banner appears a
 </div>
 ```
 
-Orange (consultant chip) is reused here because "enqueued" is conceptually a *consultation* signal — "this will be considered next, not now". The chip-soft / chip-edge / chip-text triad scales to any small status pill.
+Orange (consultant chip) is reused here because "enqueued" is conceptually a *consultation* signal — "this will be considered next, not now". The chip-soft / chip-edge / chip-text triad scales to any small status badge.
 
 ---
 
@@ -925,8 +925,7 @@ For Figma, Storybook, or other design tools:
     "sm": "8px",
     "md": "10px",
     "lg": "14px",
-    "2xl": "24px",
-    "pill": "999px"
+    "2xl": "24px"
   },
   "spacing": {
     "base": "4px",

--- a/documents/styling-specs/applications.md
+++ b/documents/styling-specs/applications.md
@@ -1,978 +1,601 @@
 ---
 title: Applications & Templates
-description: Component examples — agent chips, sidebar, input bar, tool calls, theme toggle — using paper tokens
+description: Component guidelines for OpenAgentd UI — agent chips, sidebar, input bar, tool calls, theme toggle
 status: stable
 updated: 2026-05-09
 ---
 
 # Applications & Templates
 
-Component examples using OpenAgentd paper tokens. All examples work in both modes without modification; brand pigment is reserved for the Octobot mascot, agent identity is carried by the chip palette, and chrome stays warm-neutral.
+How OpenAgentd's component language is built and combined. Each section states the role of the component, the surface and motion rules it must follow, the states it can express, and what to avoid. Pair this page with [colors.md](./colors.md), [interaction.md](./interaction.md), [motion.md](./motion.md), and [layout.md](./layout.md) — those define the underlying tokens and behaviors this page composes.
+
+Every component below works in both light and dark modes without per-mode overrides; brand pigment is reserved for the Octobot mascot; agent identity is carried by chips and dots, never by chrome.
 
 ---
 
 ## Agent chips (signature component)
 
-The agent chip is the most-used custom component in the product. It identifies which agent is talking, which role is selected in the topbar, and what kind of work is queued. The chip is a soft-pastel rounded tag (`--radius-md`, *not* a full pill) with an edge dot and a darker text color — the three colors come from `--accent-{role}-soft`, `--accent-{role}` (edge), and `--accent-{role}-text`. Full pills are reserved for genuinely circular shapes (the edge dot itself, status indicators, avatars).
+The agent chip identifies which agent is talking — in the topbar role toggle, in tool-call summaries, in queue rows, in handoff transcripts. It is the most-used custom component in the product.
 
-### The four canonical roles
+**Shape**
 
-```tsx
-// openagentd (router)
-<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
-                   bg-(--accent-green-soft) text-(--accent-green-text)
-                   text-sm font-medium
-                   hover:font-semibold transition-all duration-150">
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-green)" aria-hidden="true" />
-  openagentd
-</button>
+- Soft-pastel rounded tag at the standard medium radius — *not* a full pill. Full pills are reserved for genuinely circular shapes (the edge dot itself, status indicators, avatars).
+- Three colors per role from the chip palette: a soft fill, a saturated edge color, and a darker text color. See [colors.md § Agent chips](./colors.md#agent-chips).
+- Mono label, small text scale, weight 500 at rest.
+- Edge dot at the leading edge of the chip in the role's saturated edge color.
 
-// executor
-<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
-                   bg-(--accent-blue-soft) text-(--accent-blue-text)
-                   text-sm font-medium
-                   hover:font-semibold transition-all duration-150">
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-blue)" aria-hidden="true" />
-  executor
-</button>
+**Roles**
 
-// consultant
-<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
-                   bg-(--accent-orange-soft) text-(--accent-orange-text)
-                   text-sm font-medium
-                   hover:font-semibold transition-all duration-150">
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-orange)" aria-hidden="true" />
-  consultant
-</button>
+The four canonical roles each map to one chip color. The mapping is fixed; do not reuse a role's color for any other purpose.
 
-// explorer
-<button className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
-                   bg-(--accent-pink-soft) text-(--color-text)
-                   text-sm font-medium
-                   hover:font-semibold transition-all duration-150">
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-pink)" aria-hidden="true" />
-  explorer
-</button>
-```
+| Role | Chip color |
+|---|---|
+| `openagentd` (router) | Mint / green |
+| `executor` | Blue |
+| `consultant` | Orange |
+| `explorer` | Pink |
 
-### Selected vs unselected
+**States**
 
-The topbar role toggle uses chips for *all* states — selection is communicated by **pigment, not container shape**:
+Selection is communicated by pigment depth and outline, not by container shape — the chip never changes radius, fill family, or layout between states.
 
 | State | Treatment |
 |---|---|
-| **Unselected** | Soft fill + edge dot at full saturation, weight 500 |
-| **Selected** | Same soft fill + thicker 1.5px ring in `--accent-{role}` + weight 600 + slight shadow |
-| **Hover** | Weight 500→600, no fill change (pigment is already there) |
+| Idle | Soft fill, edge dot at full saturation, label weight 500 |
+| Hover | Label weight shifts 500 → 600. No fill change (pigment is already there) |
+| Selected | Same soft fill, label weight 600, 1.5px ring in the role's edge color, subtle drop shadow |
+| Streaming | Edge dot pulses; chip itself stays static |
+| Idle/dim | Used in the topbar when an agent is registered but not the active one — reduce dot opacity, keep label readable |
 
-```tsx
-<button
-  className={`
-    inline-flex items-center gap-1.5 rounded-md px-2.5 py-1
-    bg-(--accent-green-soft) text-(--accent-green-text)
-    text-sm transition-all duration-150
-    ${selected
-      ? 'font-semibold ring-[1.5px] ring-(--accent-green) shadow-sm'
-      : 'font-medium hover:font-semibold'}
-  `}
-  aria-pressed={selected}
->
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-green)" />
-  openagentd
-</button>
-```
+**Don't**
 
-### Anti-patterns
-
-- ❌ Using a chip color outside its role (mint anywhere except openagentd)
-- ❌ Replacing the soft fill with the saturated edge color when "selected" (loses readability)
-- ❌ Removing the edge dot (the dot doubles as a status anchor — pulse on streaming, dim when idle)
-- ❌ Using chips as buttons that *don't* refer to an agent role
+- Reuse a chip color outside its role (no mint anywhere except `openagentd`).
+- Replace the soft fill with the saturated edge color in selected state — the result loses readability.
+- Drop the edge dot. The dot doubles as a status anchor (pulse on streaming, dim when idle).
+- Use a chip as a generic button. If a control doesn't refer to an agent role, use the [Buttons](#buttons) family.
 
 ---
 
 ## Buttons
 
-### Primary (send)
+A small, rigid family of variants. Pick by role, never by visual preference.
 
-The primary CTA is the **send button** — paper inverted: warm dark surface, cream text. This is the only place the paper aesthetic flips contrast.
+| Variant | Role | Surface |
+|---|---|---|
+| Primary (default) | The single most important action in a region | Filled in `--color-accent`, text in `--color-text-on-accent`, no border |
+| Outline | Neutral or secondary actions; cancel; "view more" | `--bg-page` fill, `--color-border` outline, hover deepens both |
+| Secondary | Used inside cards/dialogs where outline would clash | `--bg-key` fill, `--color-border` outline |
+| Ghost | Tertiary, mostly icons; "skip", "close", inline edit | Transparent fill, hover wash on `--bg-key` |
+| Destructive | Removes data or breaks state (delete, revoke) | Soft `--color-error-subtle` fill, `--color-error` text and border at low alpha |
+| Link | Inline navigation that visually reads as text | No fill, accent-blue text, underline on hover |
 
-```tsx
-<button
-  className="bg-(--bg-send) text-(--color-text-on-accent)
-             px-4 py-2 rounded-md font-medium
-             hover:brightness-110 transition-all duration-150"
->
-  Send
-</button>
-```
+**Shared rules**
 
-### Secondary
+- One radius family across the variants — primary/outline/secondary at the standard small button radius, icon-only variants use the same family one step smaller.
+- Sizes are token-driven: extra-small, small, default, large, plus icon-only equivalents at each size. Pick the smallest size that meets the 44×44 touch target on mobile.
+- Font weight follows [interaction.md § Font-weight transitions](./interaction.md#font-weight-transitions-signature). Icon-only buttons skip the transition (there is no text to shift).
+- Loading state: replace the label with progressive text ("Saving…", "Connecting…"); never show a spinner *and* keep the original label.
+- Disabled state: 50% opacity, `cursor: not-allowed`, `aria-disabled`. Disabled is *unavailable*; loading is *busy*. They are not the same and must not look the same.
 
-```tsx
-<button
-  className="bg-(--bg-card) text-(--color-text)
-             border border-(--border-card)
-             px-4 py-2 rounded-md font-medium
-             hover:bg-(--bg-key) hover:font-semibold
-             transition-all duration-150"
->
-  Cancel
-</button>
-```
+**Don't**
 
-### Destructive
-
-```tsx
-<button
-  className="bg-transparent text-(--color-error)
-             border border-(--color-error)/30
-             px-4 py-2 rounded-md font-medium
-             hover:bg-(--accent-red)/10 hover:font-semibold
-             transition-all duration-150"
->
-  Delete session
-</button>
-```
-
-### Ghost
-
-```tsx
-<button
-  className="text-(--color-text-2) px-3 py-1.5 rounded-md
-             hover:text-(--color-text) hover:bg-(--bg-key)
-             font-normal hover:font-medium
-             transition-all duration-150"
->
-  Skip
-</button>
-```
-
-### Loading
-
-```tsx
-<button
-  disabled
-  className="bg-(--bg-send)/60 text-(--color-text-on-accent)
-             px-4 py-2 rounded-md font-medium cursor-not-allowed"
->
-  Sending…
-</button>
-```
-
-### With font-weight transition (signature)
-
-Interactive buttons shift weight on hover and active — see [typography.md](./typography.md#font-weight-transitions-signature-interaction).
-
-```tsx
-<button
-  className="bg-(--bg-send) text-(--color-text-on-accent)
-             px-4 py-2 rounded-md
-             font-normal hover:font-medium active:font-semibold
-             transition-all duration-150 ease-out"
->
-  Send
-</button>
-```
+- Build a custom button by hand-stacking utilities. Reach for the `Button` primitive; if its variants don't fit, the variant set should grow rather than be bypassed.
+- Pair two primary buttons in the same action cluster. There is one primary action per region; everything else is outline/ghost/destructive.
+- Use destructive coloring for "discard draft" or other reversible actions. Reserve it for irreversible loss.
 
 ---
 
 ## Card
 
-```tsx
-<div
-  className="bg-(--bg-card) border border-(--border-card)
-             rounded-lg p-6 shadow-[var(--shadow-depth)]"
->
-  <h3 className="text-h3 font-semibold text-(--color-text) mb-2">Session title</h3>
-  <p className="text-(--color-text-muted) text-sm mb-4">
-    Started 3 minutes ago · 2 agents active
-  </p>
-  <button className="text-(--color-accent) font-normal hover:font-medium transition-all">
-    View details →
-  </button>
-</div>
-```
+A card separates a self-contained unit of content from the surrounding page. The OpenAgentd card is a calm paper rectangle — warm fill, hairline border, generous corner radius — and that is it.
+
+**Rules**
+
+- Outer surface: `--bg-card` on `--color-border` with a generous corner radius (the larger end of the radius scale; compact cards trim down but keep the same family).
+- The border alone carries elevation. No drop shadow, no ambient ring, no double outline.
+- Internal padding is consistent across the card; compact variants reduce padding uniformly.
+- A footer-style chrome region distinguishes itself with a subtle `--bg-key` wash and a top divider — never a different border color or a heavier surface.
+- Reach for the shared `Card` family before rolling a hand-built surface; if the slots don't fit, repeat the same recipe inline rather than inventing new tokens.
+
+**Don't**
+
+- Layer shadows on flat cards. Only floating chrome (the queue banner, the input bar, popovers) earns a soft depth shadow.
+- Mix `--border-card` with `--color-border` in the same surface — `--border-card` is deprecated; use `--color-border`.
+- Use `ring-*` for separation; rings are reserved for focus and decorative chip outlines (see [interaction.md § Anti-patterns](./interaction.md#anti-patterns)).
 
 ---
 
 ## Status indicators
 
-Every status pairs color with an icon or label — never color alone.
+Every status pairs color with an icon or label — never color alone. See [colors.md § Status](./colors.md#semantic-status-colors) for the token set.
 
-```tsx
-// Running — pulsing success dot (mint = openagentd's color, also the success state)
-<div className="flex items-center gap-2 text-(--color-text-2)">
-  <span className="relative flex w-2 h-2">
-    <span className="absolute inset-0 bg-(--color-success) rounded-full animate-ping opacity-75" />
-    <span className="relative w-2 h-2 bg-(--color-success) rounded-full" />
-  </span>
-  <span>Running</span>
-</div>
+**Patterns**
 
-// Error
-<div className="flex items-center gap-2 text-(--color-error)">
-  <AlertCircle className="w-4 h-4" />
-  <span>Failed</span>
-</div>
+- Running: pulsing dot in `--color-success` with a written label ("Running", "Streaming").
+- Error: `lucide AlertCircle` in `--color-error` with a written label ("Failed").
+- Success (static): `lucide CheckCircle` in `--color-success` with a written label ("Completed"). Static success uses no animation; only transient confirmations pulse.
+- Pending / queued: `lucide Clock` in `--accent-orange-text` with a written label ("Queued").
 
-// Success (static, non-celebratory)
-<div className="flex items-center gap-2 text-(--color-success)">
-  <CheckCircle className="w-4 h-4" />
-  <span>Completed</span>
-</div>
+**Don't**
 
-// Pending / queued
-<div className="flex items-center gap-2 text-(--accent-orange-text)">
-  <Clock className="w-4 h-4" />
-  <span>Queued</span>
-</div>
-```
+- Rely on color alone (no plain red dot, no plain green checkmark without a label or accessible name).
+- Wrap status in a chip with a role color (mint, blue, orange, pink). Status indicators are neutral; agent identity is conveyed elsewhere.
 
 ---
 
 ## Forms
 
-### Input field
+Form layout, field anatomy, and validation behavior. Use the shared form primitives (`Input`, `Textarea`, `Select`, `RadioGroup`, `Switch`, `Checkbox`, `NumberInput`, `DateTimePicker`) — they share a single field shell so a form composed of mixed types still feels like one form.
 
-```tsx
-<div className="flex flex-col gap-2">
-  <label htmlFor="max-wait" className="text-(--color-text) font-medium text-sm">
-    Max wait time (seconds)
-  </label>
-  <input
-    id="max-wait"
-    type="number"
-    defaultValue={30}
-    className="bg-(--bg-input) border border-(--color-border) rounded-md
-               px-3 py-2 text-(--color-text) placeholder:text-(--color-text-muted)
-               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)
-               focus:border-(--color-accent) transition-colors"
-    placeholder="30"
-  />
-  <p className="text-(--color-text-muted) text-sm">
-    Increase for longer-running tool calls.
-  </p>
-</div>
-```
+**Field anatomy**
 
-### Textarea (YAML / config)
+- Label above the field, weight 500, `--color-text`.
+- Field surface: `--bg-input` fill, 1px `--color-border`, standard small radius. Focus replaces the bottom border with `--color-accent` and adds a 2px focus ring (see [interaction.md § Focus ring](./interaction.md#focus-ring-specification)).
+- Help text below the field, small text scale, `--color-text-muted`.
+- Error text replaces help text on validation failure: `--color-error`, with `lucide AlertCircle` glyph at the leading edge. The field gains `aria-invalid="true"` and `aria-describedby` pointing at the error.
+- Required indicators are written ("Required") rather than starred. If a star is used it must repeat the meaning in an accessible name.
 
-```tsx
-<textarea
-  className="bg-(--bg-input) border border-(--color-border) rounded-md
-             px-3 py-2 text-(--color-text) font-mono text-sm
-             placeholder:text-(--color-text-muted)
-             focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)
-             focus:border-(--color-accent) transition-colors resize-y min-h-[200px]"
-  placeholder="mode: chat&#10;max_wait: 30"
-/>
-```
+**Boolean toggles**
 
-### Field with error
+- Use `Switch` for on/off feature flags and reversible setting toggles. The switch reads as "this is the live state of a thing".
+- Use `Checkbox` for multi-select selections in a list, or for compound consent ("I agree to…").
+- Do not use a native `<input type="checkbox">` to mean a feature flag. Everything that toggles a runtime behavior is a `Switch`.
 
-```tsx
-<div className="flex flex-col gap-2">
-  <label htmlFor="name" className="text-(--color-text) font-medium text-sm">
-    Session name
-  </label>
-  <input
-    id="name"
-    aria-invalid="true"
-    aria-describedby="name-error"
-    className="bg-(--bg-input) border border-(--color-error) rounded-md
-               px-3 py-2 text-(--color-text)
-               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)"
-  />
-  <p id="name-error" className="text-(--color-error) text-sm flex items-center gap-1.5">
-    <AlertCircle className="w-3.5 h-3.5" />
-    Name is required.
-  </p>
-</div>
-```
+**Selects and pickers**
+
+- Use the shared `Select` (built on base-ui) for any single-choice picker — its trigger inherits the same field shell as `Input`.
+- For numeric ranges where stepping matters, use `NumberInput` rather than a `<select>` with hard-coded options.
+- For dates and times, use `DateTimePicker`. Do not roll a bespoke pair of inputs.
+
+**Don't**
+
+- Place validation messages above the field — they belong below where the eye lands after typing.
+- Use placeholder text as the only label. Placeholders disappear when the user starts typing and are inaccessible.
+- Combine a busy state and a disabled state visually. A submitting form locks input and shows progress; a disabled form has reduced opacity. They are different intents.
 
 ---
 
 ## Code block
 
-Syntax colors resolve correctly in both modes via tokens from [colors.md](./colors.md#syntax-highlighting--code).
+Code is rendered with JetBrains Mono and the syntax tokens from [colors.md § Syntax highlighting](./colors.md#syntax-highlighting--code).
 
-```tsx
-<pre className="bg-(--color-surface) border border-(--color-border) rounded-lg p-4 overflow-x-auto">
-  <code className="text-(--color-text) font-mono text-sm leading-relaxed">
-    <span className="text-(--color-syn-keyword)">const</span>{' '}
-    <span className="text-(--color-text)">agent</span>{' '}
-    <span className="text-(--color-syn-operator)">=</span>{' '}
-    <span className="text-(--color-syn-keyword)">new</span>{' '}
-    <span className="text-(--color-syn-type)">Agent</span>()
-    <span className="text-(--color-syn-operator)">.</span>
-    <span className="text-(--color-syn-function)">init</span>()
-  </code>
-</pre>
-```
+**Rules**
 
-For rendered markdown, use the `.prose` class — styled globally to consume the syntax tokens.
+- Block surface: `--color-surface` on 1px `--color-border`, standard small radius.
+- Inline code: `--bg-key` wash on a tighter padding, no border. Same mono family as block code.
+- Long blocks scroll horizontally; lines never wrap mid-token.
+- Copy controls (when present) live in the top-right corner, ghost-button-sized, revealed on hover and persistent on focus. They do not occupy layout space.
 
-### Inline code
-
-```tsx
-<code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">
-  app/agent/mode/chat.py
-</code>
-```
+For rendered markdown, use the `.prose` class — it is styled globally to consume the syntax tokens.
 
 ---
 
-## Empty room (signature empty state)
+## Empty states (hand-drawn pattern)
 
-The canonical empty state — mascot + Caveat callout. This is the "what's on your mind?" screen.
+Empty surfaces — no sessions, no tasks, no files, no agents matched a search — reuse the same hand-drawn idiom: a short Caveat callout in `--color-text-subtle`, sometimes paired with the Octobot mascot. The voice is conversational, not instructional.
 
-```tsx
-<div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-  <img
-    src="/brand/octobot-agentd-source.png"
-    alt=""
-    className="w-24 h-24 select-none"
-    draggable={false}
-  />
-  <h2 className="font-hand text-[44px] leading-none text-(--color-text)">
-    what&apos;s on your mind?
-  </h2>
-</div>
-```
+**Rules**
 
-Caveat is purely visual here — the screen reader gets nothing. If the empty state needs to convey instructions, add an Inter description below the callout (or replace the Caveat with an Inter heading entirely).
+- Caveat at the hand size from [typography.md § Hierarchy](./typography.md#type-hierarchy). Centered, with line breaks shaped to read like written speech.
+- Color is `--color-text-subtle` so the callout sits one layer behind the surrounding chrome.
+- Caveat is decorative; pair it with an accessible Inter equivalent in the DOM, or mark the Caveat `aria-hidden` and lift the meaning into a sibling element.
+- The mascot is optional. Use it on full-page empty states (the "what's on your mind?" home screen). Skip it inside narrow popovers and inline empty rows where it would crowd the surface.
+
+**The canonical empty room**
+
+The home screen's empty state is the most prominent example: mascot at a moderate size, with the Caveat prompt "what's on your mind?" below it. This is the one place the prompt is allowed; do not reuse the exact phrase elsewhere.
+
+**Don't**
+
+- Use Caveat for instructional copy ("Click + to add a task"). Instructions belong in Inter.
+- Wrap the empty state in a card. Empty states sit on the ambient page surface; the chrome is what is missing, not what is present.
 
 ---
 
 ## Error state page
 
-```tsx
-<div className="flex flex-col items-center justify-center min-h-screen bg-(--bg-page) px-4">
-  <AlertCircle className="w-16 h-16 text-(--color-error) mb-4" aria-hidden="true" />
-  <h1 className="text-h1 font-bold text-(--color-text) mb-2">Session failed</h1>
-  <p className="text-(--color-text-muted) text-center mb-6 max-w-[50ch]">
-    Session timeout after 30 seconds. Increase{' '}
-    <code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">max_wait</code>{' '}
-    in{' '}
-    <code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">chat.yaml</code>{' '}
-    and try again.
-  </p>
-  <div className="flex gap-3">
-    <button className="bg-(--bg-send) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110">
-      Retry
-    </button>
-    <a
-      href="/docs/troubleshoot"
-      className="text-(--color-text-2) hover:text-(--color-text) underline underline-offset-4 self-center"
-    >
-      Troubleshooting guide →
-    </a>
-  </div>
-</div>
-```
+Full-page error (session timeout, route not found, fatal config error). Composition: a single error glyph at large size, a heading at h1 scale, an explanatory paragraph at body scale, and one or two recovery actions.
+
+**Rules**
+
+- Glyph: `lucide AlertCircle` in `--color-error`, large icon size.
+- Heading: Inter bold at h1.
+- Paragraph: `--color-text-muted`, max measure ~50ch, may include inline `code` references to the relevant config keys.
+- Actions: a primary button to retry or recover, plus an outlined or link-styled secondary path to documentation.
+- Layout sits on the page surface — no card, no border. The error is the surface.
 
 ---
 
 ## Modal / dialog
 
-```tsx
-{/* Backdrop */}
-<div className="fixed inset-0 bg-(--color-overlay) flex items-center justify-center z-50 animate-in fade-in duration-150">
-  {/* Panel */}
-  <div
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="dialog-title"
-    className="bg-(--bg-card) border border-(--border-card)
-               rounded-lg shadow-2xl w-96 max-w-[90vw]
-               animate-in fade-in zoom-in-95 slide-in-from-bottom-2 duration-240"
-  >
-    <div className="border-b border-(--color-border) px-6 py-4">
-      <h2 id="dialog-title" className="text-h3 font-semibold text-(--color-text)">
-        Confirm deletion
-      </h2>
-    </div>
+A modal interrupts the user to demand a decision or surface critical information. It is the heaviest piece of chrome the UI uses; reach for a popover, drawer, or inline disclosure first.
 
-    <div className="px-6 py-4">
-      <p className="text-(--color-text-2)">This cannot be undone. Delete this session?</p>
-    </div>
+**Surface**
 
-    <div className="border-t border-(--color-border) px-6 py-4 flex justify-end gap-3">
-      <button className="text-(--color-text-2) hover:text-(--color-text) px-4 py-2 rounded-md transition-colors">
-        Cancel
-      </button>
-      <button className="bg-(--color-error) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110 transition-all">
-        Delete
-      </button>
-    </div>
-  </div>
-</div>
-```
+- Same recipe as [Card](#card) — paper fill, hairline border, generous radius.
+- A translucent backdrop tints the page so the modal reads as elevated *without* a drop shadow. The warm border carries the rest of the elevation.
+- A header region holds the title (semibold, h3 scale) and an optional one-line description (`--color-text-muted`).
+- A footer region (when present) inverts to the `--bg-key` wash, separates with a top divider, and right-aligns the action cluster on `≥ sm` viewports.
 
-Focus is trapped inside the dialog; `Esc` closes it; focus returns to the trigger on close. See [interaction.md](./interaction.md#focus-trap-rules).
+**Behavior**
+
+- Focus is trapped inside the panel. The first focusable control receives focus on open.
+- `Esc` always closes (except for explicit confirmation flows that require an action). Focus returns to the trigger.
+- A close button is offered in the top-right by default; opt out only when the dialog is unconditionally dismissable.
+- Animate in with fade + zoom over the standard motion duration; reverse on close. See [motion.md](./motion.md).
+- Scrolling is scoped to the dialog body, never the page beneath.
+
+**Composition**
+
+- Action buttons follow the [Buttons](#buttons) hierarchy — one primary, one or two secondary/outline, destructive only when destructive.
+- Forms inside the dialog use the standard field rules.
+
+**Don't**
+
+- Stack modals. If a confirmation is needed mid-flow, replace the current modal or use an inline confirmation step.
+- Add a drop shadow or `ring-*` to the panel — the backdrop and border are sufficient.
+- Use a modal for non-blocking information; toast or inline status patterns are better.
+
+The same chrome is reused by drawers (sheets), popovers, dropdown menus, and command palettes — when a floating surface is needed, pick the primitive that matches the interaction model rather than hand-rolling another portal.
 
 ---
 
-## Sidebar navigation (expanded)
+## Sidebar navigation
 
-```tsx
-<aside className="w-64 bg-(--bg-sidebar) border-r border-(--border-soft) h-screen overflow-y-auto flex flex-col">
-  {/* Brand header */}
-  <div className="px-4 py-4 flex items-center gap-2 border-b border-(--border-soft)">
-    <img
-      src="/brand/openagentd-app-icon.png"
-      alt=""
-      className="w-7 h-7"
-      draggable={false}
-    />
-    <span className="font-bold text-(--color-text) tracking-tight">OpenAgentd</span>
-  </div>
+The left rail is the persistent home for: brand identity, primary nav actions, and the recent-session list. It collapses to an icon-only strip on desktop and slides in as a full-width drawer on mobile.
 
-  {/* Primary nav */}
-  <nav aria-label="Primary" className="flex flex-col gap-0.5 p-3 flex-1">
-    <a
-      href="/chat"
-      className="flex items-center gap-3 px-3 py-2 rounded-md
-                 text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)
-                 font-normal hover:font-medium
-                 transition-all duration-150"
-    >
-      <MessageCircle className="w-4 h-4" aria-hidden="true" />
-      <span>New chat</span>
-    </a>
-    <a
-      href="/commands"
-      aria-current="page"
-      className="flex items-center gap-3 px-3 py-2 rounded-md
-                 bg-(--bg-key) text-(--color-text) font-medium"
-    >
-      <Command className="w-4 h-4" aria-hidden="true" />
-      <span>Commands</span>
-    </a>
-    <a
-      href="/memory"
-      className="flex items-center gap-3 px-3 py-2 rounded-md
-                 text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)
-                 font-normal hover:font-medium
-                 transition-all duration-150"
-    >
-      <Brain className="w-4 h-4" aria-hidden="true" />
-      <span>Memory wiki</span>
-    </a>
-  </nav>
+The sidebar composes two reusable primitives: a brand header and a sidebar item. Compose, do not bypass.
 
-  {/* Footer */}
-  <div className="p-3 border-t border-(--border-soft) flex items-center justify-between">
-    <ThemeToggle />
-  </div>
-</aside>
-```
+### Brand header
 
-Current page shows `aria-current="page"` + permanent selected styling (the same warm `--bg-key` used as hover). Hover shifts weight (see [typography.md](./typography.md#font-weight-transitions-signature-interaction)).
+- A 16-unit-tall row containing the mascot, the wordmark, and a dock-toggle button.
+- Mascot: app icon at 44×44, no decoration.
+- Title: Caveat at 28px, bold, `--color-text`. The wordmark is decorative chrome — it is also conveyed by the document title and by the logo asset itself, so a screen reader will still encounter "OpenAgentd" elsewhere.
+- Subtitle: mono 11px, `--color-text-muted`, reading "on-machine ai".
+- Dock toggle: outlined icon button on the right; flips icon between collapse and expand based on the rail's current state.
 
-### Collapsed sidebar
+### Sidebar item
 
-When collapsed, the sidebar shrinks to icon-only. The active item must keep a visible affordance — either the same `--bg-key` fill or a 2px left accent bar in `--color-accent`.
+- Icon + label + optional keyboard hint, in a single row.
+- Two render modes:
+  - Expanded: `[icon] [label …………] [kbd?]`. Padding sits at the standard nav scale; row height ~10 spacing units.
+  - Collapsed: `[icon]` centered in a square cell of the row's height. Label is removed from the DOM (not just visually hidden) so the rail computes correctly.
+- Active state uses `--bg-key` fill with `--color-text` and weight 500. Hover uses the same fill and bumps weight from 500 to 600 (see [typography.md § Font-weight transitions](./typography.md#font-weight-transitions-signature-interaction)).
+- Keyboard hint pill renders as outlined `--color-border` on `--bg-page` with mono text — only visible in expanded mode. On collapsed rails the shortcut is surfaced via the row's `title` attribute instead.
 
-```tsx
-<aside className="w-14 bg-(--bg-sidebar) border-r border-(--border-soft) h-screen flex flex-col items-center py-3 gap-1">
-  {navItems.map((item) => (
-    <a
-      key={item.href}
-      href={item.href}
-      aria-label={item.label}
-      aria-current={item.active ? 'page' : undefined}
-      className={`
-        relative flex items-center justify-center w-9 h-9 rounded-md
-        transition-all duration-150
-        ${item.active
-          ? 'bg-(--bg-key) text-(--color-text)'
-          : 'text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)'}
-      `}
-    >
-      <item.Icon className="w-4 h-4" aria-hidden="true" />
-    </a>
-  ))}
-</aside>
-```
+### Recent sessions
+
+- Grouped by relative date headers ("Today", "Yesterday", "Older"). Headers use mono uppercase 10px in `--color-text-muted`.
+- Rows use the proximity-fade pattern (see [interaction.md § Proximity effects](./interaction.md#proximity-effects)): hover wash strength tracks cursor distance, not binary on/off.
+- A delete affordance lives at the trailing edge of each row. On desktop it is hidden until hover; on mobile it is always visible (touch has no hover state).
+- Scheduled sessions add a "sched" mono badge after the title and a second line with the schedule name in `--color-text-subtle`.
+
+### Collapsed rail
+
+- Width snaps to a single icon's worth of horizontal space; row height is preserved.
+- Recent sessions degrade to a vertical column of small dots (one per recent session, capped). The active session's dot uses `--color-accent`.
+- Footer keeps the theme toggle; the health dot is dropped in collapsed mode.
+
+### Mobile drawer
+
+- Slides in from the left over a translucent backdrop. The drawer is always at expanded width; there is no icon-only mode on mobile.
+- Tapping the backdrop or selecting a session closes the drawer.
+- Brand header's dock-toggle is repurposed to a close action; the chevron icon is the same.
+
+### Don't
+
+- Replace `bg-(--bg-sidebar)` with `bg-(--bg-page)`. The sidebar is one tonal step warmer than the page on purpose; the rail must read as part of the chrome.
+- Use a different active-state color from the rest of the nav. Sidebar items, command palette rows, and topbar tabs share the `--bg-key` active wash for consistency.
+- Hide the active session in collapsed mode. The dot column must always show the current session at full color.
 
 ---
 
-## Theme toggle (three-way)
+## Theme toggle
 
-`system` / `light` / `dark`. Persisted to `localStorage`. No flash of wrong theme on load (see [layout.md](./layout.md#mode-switching)).
+A three-state segmented control (`system` / `light` / `dark`), persisted to `localStorage`, applied without a flash of the wrong theme on first paint (see [layout.md § Mode switching](./layout.md#mode-switching)).
 
-```tsx
-import { Monitor, Sun, Moon } from 'lucide-react';
+**Rules**
 
-type Theme = 'system' | 'light' | 'dark';
-
-function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem('theme') as Theme) ?? 'system'
-  );
-
-  useEffect(() => {
-    localStorage.setItem('theme', theme);
-    const resolved =
-      theme === 'system'
-        ? matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light'
-        : theme;
-    document.documentElement.classList.remove('light', 'dark');
-    document.documentElement.classList.add(resolved);
-  }, [theme]);
-
-  return (
-    <div
-      role="radiogroup"
-      aria-label="Theme"
-      className="inline-flex gap-0.5 bg-(--bg-card) border border-(--border-card) rounded-md p-0.5"
-    >
-      {(['system', 'light', 'dark'] as const).map((mode) => {
-        const Icon = mode === 'system' ? Monitor : mode === 'light' ? Sun : Moon;
-        const selected = theme === mode;
-        return (
-          <button
-            key={mode}
-            role="radio"
-            aria-checked={selected}
-            aria-label={`${mode} theme`}
-            onClick={() => setTheme(mode)}
-            className={`
-              flex items-center justify-center w-7 h-7 rounded-md transition-all duration-150
-              ${selected
-                ? 'bg-(--bg-send) text-(--color-text-on-accent)'
-                : 'text-(--color-text-muted) hover:text-(--color-text)'}
-            `}
-          >
-            <Icon className="w-3.5 h-3.5" />
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-```
+- Three icon-only buttons in a single rounded outline (`--bg-card` fill, `--border-card` outline). Icons: `lucide Monitor` / `lucide Sun` / `lucide Moon`.
+- Active button uses the inverted-paper recipe: `--bg-send` fill, `--color-text-on-accent` glyph. Inactive buttons stay transparent with `--color-text-muted` glyphs.
+- The control is a `radiogroup` with `aria-checked` per button. Labels live on `aria-label` only; the icons are too dense for visible text.
+- Reduced motion still applies to the cross-fade between themes — flashes longer than 80ms read as broken.
 
 ---
 
 ## Thinking indicator (streaming)
 
-Full motion spec in [motion.md](./motion.md#thinking-indicator-pulse-dots). Progressive label text named by the agent. The dot color matches the agent's chip edge color.
+A paper card that records an assistant turn's reasoning. It collapses to a one-line header and expands to reveal the full trace. It is part of the assistant turn, not a free-floating ornament.
 
-```tsx
-function ThinkingIndicator({ label, role }: { label: string; role?: AgentRole }) {
-  const dotColor = role ? `var(--accent-${roleToColor[role]})` : 'var(--color-text-muted)';
-  return (
-    <div
-      className="flex items-center gap-2 text-(--color-text-muted)"
-      role="status"
-      aria-live="polite"
-    >
-      <div className="flex gap-1">
-        <span
-          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:0ms]"
-          style={{ backgroundColor: dotColor }}
-        />
-        <span
-          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:200ms]"
-          style={{ backgroundColor: dotColor }}
-        />
-        <span
-          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:400ms]"
-          style={{ backgroundColor: dotColor }}
-        />
-      </div>
-      <span className="text-sm">{label}</span>
-    </div>
-  );
-}
+### Resting / collapsed
 
-// Usage — label updates as the agent progresses, dot color identifies the role
-<ThinkingIndicator role="openagentd" label="Thinking" />
-<ThinkingIndicator role="executor" label="Reading 4 files" />
-<ThinkingIndicator role="explorer" label="Searching memory" />
-```
+A single header row: chevron, label, sub-hint.
+
+- Outer surface: small radius, 1px `--color-border`, no fill — the row sits on the ambient chat surface.
+- Chevron points right at rest, rotates 90° when expanded; muted text color.
+- Label: Inter 13px, medium weight, `--color-text-2`. Default text is "Reasoning".
+- Sub-hint: mono 11px, `--color-text-muted`. Reads "tap to read" when collapsed, "tap to collapse" when expanded.
+
+### Streaming
+
+While reasoning tokens are still arriving, replace the sub-hint with the three-dot animation. The label stays as the visual anchor; the row never reflows mid-thought.
+
+### Label derivation
+
+The label may be promoted from the first non-empty line of the reasoning content, but only once that line has *finalised* — meaning a newline has arrived, or a leading bold heading has closed. Promoted labels are cleaned of common markdown decorations and capped to a short character budget; longer or still-streaming first lines stay on "Reasoning" rather than thrashing or truncating.
+
+When the first line is promoted to the label, the expanded body omits it to avoid duplication.
+
+### Expanded body
+
+A divider separates the header from the body. The body uses the calm `--bg-key` reading wash, mono italic at the small text scale, in `--color-text-muted`. Whitespace is preserved.
+
+The same divider + `--bg-key` wash is shared with the [tool-call row](#tool-call-row) expanded panel — these two surfaces are deliberately sibling-shaped so a turn's reasoning + tool calls + answer scan as a single unit.
+
+### Don't
+
+- Use three free-floating pulse dots inline with prose. That pattern is reserved for waiting/spinner contexts; reasoning always gets the paper card.
+- Color the dot or border by agent role. Reasoning belongs to the assistant turn as a whole; agent identity is carried by chips and bubble flow, not by reasoning chrome.
+- Mutate the label character-by-character while streaming. Only promote first lines that have finalised.
 
 ---
 
 ## Streaming cursor
 
-The blinking cursor that trails live-streamed text. Spec in [motion.md](./motion.md#streaming-cursor-blink).
+A blinking caret trailing live-streamed text. Spec in [motion.md § Streaming cursor](./motion.md#streaming-cursor-blink).
 
-```tsx
-<span className="inline-block w-[0.5ch] h-[1em] bg-(--color-text) align-text-bottom animate-[streaming-cursor_1s_steps(2,end)_infinite]" />
-```
-
-```css
-@keyframes streaming-cursor {
-  0%, 50%   { opacity: 1; }
-  51%, 100% { opacity: 0; }
-}
-```
-
-Remove the cursor the moment streaming ends or a tool call starts. A blinking cursor with no live generation is a bug.
-
----
-
-## Input bar (floating composer)
-
-The input bar is a **paper capsule** floating above the conversation — `--bg-card` with a soft border and `--shadow-depth`. It is draggable via a top-edge grip; position is persisted to `localStorage` (`oa-input-position`); a double-click on the grip resets to bottom-center.
-
-### Surface
-
-```tsx
-<div
-  className="bg-(--bg-card)/90 backdrop-blur-xl
-             border border-(--border-card) shadow-[var(--shadow-depth)]
-             rounded-2xl
-             px-3 py-2"
->
-  {/* grip + textarea + attach + send */}
-</div>
-```
-
-The capsule uses `--radius-2xl` (24px) — the largest radius in the system. It reads as a *physical writing instrument*, not a toolbar.
-
-### States
-
-The pencil documents distinct input bar states; each maps to a small visual cue rather than a different layout:
-
-| State | Cue |
-|---|---|
-| **Empty** | Placeholder text, send button at reduced opacity |
-| **Typing** | Send button at full opacity, character counter (if relevant) |
-| **Streaming** | Send button replaced with a stop icon; thin border accent in the active agent's chip color |
-| **Queue armed** | Small "Queue" badge prefixed with `+1 message · enqueued`, edge in `--accent-orange` |
-| **With attachments** | Attachment chips render adjacent to the bar (above or below per `filesBelow` rule) |
-| **Collapsed** | Compressed height when sidebar is collapsed; same surface, less padding |
-
-### Attachment previews
-
-File-attachment chips (images rendered as thumbnails, other files as `FileCard`) live in a row adjacent to the input bar. Three rules keep the composer usable:
-
-1. **Direction is position-dependent** — `FloatingInputBar` computes a `filesBelow` boolean and passes it to `InputBar`:
-   - **Default: `true`** — previews render *below* the input bar.
-   - **Flips to `false`** only when the panel is docked far from the bottom (`bounds.bottom - panel.bottom ≥ 140px`).
-   - Recomputed on mount, `window` resize, drag end, and double-click reset.
-2. **Single row with horizontal scroll, never vertical wrap** — `flex flex-nowrap w-max` inside an `overflow-x-auto` container.
-3. **Image thumbnails render in *compact* mode** — `max-h-[160px] max-w-[160px]` instead of the default 200×200. Click-to-expand lightbox is unaffected.
-
-### Drag handle
-
-The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that `InputBar` can position it relative to the input bar (not the outer panel). The handle uses `absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2` to sit straddling the bar's top edge.
-
-```tsx
-<InputBar
-  floating
-  filesBelow={filesBelow}
-  renderDragHandle={() => (
-    <button
-      type="button"
-      aria-label="Drag input bar (double-click to reset position)"
-      title="Drag to move · Double-click to reset"
-      onPointerDown={(e) => dragControls.start(e)}
-      onDoubleClick={handleReset}
-      className="absolute left-1/2 top-0 z-10 -translate-x-1/2 -translate-y-1/2
-                 w-12 h-3 flex items-center justify-center
-                 rounded-full bg-(--bg-card) border border-(--border-card)
-                 text-(--color-text-muted) hover:text-(--color-text)
-                 transition-colors"
-    >
-      <GripHorizontal size={12} aria-hidden="true" />
-    </button>
-  )}
-  {...inputProps}
-/>
-```
-
-Use framer-motion's `useDragControls` with `dragListener={false}` on the motion wrapper, then start drag manually from the handle's `onPointerDown`. This is the only reliable way to gate drag to a sub-region without breaking pointer events on the rest of the panel.
-
----
-
-## Draggable panes
-
-The same handle-only drag pattern applies to team view agent panes. Drag is gated to a visible `GripVertical`; the whole panel remains a valid drop target via `onDragOver` / `onDrop` on its root.
-
-```tsx
-<div onDragOver={handleDragOver} onDrop={handleDrop} className="relative">
-  <div
-    draggable
-    onDragStart={handleDragStart}
-    className="absolute top-2 left-2 cursor-grab"
-    aria-label="Reorder pane"
-  >
-    <GripVertical className="w-4 h-4 text-(--color-text-muted)" />
-  </div>
-  {/* pane content — selectable, clickable, normal */}
-</div>
-```
+- Half-character-width vertical bar in `--color-text`, full line-height tall.
+- Two-step blink at 1s — fully on, fully off; no fade.
+- Removed the moment streaming ends or a tool call starts. A blinking caret with no live generation is a bug.
 
 ---
 
 ## Tool-call row
 
-Slides in from below with a spring ([motion.md](./motion.md#tool-call-row-slide-in)). Tool calls are role-tagged: the wrench icon picks up the calling agent's chip edge color.
+A paper card recording one tool invocation. Identity is carried by a colored status dot, not a tool icon, so the same chrome serves every tool the agent might call.
 
-### Collapsed (single line)
+### Lifecycle
 
-```tsx
-<div
-  className="bg-(--bg-card) border border-(--border-card) rounded-md
-             px-3 py-2 flex items-center gap-3
-             animate-in slide-in-from-bottom-1 fade-in duration-240 ease-out"
->
-  <Wrench className="w-4 h-4 text-(--accent-blue)" aria-hidden="true" />
-  <span className="text-sm font-mono text-(--color-text-2)">read_file</span>
-  <span className="text-sm text-(--color-text-muted) truncate font-mono">
-    app/agent/mode/chat.py
-  </span>
-  <span className="ml-auto text-xs text-(--color-text-muted)">124ms</span>
-  <ChevronRight
-    className="w-3.5 h-3.5 text-(--color-text-subtle) transition-transform"
-    aria-hidden="true"
-  />
-</div>
-```
+| State | When | Dot |
+|---|---|---|
+| Start | Tool name has arrived but arguments have not | Muted, gentle pulse |
+| Running | Arguments are streaming, no result yet | Accent-blue, gentle pulse |
+| Success | Result has landed and does not look like a failure | `--color-success`, static |
+| Failed | Result begins with a known failure prefix or a non-zero exit signal | `--color-error`, static |
 
-### Expanded (with output)
+The failure detection is conservative: prefer false negatives over false positives. The dot only flips to error when the result text matches one of the agreed failure shapes (e.g. `[failed`, `[error`, `exit code 1`, `exit 1`). Tool result formatters must use those prefixes consistently so the indicator stays trustworthy.
 
-```tsx
-<div
-  className="bg-(--bg-card) border border-(--border-card) rounded-md
-             flex flex-col
-             animate-in slide-in-from-bottom-1 fade-in duration-240 ease-out"
->
-  {/* Header row — same as collapsed */}
-  <div className="px-3 py-2 flex items-center gap-3 border-b border-(--border-soft)">
-    <Wrench className="w-4 h-4 text-(--accent-blue)" aria-hidden="true" />
-    <span className="text-sm font-mono text-(--color-text-2)">read_file</span>
-    <span className="text-sm text-(--color-text-muted) truncate font-mono">
-      app/agent/mode/chat.py
-    </span>
-    <span className="ml-auto text-xs text-(--color-text-muted)">124ms</span>
-    <ChevronDown className="w-3.5 h-3.5 text-(--color-text-subtle)" aria-hidden="true" />
-  </div>
+### Chrome
 
-  {/* Output — code block on slightly inset surface */}
-  <pre className="px-3 py-2 bg-(--color-tint-mint) text-sm font-mono text-(--color-text) overflow-x-auto">
-    <code>{toolOutput}</code>
-  </pre>
-</div>
-```
+- Outer card: small radius, 1px `--color-border`, no fill — sits on the ambient chat surface so a stack of rows reads as a single column.
+- Header row: status dot, mono name (or a tool-specific summary), chevron at the trailing edge. Header padding sits at the small-card scale.
+- Hover wash on `--bg-key` only when the row is expandable. A row with no details is non-interactive and skips the wash.
+- Expanded body: divider, then the calm `--bg-key` wash. Inside the body, two sections — arguments and result — each captioned with mono uppercase 10px in `--color-text-subtle`, with copy-to-clipboard affordance per section.
 
-The output uses `--color-tint-mint` (very-low-alpha mint) as a subtle "this came back successfully" wash — *only* when the call returned `success`. Errors use `--accent-red` at 8% alpha; pending (still executing) uses `--color-tint-orange`.
+### Per-tool customisation
+
+Tools may customise the header summary (e.g. "Read `src/main.py`" instead of "read_file") and the way arguments are rendered (e.g. shell commands prefixed with `$`, JSON formatted as syntax-highlighted blocks). That customisation is per-tool and lives next to the chrome, not inside it. The chrome rules do not change between tools.
+
+### Don't
+
+- Add a wrench (or any tool icon) to the header. The status dot is the only identity glyph; a tool icon adds noise without information.
+- Tint the result body green or red to match status. The dot already conveys state; the warm `--bg-key` reads as a calm reading wash regardless of outcome.
+- Fill the outer card. Leave it transparent so the row blends into the chat surface; only the expanded body gets a fill.
+- Use the deprecated `--border-card` token; use `--color-border`.
+
+---
+
+## Agent topbar
+
+The chat surface's right cluster — the consistent bar of controls that follows the user across agent / split / unified views. It sits at the trailing edge of the topbar; the left side varies per view mode.
+
+The topbar is composed from smaller primitives. Each primitive owns its appearance; the topbar owns the order and the visibility rules.
+
+**Primitives in the right cluster (in order)**
+
+1. **Token meter** — desktop only, hidden until totals exceed zero. Shows `input · output · cached` tokens in mono 11px on a transparent background; cached column appears only after the first cache hit. A pulsing dot may follow the numbers while values are still climbing.
+2. **Dream indicator** — small mono row with a pulsing moon glyph, shown while the dream loop is running. Label is hidden on narrow viewports; the pulsing glyph is the minimum.
+3. **Split-pane controls** — desktop only, only meaningful in unified view. Two icon-only ghost buttons for "split down" and "split right".
+4. **View toggle** — desktop only. Three-state segmented control for `agent` / `split` / `unified`. See [View toggle](#view-toggle).
+5. **Topbar action triplet** — Todos, Files, Agents. Each is a small icon+label button (see [Topbar action](#topbar-action)).
+
+**Visibility rules**
+
+- Mobile collapses everything except the action triplet — token meter, dream indicator, split controls, and view toggle are all desktop-only.
+- The topbar is a `shrink-0` flex row. The left side of the topbar must own its `min-w-0` so the topbar never pushes content off-screen.
+
+**Don't**
+
+- Mix the topbar action triplet with the view toggle order. The order is fixed; users learn the position of each control across sessions.
+- Use a chip-colored indicator on a topbar action to signal an open panel state. Use the small accent dot on `TopbarAction` (`indicator`) — that affordance is reserved for that purpose.
+
+---
+
+## View toggle
+
+Three-state icon-only segmented control for chat view modes — `agent` (single agent focus), `split` (side-by-side panes), `unified` (tiled view).
+
+**Rules**
+
+- Three equally-sized icon-only buttons inside a rounded outline. Outline uses `--color-border-subtle`; padding inside is half a unit.
+- Active button: `--color-surface-2` fill, `--color-text` glyph. Inactive: transparent fill, `--color-text-muted` glyph that hovers to `--color-text-2` on `--bg-key`.
+- Icons are mapped to the closest lucide equivalents of the design source's Material Symbols `person` / `view_column` / `view_quilt` (currently `User` / `Columns2` / `LayoutGrid`).
+- Implemented as a `radiogroup`; per-button `aria-checked`. Labels live on `aria-label` and `title` only — the control is too dense to fit visible labels in the topbar; tooltips surface them on hover and on focus.
+
+**Don't**
+
+- Re-skin the active button as a primary-button surface (`--color-accent`). The toggle communicates a *view mode*, not a primary action; it must stay neutral.
+
+---
+
+## Topbar action
+
+Small icon+label button used in the agent topbar (Todos, Files, Agents).
+
+**Rules**
+
+- Padding sits at the compact scale, gap between icon and label is a single spacing unit, radius at the small scale.
+- Transparent fill at rest; hover wash on `--bg-key` with the label color shifting from `--color-text-2` to `--color-text`.
+- Lucide icon at 13px, label at 12px weight 500. Both inherit the same color.
+- Disabled state reduces opacity to 50% and removes the hover wash.
+- Labels are hidden on narrow viewports by default but stay in the DOM as accessible names. Optional small accent dot at the trailing edge signals an active or in-progress state; an override color (e.g. `--color-error`) is allowed for error states.
+
+---
+
+## Todos popover
+
+Task-list popover surfaced from the agent topbar. Trigger is a `TopbarAction`; content is a paper-card panel.
+
+**Trigger**
+
+- Uses the `TopbarAction` primitive directly so it sits inline with Files and Agents.
+- The accent dot is shown when any task is in progress.
+- Disabled (with a "No active session" tooltip) when there is no session.
+
+**Panel chrome**
+
+- Surface: medium-width panel, small radius, `--color-surface` fill, 1px `--color-border` outline (no shadow ring), shadow at the depth scale because the panel floats over chat.
+- Header: mono uppercase 10px title ("Tasks"), mono completion counter ("3 / 8 done") aligned to the trailing edge.
+- Empty state: hand-drawn Caveat callout in `--color-text-subtle` ("No tasks yet — ask the agent to plan"). Same idiom as the rest of the app's empty surfaces.
+
+**Item rules**
+
+- Sort order: in-progress, then pending, then completed, then cancelled.
+- Status glyph leads the row, sized small. Completed and cancelled rows use `line-through` and shift the text to `--color-text-subtle`.
+- Priority badge trails the row in mono uppercase 9px on a soft fill: high uses `--color-error` at low alpha, medium uses `--color-warning` at low alpha, low uses `--bg-key` neutral.
+
+**Don't**
+
+- Color the status glyph by agent role. The popover represents the assistant's task list as a whole.
+- Use the chip palette for priority. Priority is a status concept, not an identity concept.
+
+---
+
+## File preview strip
+
+A horizontal row of file-preview chips below or above the input bar. Used by the input composer when files are attached or staged.
+
+**Rules**
+
+- Single row; horizontal scroll, never wrap.
+- Image attachments render as compact thumbnails (capped at a moderate max edge); other files render as the shared `FileCard`.
+- When the row content overflows the visible width, a thin scroll-position pill appears below the strip — a 3px-tall track with a thumb that mirrors current scroll position. The pill is hidden when content fits.
+- Direction (above vs. below the input) is set by the parent based on docking position. The input bar's parent owns the rule and passes the direction to the strip; the strip never decides for itself.
+
+---
+
+## Input bar (floating composer)
+
+The input bar is a paper capsule floating above the conversation. It is the most-touched surface in the product and follows two distinct mode rules.
+
+### Surface
+
+- `--bg-card` fill (slightly translucent to allow background blur), 1px `--color-border` outline, depth shadow because the bar floats. Radius at the largest scale in the system — the bar reads as a *physical writing instrument*, not a toolbar.
+- Padding is compact; the bar grows vertically with the textarea up to a maximum height, then scrolls internally.
+
+### States
+
+| State | Cue |
+|---|---|
+| Empty | Placeholder text, send button at reduced opacity |
+| Typing | Send button at full opacity; optional character counter on long messages |
+| Streaming | Send button is replaced with a stop control; the bar's border picks up a thin accent in the active agent's chip color |
+| Queue armed | A queue badge appears above the bar (`+1 message · enqueued`); see [Queue banner](#queue-banner) |
+| With attachments | Attachment chips render adjacent to the bar via the [File preview strip](#file-preview-strip) |
+| Minimized | Desktop only — collapses to a slim icon strip when the textarea blurs while empty |
+
+### Desktop minimize / summon
+
+A blurred composer should not dominate the chat surface, but the user must be able to summon it from anywhere. The bar collapses and expands by the same set of rules:
+
+- Starts collapsed on first paint. The slim icon strip is the resting state on desktop.
+- Expands on focus, on attaching a file, while streaming, while there is queued content, while disabled (waiting for a response), or while content is held inside the composer.
+- Collapses again after a short delay following blur, but only when there is genuinely no content. The delay is short enough to feel snappy and long enough to avoid collapsing mid-action when the user clicks an adjacent control inside the bar.
+- A global shortcut (`Ctrl/⌘+I`) summons the composer from any focus context. The textarea takes focus and the bar expands if needed.
+
+Mobile keeps the full bar at all times — the soft keyboard already dictates focus cadence, and a collapse race there would feel broken.
+
+### Drag (desktop)
+
+- The bar is draggable from a top-edge grip handle; pointer events outside the grip do not initiate drag.
+- Position persists across sessions; on resize the position is clamped so the bar stays inside the viewport.
+- A double-click on the grip resets to the default docked position (bottom-center with a small gap).
+
+### Mobile dock
+
+- Static, full-width, pinned to the bottom of the viewport.
+- A top border separates the dock from the chat above; bottom padding accounts for the home indicator (`pb-safe`).
+- No drag, no position memory — the keyboard owns the bottom region and any motion would fight the system.
+
+### Attachment direction
+
+The parent (`FloatingInputBar`) computes whether previews render above or below the bar based on the bar's distance from the viewport bottom: previews default to *below*, and only flip to *above* when the bar is docked near the top of the chat region. The rule recomputes on mount, on window resize, on drag end, and on reset.
+
+### Don't
+
+- Replace the depth shadow with a heavier border. The bar floats; the shadow is what communicates that.
+- Use the bar's radius scale anywhere else. The 24-ish-px corner is reserved for the composer.
+- Show the slim minimized strip on mobile.
+
+---
+
+## Draggable panes
+
+Side-by-side and tiled agent panes use the same handle-only drag pattern. Drag is gated to a visible grip; the rest of the pane remains a normal click/scroll target. The pane is a valid drop target via `onDragOver` / `onDrop` on its root.
+
+- Grip: `lucide GripVertical` (or `GripHorizontal` for top-mounted handles), `--color-text-muted`, sized small.
+- Cursor: `grab` at rest, `grabbing` while pressed.
+- Use the framework's drag-controls pattern — start drag manually from the grip's pointer-down — so the handle is the only drag entry point.
 
 ---
 
 ## Queue banner
 
-When messages are enqueued behind a streaming response, a small banner appears above the input bar.
+When messages are enqueued behind a streaming response, an aggregate banner sits above the input bar. It is the only place orange-marker pigment is reused outside the chip palette.
 
-```tsx
-<div
-  className="flex items-center gap-2 px-3 py-1.5
-             bg-(--accent-orange-soft) text-(--accent-orange-text)
-             rounded-md text-sm font-medium
-             border border-(--accent-orange)/30"
-  role="status"
-  aria-live="polite"
->
-  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-orange)" aria-hidden="true" />
-  <span>+1 message · enqueued</span>
-  <button className="ml-2 text-(--accent-orange-text)/70 hover:text-(--accent-orange-text)">
-    <X className="w-3 h-3" />
-  </button>
-</div>
-```
+**Rules**
 
-Orange (consultant chip) is reused here because "enqueued" is conceptually a *consultation* signal — "this will be considered next, not now". The chip-soft / chip-edge / chip-text triad scales to any small status badge.
+- Surface: `--color-surface` fill, 1px `--color-border` outline, depth shadow because the banner floats near the input bar. Small radius.
+- Header text: mono 11px, weight 600, letter-spaced; reads `QUEUE · N messages awaiting`. The pluralization is computed from the count.
+- Marker dot at the leading edge: `--color-marker-orange`. Optional collapse chevron at the trailing edge when the banner is interactive.
+- Status semantics: when the banner is not interactive, it is a `role="status"` with `aria-live="polite"`. When interactive, it is a button with `aria-expanded`.
+
+Per-message rows below the banner are owned by the pending-queue list, not by the banner itself.
+
+**Don't**
+
+- Use chip-soft / chip-edge / chip-text orange tokens for the banner. The marker tokens are deliberately more saturated; the banner is intentionally louder than a chip.
+- Stack a queue banner inside a card. The banner is itself a floating chrome surface.
 
 ---
 
-## Design token export (JSON)
+## Token meter
 
-For Figma, Storybook, or other design tools:
+Compact pill that shows token totals in the agent topbar.
 
-```json
-{
-  "mode": {
-    "light": {
-      "color": {
-        "bg-page": "#FAF6EC",
-        "bg-sidebar": "#F5EFDD",
-        "bg-card": "#FFFBF1",
-        "bg-input": "#FAF6EC",
-        "bg-key": "#F0E9D4",
-        "bg-send": "#2D241B",
-        "surface": "#FFFDF7",
-        "surface-2": "#F5EBD8",
-        "border-soft": "#E8DFC6",
-        "border-card": "#E0D5B7",
-        "border": "#D7C7AA",
-        "border-strong": "#A89880",
-        "text": "#1A1714",
-        "text-2": "#5F5143",
-        "text-muted": "#7A6B58",
-        "text-subtle": "#A89880",
-        "text-on-accent": "#FFFDF7",
-        "accent": "#3F3429",
-        "accent-blue": "#5AA8E2",
-        "accent-blue-soft": "#DCEEFB",
-        "accent-blue-text": "#2D6FA8",
-        "accent-green": "#3DA66A",
-        "accent-green-soft": "#E2F2E5",
-        "accent-green-text": "#2D7A4F",
-        "accent-orange": "#F59E3B",
-        "accent-orange-soft": "#FFF1D8",
-        "accent-orange-text": "#C26A1E",
-        "accent-pink": "#E63D7A",
-        "accent-pink-soft": "#FBE0EB",
-        "accent-purple": "#7C5BCF",
-        "accent-purple-soft": "#E8DEF8",
-        "accent-red": "#C8333E",
-        "marker-blue": "#0284C7",
-        "marker-mint": "#16A34A",
-        "marker-orange": "#FA8030",
-        "marker-pink": "#DB2777",
-        "marker-yellow": "#B77900",
-        "violet": "#7C3AED",
-        "success": "#3DA66A",
-        "warning": "#F59E3B",
-        "error": "#B91C1C",
-        "info": "#5AA8E2",
-        "overlay": "#1A171466"
-      },
-      "focus-ring": "#3F3429",
-      "shadow-depth": "0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.05)"
-    },
-    "dark": {
-      "color": {
-        "bg-page": "#15110D",
-        "bg-sidebar": "#1C1813",
-        "bg-card": "#1C1813",
-        "bg-input": "#1C1813",
-        "bg-key": "#2A2219",
-        "bg-send": "#F5EBD8",
-        "surface": "#221C16",
-        "surface-2": "#2A2219",
-        "border-soft": "#2C231A",
-        "border-card": "#3A2F23",
-        "border": "#3A2F23",
-        "border-strong": "#5C4B36",
-        "text": "#F5EBD8",
-        "text-2": "#C5B59A",
-        "text-muted": "#9C8A72",
-        "text-subtle": "#7A6B58",
-        "text-on-accent": "#15110D",
-        "accent": "#F5EBD8",
-        "accent-blue": "#7CC2F0",
-        "accent-blue-soft": "#1E3A52",
-        "accent-blue-text": "#9DD0F5",
-        "accent-green": "#5DC487",
-        "accent-green-soft": "#1F3A2A",
-        "accent-green-text": "#92E0B0",
-        "accent-orange": "#FDB75D",
-        "accent-orange-soft": "#3D2D14",
-        "accent-orange-text": "#FCC780",
-        "accent-pink": "#F472B6",
-        "accent-pink-soft": "#3D1F2D",
-        "accent-purple": "#A78BFA",
-        "accent-purple-soft": "#2D2440",
-        "accent-red": "#F87171",
-        "marker-blue": "#38BDF8",
-        "marker-mint": "#4ADE80",
-        "marker-orange": "#FCC352",
-        "marker-pink": "#F472B6",
-        "marker-yellow": "#FBBF24",
-        "violet": "#A78BFA",
-        "success": "#5DC487",
-        "warning": "#FDB75D",
-        "error": "#F87171",
-        "info": "#7CC2F0",
-        "overlay": "#00000099"
-      },
-      "focus-ring": "#F5EBD8",
-      "shadow-depth": "0 1px 2px rgba(0,0,0,0.3), 0 2px 8px rgba(0,0,0,0.25)"
-    }
-  },
-  "typography": {
-    "font-sans": "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-    "font-mono": "'JetBrains Mono', ui-monospace, 'SF Mono', 'Courier New', monospace",
-    "font-hand": "'Caveat', 'Bradley Hand', cursive",
-    "size": {
-      "hand": "44px",
-      "display": "32px",
-      "h1": "28px",
-      "h2": "24px",
-      "h3": "20px",
-      "body": "16px",
-      "sm": "14px",
-      "xs": "12px"
-    },
-    "weight": {
-      "regular": 400,
-      "medium": 500,
-      "semibold": 600,
-      "bold": 700
-    }
-  },
-  "radius": {
-    "xs": "6px",
-    "sm": "8px",
-    "md": "10px",
-    "lg": "14px",
-    "2xl": "24px"
-  },
-  "spacing": {
-    "base": "4px",
-    "xs": "4px",
-    "sm": "8px",
-    "md": "12px",
-    "lg": "16px",
-    "xl": "24px",
-    "2xl": "32px",
-    "3xl": "48px",
-    "4xl": "64px"
-  },
-  "motion": {
-    "duration": {
-      "instant": "80ms",
-      "fast": "150ms",
-      "base": "240ms",
-      "slow": "400ms",
-      "glacial": "800ms"
-    },
-    "ease": {
-      "out": "cubic-bezier(0.16, 1, 0.3, 1)",
-      "in-out": "cubic-bezier(0.4, 0, 0.2, 1)",
-      "spring-soft": "cubic-bezier(0.34, 1.2, 0.64, 1)",
-      "spring-snappy": "cubic-bezier(0.22, 1.4, 0.36, 1)"
-    }
-  }
-}
-```
+- Mono 11px, padding compact, radius at the small scale, no fill.
+- Numbers in `--color-text`; `·` separators in `--color-text-muted`.
+- Cached column appears only when its value exceeds zero — a fresh session shows two numbers, not three.
+- Optional pulsing dot to signal that values are still climbing during a stream.
 
 ---
 
 ## Pre-ship checklist
 
-- [ ] Tokens used (`--bg-*`, `--color-*`, `--accent-*`, `--fg-*`) — no raw hex values
-- [ ] Both modes verified (toggle between light/dark — nothing should look broken)
-- [ ] Body uses Inter; code uses JetBrains Mono; Caveat is opt-in only on hand callouts
-- [ ] Spacing aligns to 4px base; radius uses `--radius-*`
-- [ ] Focus ring visible on `:focus-visible` (tab through the UI to verify)
-- [ ] Contrast ≥ 4.5:1 for body text (Lighthouse / WebAIM)
-- [ ] Icons from lucide-react, sized to the [imagery.md](./imagery.md#sizing) scale
-- [ ] Status colors paired with icon or label (never color alone)
-- [ ] Agent chips use the correct `--accent-{role}-*` triad — soft fill, edge dot, text
-- [ ] Brand pigment (Octobot gold/orange) only on mascot and lockups, never on UI chrome
-- [ ] Motion uses tokens from [motion.md](./motion.md) — no magic ms values
-- [ ] Font-weight transitions on interactive elements only (not on Caveat)
-- [ ] `prefers-reduced-motion` tested
-- [ ] Keyboard navigation works end-to-end (no traps, logical tab order)
-- [ ] Touch targets ≥ 44×44 on mobile
-- [ ] Empty/error/loading states all present
+Before shipping a new component or screen:
+
+- Tokens used everywhere — no raw hex values anywhere in component CSS or inline style.
+- Both modes verified by toggling `system → light → dark`. Nothing flickers, nothing inverts incorrectly.
+- Body text is Inter; code text is JetBrains Mono; Caveat is opt-in only on hand callouts.
+- Spacing aligns to the 4px base; radii come from the radius scale; no magic px values.
+- Focus ring visible on `:focus-visible` for every interactive element. Tab through the surface to verify.
+- Body text contrast ≥ 4.5:1 against its surface (Lighthouse / WebAIM).
+- Icons come from `lucide-react`, sized to [imagery.md § Sizing](./imagery.md#sizing).
+- Status colors are paired with an icon or label; no color-alone signals.
+- Agent chips use the correct role triad — soft fill, edge dot, text. No reuse of role colors outside the role.
+- Brand pigment (Octobot) is on the mascot and lockups only — never on UI chrome.
+- Motion durations and easings come from [motion.md](./motion.md); `prefers-reduced-motion` is honored.
+- Font-weight transitions are on interactive elements only; never on Caveat.
+- Keyboard navigation works end-to-end with logical tab order and no traps.
+- Touch targets ≥ 44×44 on mobile.
+- Empty, error, and loading states are all designed and present.

--- a/documents/styling-specs/applications.md
+++ b/documents/styling-specs/applications.md
@@ -1,38 +1,122 @@
 ---
 title: Applications & Templates
-description: Component examples using OpenAgentd tokens in both light and dark modes
+description: Component examples — agent chips, sidebar, input bar, tool calls, theme toggle — using paper tokens
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # Applications & Templates
 
-Component examples using OpenAgentd tokens. All examples work in both modes without modification; brand pigment is reserved for identity, agent state, and primary moments.
+Component examples using OpenAgentd paper tokens. All examples work in both modes without modification; brand pigment is reserved for the Octobot mascot, agent identity is carried by the chip palette, and chrome stays warm-neutral.
+
+---
+
+## Agent chips (signature component)
+
+The agent chip is the most-used custom component in the product. It identifies which agent is talking, which role is selected in the topbar, and what kind of work is queued. The chip is a soft pastel pill with an edge dot and a darker text color — the three colors come from `--accent-{role}-soft`, `--accent-{role}` (edge), and `--accent-{role}-text`.
+
+### The four canonical roles
+
+```tsx
+// openagentd (router)
+<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+                   bg-(--accent-green-soft) text-(--accent-green-text)
+                   text-sm font-medium
+                   hover:font-semibold transition-all duration-150">
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-green)" aria-hidden="true" />
+  openagentd
+</button>
+
+// executor
+<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+                   bg-(--accent-blue-soft) text-(--accent-blue-text)
+                   text-sm font-medium
+                   hover:font-semibold transition-all duration-150">
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-blue)" aria-hidden="true" />
+  executor
+</button>
+
+// consultant
+<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+                   bg-(--accent-orange-soft) text-(--accent-orange-text)
+                   text-sm font-medium
+                   hover:font-semibold transition-all duration-150">
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-orange)" aria-hidden="true" />
+  consultant
+</button>
+
+// explorer
+<button className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+                   bg-(--accent-pink-soft) text-(--color-text)
+                   text-sm font-medium
+                   hover:font-semibold transition-all duration-150">
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-pink)" aria-hidden="true" />
+  explorer
+</button>
+```
+
+### Selected vs unselected
+
+The topbar role toggle uses chips for *all* states — selection is communicated by **pigment, not container shape**:
+
+| State | Treatment |
+|---|---|
+| **Unselected** | Soft fill + edge dot at full saturation, weight 500 |
+| **Selected** | Same soft fill + thicker 1.5px ring in `--accent-{role}` + weight 600 + slight shadow |
+| **Hover** | Weight 500→600, no fill change (pigment is already there) |
+
+```tsx
+<button
+  className={`
+    inline-flex items-center gap-1.5 rounded-full px-2.5 py-1
+    bg-(--accent-green-soft) text-(--accent-green-text)
+    text-sm transition-all duration-150
+    ${selected
+      ? 'font-semibold ring-[1.5px] ring-(--accent-green) shadow-sm'
+      : 'font-medium hover:font-semibold'}
+  `}
+  aria-pressed={selected}
+>
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-green)" />
+  openagentd
+</button>
+```
+
+### Anti-patterns
+
+- ❌ Using a chip color outside its role (mint anywhere except openagentd)
+- ❌ Replacing the soft fill with the saturated edge color when "selected" (loses readability)
+- ❌ Removing the edge dot (the dot doubles as a status anchor — pulse on streaming, dim when idle)
+- ❌ Using chips as buttons that *don't* refer to an agent role
 
 ---
 
 ## Buttons
 
-### Primary
+### Primary (send)
 
-Uses the accent. The gradient variant is reserved for hero/landing — regular UI uses the flat accent.
+The primary CTA is the **send button** — paper inverted: warm dark surface, cream text. This is the only place the paper aesthetic flips contrast.
 
 ```tsx
-// Regular primary
-<button className="bg-accent text-bg px-4 py-2 rounded font-medium hover:bg-accent-hover transition-all duration-150">
-  Start session
-</button>
-
-// Hero primary (gradient — one per surface)
-<button className="bg-[image:var(--gradient-accent)] text-bg px-5 py-2.5 rounded font-medium shadow-sm hover:brightness-110 transition-all duration-150">
-  Start session
+<button
+  className="bg-(--bg-send) text-(--color-text-on-accent)
+             px-4 py-2 rounded-md font-medium
+             hover:brightness-110 transition-all duration-150"
+>
+  Send
 </button>
 ```
 
 ### Secondary
 
 ```tsx
-<button className="bg-surface-2 text-text border border-border px-4 py-2 rounded font-medium hover:bg-surface-3 hover:border-border-strong transition-all duration-150">
+<button
+  className="bg-(--bg-card) text-(--color-text)
+             border border-(--border-card)
+             px-4 py-2 rounded-md font-medium
+             hover:bg-(--bg-key) hover:font-semibold
+             transition-all duration-150"
+>
   Cancel
 </button>
 ```
@@ -40,7 +124,13 @@ Uses the accent. The gradient variant is reserved for hero/landing — regular U
 ### Destructive
 
 ```tsx
-<button className="bg-error text-bg px-4 py-2 rounded font-medium hover:brightness-110 transition-all duration-150">
+<button
+  className="bg-transparent text-(--color-error)
+             border border-(--color-error)/30
+             px-4 py-2 rounded-md font-medium
+             hover:bg-(--accent-red)/10 hover:font-semibold
+             transition-all duration-150"
+>
   Delete session
 </button>
 ```
@@ -48,18 +138,25 @@ Uses the accent. The gradient variant is reserved for hero/landing — regular U
 ### Ghost
 
 ```tsx
-<button className="text-text px-4 py-2 rounded font-medium hover:bg-accent-subtle transition-all duration-150">
+<button
+  className="text-(--color-text-2) px-3 py-1.5 rounded-md
+             hover:text-(--color-text) hover:bg-(--bg-key)
+             font-normal hover:font-medium
+             transition-all duration-150"
+>
   Skip
 </button>
 ```
 
 ### Loading
 
-Label swaps to progressive text; pointer events lock. No spinner unless progress text isn't possible.
-
 ```tsx
-<button disabled className="bg-accent/60 text-bg px-4 py-2 rounded font-medium cursor-not-allowed">
-  Connecting…
+<button
+  disabled
+  className="bg-(--bg-send)/60 text-(--color-text-on-accent)
+             px-4 py-2 rounded-md font-medium cursor-not-allowed"
+>
+  Sending…
 </button>
 ```
 
@@ -69,11 +166,12 @@ Interactive buttons shift weight on hover and active — see [typography.md](./t
 
 ```tsx
 <button
-  className="bg-accent text-bg px-4 py-2 rounded
+  className="bg-(--bg-send) text-(--color-text-on-accent)
+             px-4 py-2 rounded-md
              font-normal hover:font-medium active:font-semibold
              transition-all duration-150 ease-out"
 >
-  Start session
+  Send
 </button>
 ```
 
@@ -82,16 +180,19 @@ Interactive buttons shift weight on hover and active — see [typography.md](./t
 ## Card
 
 ```tsx
-<div className="bg-surface border border-border rounded-lg p-6 shadow-[var(--shadow-depth)]">
-  <h3 className="text-h3 font-semibold text-text mb-2">Session title</h3>
-  <p className="text-text-muted text-sm mb-4">Started 3 minutes ago · 2 agents active</p>
-  <button className="text-accent hover:text-accent-hover font-normal hover:font-medium transition-all">
+<div
+  className="bg-(--bg-card) border border-(--border-card)
+             rounded-lg p-6 shadow-[var(--shadow-depth)]"
+>
+  <h3 className="text-h3 font-semibold text-(--color-text) mb-2">Session title</h3>
+  <p className="text-(--color-text-muted) text-sm mb-4">
+    Started 3 minutes ago · 2 agents active
+  </p>
+  <button className="text-(--color-accent) font-normal hover:font-medium transition-all">
     View details →
   </button>
 </div>
 ```
-
-`var(--shadow-depth)` resolves to `none` on dark (brightness provides depth) and to a real shadow on light.
 
 ---
 
@@ -100,29 +201,29 @@ Interactive buttons shift weight on hover and active — see [typography.md](./t
 Every status pairs color with an icon or label — never color alone.
 
 ```tsx
-// Running — pulsing success dot
-<div className="flex items-center gap-2 text-text-2">
+// Running — pulsing success dot (mint = openagentd's color, also the success state)
+<div className="flex items-center gap-2 text-(--color-text-2)">
   <span className="relative flex w-2 h-2">
-    <span className="absolute inset-0 bg-success rounded-full animate-ping opacity-75" />
-    <span className="relative w-2 h-2 bg-success rounded-full" />
+    <span className="absolute inset-0 bg-(--color-success) rounded-full animate-ping opacity-75" />
+    <span className="relative w-2 h-2 bg-(--color-success) rounded-full" />
   </span>
   <span>Running</span>
 </div>
 
 // Error
-<div className="flex items-center gap-2 text-error">
+<div className="flex items-center gap-2 text-(--color-error)">
   <AlertCircle className="w-4 h-4" />
   <span>Failed</span>
 </div>
 
 // Success (static, non-celebratory)
-<div className="flex items-center gap-2 text-success">
+<div className="flex items-center gap-2 text-(--color-success)">
   <CheckCircle className="w-4 h-4" />
   <span>Completed</span>
 </div>
 
-// Pending
-<div className="flex items-center gap-2 text-warning">
+// Pending / queued
+<div className="flex items-center gap-2 text-(--accent-orange-text)">
   <Clock className="w-4 h-4" />
   <span>Queued</span>
 </div>
@@ -136,19 +237,20 @@ Every status pairs color with an icon or label — never color alone.
 
 ```tsx
 <div className="flex flex-col gap-2">
-  <label htmlFor="max-wait" className="text-text font-medium text-sm">
+  <label htmlFor="max-wait" className="text-(--color-text) font-medium text-sm">
     Max wait time (seconds)
   </label>
   <input
     id="max-wait"
     type="number"
     defaultValue={30}
-    className="bg-surface-2 border border-border rounded px-3 py-2 text-text placeholder:text-text-muted
-               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]
-               focus:border-accent transition-colors"
+    className="bg-(--bg-input) border border-(--color-border) rounded-md
+               px-3 py-2 text-(--color-text) placeholder:text-(--color-text-muted)
+               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)
+               focus:border-(--color-accent) transition-colors"
     placeholder="30"
   />
-  <p className="text-text-muted text-sm">
+  <p className="text-(--color-text-muted) text-sm">
     Increase for longer-running tool calls.
   </p>
 </div>
@@ -158,10 +260,11 @@ Every status pairs color with an icon or label — never color alone.
 
 ```tsx
 <textarea
-  className="bg-surface-2 border border-border rounded px-3 py-2 text-text font-mono text-sm
-             placeholder:text-text-muted
-             focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]
-             focus:border-accent transition-colors resize-y min-h-[200px]"
+  className="bg-(--bg-input) border border-(--color-border) rounded-md
+             px-3 py-2 text-(--color-text) font-mono text-sm
+             placeholder:text-(--color-text-muted)
+             focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)
+             focus:border-(--color-accent) transition-colors resize-y min-h-[200px]"
   placeholder="mode: chat&#10;max_wait: 30"
 />
 ```
@@ -170,15 +273,18 @@ Every status pairs color with an icon or label — never color alone.
 
 ```tsx
 <div className="flex flex-col gap-2">
-  <label htmlFor="name" className="text-text font-medium text-sm">Session name</label>
+  <label htmlFor="name" className="text-(--color-text) font-medium text-sm">
+    Session name
+  </label>
   <input
     id="name"
     aria-invalid="true"
     aria-describedby="name-error"
-    className="bg-surface-2 border border-error rounded px-3 py-2 text-text
-               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]"
+    className="bg-(--bg-input) border border-(--color-error) rounded-md
+               px-3 py-2 text-(--color-text)
+               focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)"
   />
-  <p id="name-error" className="text-error text-sm flex items-center gap-1.5">
+  <p id="name-error" className="text-(--color-error) text-sm flex items-center gap-1.5">
     <AlertCircle className="w-3.5 h-3.5" />
     Name is required.
   </p>
@@ -192,61 +298,77 @@ Every status pairs color with an icon or label — never color alone.
 Syntax colors resolve correctly in both modes via tokens from [colors.md](./colors.md#syntax-highlighting--code).
 
 ```tsx
-<pre className="bg-surface border border-border rounded-lg p-4 overflow-x-auto">
-  <code className="text-text font-mono text-sm leading-relaxed">
-    <span className="text-syn-keyword">const</span>{' '}
-    <span className="text-text">agent</span>{' '}
-    <span className="text-syn-operator">=</span>{' '}
-    <span className="text-syn-keyword">new</span>{' '}
-    <span className="text-syn-type">Agent</span>()
-    <span className="text-syn-operator">.</span>
-    <span className="text-syn-function">init</span>()
+<pre className="bg-(--color-surface) border border-(--color-border) rounded-lg p-4 overflow-x-auto">
+  <code className="text-(--color-text) font-mono text-sm leading-relaxed">
+    <span className="text-(--color-syn-keyword)">const</span>{' '}
+    <span className="text-(--color-text)">agent</span>{' '}
+    <span className="text-(--color-syn-operator)">=</span>{' '}
+    <span className="text-(--color-syn-keyword)">new</span>{' '}
+    <span className="text-(--color-syn-type)">Agent</span>()
+    <span className="text-(--color-syn-operator)">.</span>
+    <span className="text-(--color-syn-function)">init</span>()
   </code>
 </pre>
 ```
 
 For rendered markdown, use the `.prose` class — styled globally to consume the syntax tokens.
 
+### Inline code
+
+```tsx
+<code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">
+  app/agent/mode/chat.py
+</code>
+```
+
+---
+
+## Empty room (signature empty state)
+
+The canonical empty state — mascot + Caveat callout. This is the "what's on your mind?" screen.
+
+```tsx
+<div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+  <img
+    src="/brand/octobot-agentd-source.png"
+    alt=""
+    className="w-24 h-24 select-none"
+    draggable={false}
+  />
+  <h2 className="font-hand text-[44px] leading-none text-(--color-text)">
+    what&apos;s on your mind?
+  </h2>
+</div>
+```
+
+Caveat is purely visual here — the screen reader gets nothing. If the empty state needs to convey instructions, add an Inter description below the callout (or replace the Caveat with an Inter heading entirely).
+
 ---
 
 ## Error state page
 
 ```tsx
-<div className="flex flex-col items-center justify-center min-h-screen bg-bg px-4">
-  <AlertCircle className="w-16 h-16 text-error mb-4" aria-hidden="true" />
-  <h1 className="text-h1 font-bold text-text mb-2">
-    Session failed
-  </h1>
-  <p className="text-text-muted text-center mb-6 max-w-[50ch]">
-    Session timeout after 30 seconds. Increase <code className="bg-surface-2 px-1.5 py-0.5 rounded font-mono text-sm">max_wait</code> in <code className="bg-surface-2 px-1.5 py-0.5 rounded font-mono text-sm">chat.yaml</code> and try again.
+<div className="flex flex-col items-center justify-center min-h-screen bg-(--bg-page) px-4">
+  <AlertCircle className="w-16 h-16 text-(--color-error) mb-4" aria-hidden="true" />
+  <h1 className="text-h1 font-bold text-(--color-text) mb-2">Session failed</h1>
+  <p className="text-(--color-text-muted) text-center mb-6 max-w-[50ch]">
+    Session timeout after 30 seconds. Increase{' '}
+    <code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">max_wait</code>{' '}
+    in{' '}
+    <code className="bg-(--bg-key) px-1.5 py-0.5 rounded-xs font-mono text-sm">chat.yaml</code>{' '}
+    and try again.
   </p>
   <div className="flex gap-3">
-    <button className="bg-accent text-bg px-4 py-2 rounded hover:bg-accent-hover transition-colors">
+    <button className="bg-(--bg-send) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110">
       Retry
     </button>
-    <a href="/docs/troubleshoot" className="text-text-2 hover:text-text underline underline-offset-4 self-center">
+    <a
+      href="/docs/troubleshoot"
+      className="text-(--color-text-2) hover:text-(--color-text) underline underline-offset-4 self-center"
+    >
       Troubleshooting guide →
     </a>
   </div>
-</div>
-```
-
----
-
-## Empty state
-
-```tsx
-<div className="flex flex-col items-center justify-center py-12 bg-surface rounded-lg border border-border">
-  <Inbox className="w-12 h-12 text-text-muted mb-4" aria-hidden="true" />
-  <h2 className="text-h3 font-semibold text-text mb-2">
-    No sessions yet
-  </h2>
-  <p className="text-text-muted text-center mb-6 max-w-[40ch]">
-    Create a session to start working with agents.
-  </p>
-  <button className="bg-accent text-bg px-4 py-2 rounded hover:bg-accent-hover transition-colors">
-    Create session
-  </button>
 </div>
 ```
 
@@ -256,32 +378,31 @@ For rendered markdown, use the `.prose` class — styled globally to consume the
 
 ```tsx
 {/* Backdrop */}
-<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-in fade-in duration-150">
+<div className="fixed inset-0 bg-(--color-overlay) flex items-center justify-center z-50 animate-in fade-in duration-150">
   {/* Panel */}
   <div
     role="dialog"
     aria-modal="true"
     aria-labelledby="dialog-title"
-    className="bg-surface border border-border rounded-lg shadow-2xl w-96 max-w-[90vw]
+    className="bg-(--bg-card) border border-(--border-card)
+               rounded-lg shadow-2xl w-96 max-w-[90vw]
                animate-in fade-in zoom-in-95 slide-in-from-bottom-2 duration-240"
   >
-    <div className="border-b border-border px-6 py-4">
-      <h2 id="dialog-title" className="text-h3 font-semibold text-text">
+    <div className="border-b border-(--color-border) px-6 py-4">
+      <h2 id="dialog-title" className="text-h3 font-semibold text-(--color-text)">
         Confirm deletion
       </h2>
     </div>
 
     <div className="px-6 py-4">
-      <p className="text-text-2">
-        This cannot be undone. Delete this session?
-      </p>
+      <p className="text-(--color-text-2)">This cannot be undone. Delete this session?</p>
     </div>
 
-    <div className="border-t border-border px-6 py-4 flex justify-end gap-3">
-      <button className="text-text-2 hover:text-text px-4 py-2 rounded transition-colors">
+    <div className="border-t border-(--color-border) px-6 py-4 flex justify-end gap-3">
+      <button className="text-(--color-text-2) hover:text-(--color-text) px-4 py-2 rounded-md transition-colors">
         Cancel
       </button>
-      <button className="bg-error text-bg px-4 py-2 rounded hover:brightness-110 transition-all">
+      <button className="bg-(--color-error) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110 transition-all">
         Delete
       </button>
     </div>
@@ -293,52 +414,88 @@ Focus is trapped inside the dialog; `Esc` closes it; focus returns to the trigge
 
 ---
 
-## Sidebar navigation
+## Sidebar navigation (expanded)
 
 ```tsx
-<aside className="w-64 bg-surface border-r border-border h-screen overflow-y-auto flex flex-col">
-  <div className="px-6 py-5 border-b border-border">
-    <span className="font-bold text-lg text-text tracking-tight">OpenAgentd</span>
+<aside className="w-64 bg-(--bg-sidebar) border-r border-(--border-soft) h-screen overflow-y-auto flex flex-col">
+  {/* Brand header */}
+  <div className="px-4 py-4 flex items-center gap-2 border-b border-(--border-soft)">
+    <img
+      src="/brand/openagentd-app-icon.png"
+      alt=""
+      className="w-7 h-7"
+      draggable={false}
+    />
+    <span className="font-bold text-(--color-text) tracking-tight">OpenAgentd</span>
   </div>
 
+  {/* Primary nav */}
   <nav aria-label="Primary" className="flex flex-col gap-0.5 p-3 flex-1">
     <a
       href="/chat"
-      className="flex items-center gap-3 px-3 py-2 rounded text-text-2
-                 hover:bg-accent-subtle hover:text-text
+      className="flex items-center gap-3 px-3 py-2 rounded-md
+                 text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)
                  font-normal hover:font-medium
                  transition-all duration-150"
     >
       <MessageCircle className="w-4 h-4" aria-hidden="true" />
-      <span>Chat</span>
+      <span>New chat</span>
     </a>
     <a
-      href="/teams"
+      href="/commands"
       aria-current="page"
-      className="flex items-center gap-3 px-3 py-2 rounded bg-accent-subtle text-text font-medium"
+      className="flex items-center gap-3 px-3 py-2 rounded-md
+                 bg-(--bg-key) text-(--color-text) font-medium"
     >
-      <Users className="w-4 h-4" aria-hidden="true" />
-      <span>Teams</span>
+      <Command className="w-4 h-4" aria-hidden="true" />
+      <span>Commands</span>
     </a>
     <a
-      href="/docs"
-      className="flex items-center gap-3 px-3 py-2 rounded text-text-2
-                 hover:bg-accent-subtle hover:text-text
+      href="/memory"
+      className="flex items-center gap-3 px-3 py-2 rounded-md
+                 text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)
                  font-normal hover:font-medium
                  transition-all duration-150"
     >
-      <BookOpen className="w-4 h-4" aria-hidden="true" />
-      <span>Docs</span>
+      <Brain className="w-4 h-4" aria-hidden="true" />
+      <span>Memory wiki</span>
     </a>
   </nav>
 
-  <div className="p-3 border-t border-border">
+  {/* Footer */}
+  <div className="p-3 border-t border-(--border-soft) flex items-center justify-between">
     <ThemeToggle />
   </div>
 </aside>
 ```
 
-Current page shows `aria-current="page"` + permanent selected styling. Hover shifts weight (see [typography.md](./typography.md#font-weight-transitions-signature-interaction)).
+Current page shows `aria-current="page"` + permanent selected styling (the same warm `--bg-key` used as hover). Hover shifts weight (see [typography.md](./typography.md#font-weight-transitions-signature-interaction)).
+
+### Collapsed sidebar
+
+When collapsed, the sidebar shrinks to icon-only. The active item must keep a visible affordance — either the same `--bg-key` fill or a 2px left accent bar in `--color-accent`.
+
+```tsx
+<aside className="w-14 bg-(--bg-sidebar) border-r border-(--border-soft) h-screen flex flex-col items-center py-3 gap-1">
+  {navItems.map((item) => (
+    <a
+      key={item.href}
+      href={item.href}
+      aria-label={item.label}
+      aria-current={item.active ? 'page' : undefined}
+      className={`
+        relative flex items-center justify-center w-9 h-9 rounded-md
+        transition-all duration-150
+        ${item.active
+          ? 'bg-(--bg-key) text-(--color-text)'
+          : 'text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)'}
+      `}
+    >
+      <item.Icon className="w-4 h-4" aria-hidden="true" />
+    </a>
+  ))}
+</aside>
+```
 
 ---
 
@@ -360,9 +517,9 @@ function ThemeToggle() {
     localStorage.setItem('theme', theme);
     const resolved =
       theme === 'system'
-        ? matchMedia('(prefers-color-scheme: light)').matches
-          ? 'light'
-          : 'dark'
+        ? matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light'
         : theme;
     document.documentElement.classList.remove('light', 'dark');
     document.documentElement.classList.add(resolved);
@@ -372,7 +529,7 @@ function ThemeToggle() {
     <div
       role="radiogroup"
       aria-label="Theme"
-      className="inline-flex gap-0.5 bg-surface-2 border border-border rounded-full p-0.5"
+      className="inline-flex gap-0.5 bg-(--bg-card) border border-(--border-card) rounded-full p-0.5"
     >
       {(['system', 'light', 'dark'] as const).map((mode) => {
         const Icon = mode === 'system' ? Monitor : mode === 'light' ? Sun : Moon;
@@ -386,7 +543,9 @@ function ThemeToggle() {
             onClick={() => setTheme(mode)}
             className={`
               flex items-center justify-center w-7 h-7 rounded-full transition-all duration-150
-              ${selected ? 'bg-accent text-bg' : 'text-text-muted hover:text-text'}
+              ${selected
+                ? 'bg-(--bg-send) text-(--color-text-on-accent)'
+                : 'text-(--color-text-muted) hover:text-(--color-text)'}
             `}
           >
             <Icon className="w-3.5 h-3.5" />
@@ -402,26 +561,40 @@ function ThemeToggle() {
 
 ## Thinking indicator (streaming)
 
-Full motion spec in [motion.md](./motion.md#thinking-indicator-pulse-dots). Progressive label text named by the agent.
+Full motion spec in [motion.md](./motion.md#thinking-indicator-pulse-dots). Progressive label text named by the agent. The dot color matches the agent's chip edge color.
 
 ```tsx
-function ThinkingIndicator({ label }: { label: string }) {
+function ThinkingIndicator({ label, role }: { label: string; role?: AgentRole }) {
+  const dotColor = role ? `var(--accent-${roleToColor[role]})` : 'var(--color-text-muted)';
   return (
-    <div className="flex items-center gap-2 text-text-muted" role="status" aria-live="polite">
+    <div
+      className="flex items-center gap-2 text-(--color-text-muted)"
+      role="status"
+      aria-live="polite"
+    >
       <div className="flex gap-1">
-        <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-pulse [animation-delay:0ms]" />
-        <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-pulse [animation-delay:200ms]" />
-        <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-pulse [animation-delay:400ms]" />
+        <span
+          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:0ms]"
+          style={{ backgroundColor: dotColor }}
+        />
+        <span
+          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:200ms]"
+          style={{ backgroundColor: dotColor }}
+        />
+        <span
+          className="w-1.5 h-1.5 rounded-full animate-pulse [animation-delay:400ms]"
+          style={{ backgroundColor: dotColor }}
+        />
       </div>
       <span className="text-sm">{label}</span>
     </div>
   );
 }
 
-// Usage — label updates as the agent progresses
-<ThinkingIndicator label="Thinking" />
-<ThinkingIndicator label="Reading 4 files" />
-<ThinkingIndicator label="Writing patch" />
+// Usage — label updates as the agent progresses, dot color identifies the role
+<ThinkingIndicator role="openagentd" label="Thinking" />
+<ThinkingIndicator role="executor" label="Reading 4 files" />
+<ThinkingIndicator role="explorer" label="Searching memory" />
 ```
 
 ---
@@ -431,7 +604,7 @@ function ThinkingIndicator({ label }: { label: string }) {
 The blinking cursor that trails live-streamed text. Spec in [motion.md](./motion.md#streaming-cursor-blink).
 
 ```tsx
-<span className="inline-block w-[0.5ch] h-[1em] bg-text align-text-bottom animate-[streaming-cursor_1s_steps(2,end)_infinite]" />
+<span className="inline-block w-[0.5ch] h-[1em] bg-(--color-text) align-text-bottom animate-[streaming-cursor_1s_steps(2,end)_infinite]" />
 ```
 
 ```css
@@ -445,48 +618,52 @@ Remove the cursor the moment streaming ends or a tool call starts. A blinking cu
 
 ---
 
-## Floating composer
+## Input bar (floating composer)
 
-The chat input is a *glass* surface (see [layout.md](./layout.md#elevation-levels)) that floats over the conversation rather than docking to the bottom. It is draggable via a top-edge grip, position is persisted to `localStorage` (`oa-input-position`), and a double-click on the grip resets to bottom-center.
-
-### Rules
-
-- **Width**: `max-w-xl` (576px) — narrower than a docked strip so it feels like an instrument, not a toolbar
-- **Default position**: bottom-center, 16px gap from the viewport edge
-- **Drag affordance**: handle-only (`GripHorizontal` at top-center). The whole panel is *not* draggable — text selection and inner controls must work normally
-- **Grip anchors to the input pill, not the outer panel**: the `GripHorizontal` is rendered via `InputBar`'s `renderDragHandle` render-prop inside a `relative` wrapper that scopes it to the pill. This keeps the grip pinned to the pill's top edge regardless of whether file previews are rendered above or below (see *Attachment previews* below). Older revisions anchored it to the outer panel, which made the grip drift to the top of the preview strip when files were attached.
-- **Persistence**: `{x, y}` written to `oa-input-position`; clamped to viewport on mount and on `resize`
-- **Reset**: double-click the grip returns to default position
-- **No bottom padding underneath**: the content area flows behind the composer. Blur + low tint are what separate them — adding `pb-24` would re-create the docked strip we removed
-
-### Attachment previews
-
-File-attachment chips (images rendered as thumbnails, other files as `FileCard`) live in a row adjacent to the input pill. Three rules keep the composer usable even when users drag it around or attach many files:
-
-1. **Direction is position-dependent** — `FloatingInputBar` computes a `filesBelow` boolean and passes it to `InputBar`:
-   - **Default: `true`** — previews render *below* the input pill. This is the preferred direction because the pill hugs the bottom of the viewport by default and there is no room above for a preview strip that doesn't feel like a popover.
-   - **Flips to `false` (previews above)** only when the panel is docked far from the bottom — specifically when `bounds.bottom - panel.bottom ≥ 140px`. This threshold is just enough clearance for a compact preview row without re-colliding with the viewport edge.
-   - Recomputed on: mount, `window` resize, drag end, and double-click reset. There is no hysteresis — the decision is re-derived from current geometry every time the panel moves.
-2. **Single row with horizontal scroll, never vertical wrap** — the row is `flex flex-nowrap w-max` inside an `overflow-x-auto` scroll container. Attaching more files scrolls sideways; it never pushes the pill vertically off screen. `-mx-2 -my-2` on the outer wrapper neutralizes `px-2 py-2` on the scroll container (the padding exists so `-top-2`/`-right-2` remove buttons on each chip are not clipped — `overflow-x` forces y-axis clipping, so vertical padding must be explicit).
-3. **Image thumbnails render in *compact* mode** — `ImageAttachment` takes a `compact?: boolean` prop. When `true` (the mode used here), the `<img>` uses `max-h-[160px] max-w-[160px]` instead of the default `200×200`. The click-to-expand lightbox is unaffected — full-size preview remains available. This caps vertical intrusion from tall portrait images. `FileCard` is ~40px tall and needs no compact mode.
+The input bar is a **paper pill** floating above the conversation — `--bg-card` with a soft border and `--shadow-depth`. It is draggable via a top-edge grip; position is persisted to `localStorage` (`oa-input-position`); a double-click on the grip resets to bottom-center.
 
 ### Surface
 
 ```tsx
 <div
-  className="bg-(--color-surface-2)/20 backdrop-blur-xl shadow-xl
-             border border-border rounded-2xl
+  className="bg-(--bg-card)/90 backdrop-blur-xl
+             border border-(--border-card) shadow-[var(--shadow-depth)]
+             rounded-2xl
              px-3 py-2"
 >
-  {/* grip + textarea + send */}
+  {/* grip + textarea + attach + send */}
 </div>
 ```
 
-The outer positioning wrapper has no background of its own — all glass styling lives on the inner pill so the translucency reads correctly against whatever is scrolling underneath. Putting `bg-*` on the wrapper *and* the pill produces a double-layer that looks opaque; pick one (the pill) and keep the wrapper bare.
+The pill uses `--radius-2xl` (24px) — the largest radius in the system. It reads as a *physical writing instrument*, not a toolbar.
+
+### States
+
+The pencil documents distinct input bar states; each maps to a small visual cue rather than a different layout:
+
+| State | Cue |
+|---|---|
+| **Empty** | Placeholder text, send button at reduced opacity |
+| **Typing** | Send button at full opacity, character counter (if relevant) |
+| **Streaming** | Send button replaced with a stop icon; thin border accent in the active agent's chip color |
+| **Queue armed** | Small "Queue" pill prefixed with `+1 message · enqueued`, edge in `--accent-orange` |
+| **With attachments** | Attachment chips render adjacent to the pill (above or below per `filesBelow` rule) |
+| **Collapsed** | Compressed height when sidebar is collapsed; same surface, less padding |
+
+### Attachment previews
+
+File-attachment chips (images rendered as thumbnails, other files as `FileCard`) live in a row adjacent to the input pill. Three rules keep the composer usable:
+
+1. **Direction is position-dependent** — `FloatingInputBar` computes a `filesBelow` boolean and passes it to `InputBar`:
+   - **Default: `true`** — previews render *below* the input pill.
+   - **Flips to `false`** only when the panel is docked far from the bottom (`bounds.bottom - panel.bottom ≥ 140px`).
+   - Recomputed on mount, `window` resize, drag end, and double-click reset.
+2. **Single row with horizontal scroll, never vertical wrap** — `flex flex-nowrap w-max` inside an `overflow-x-auto` container.
+3. **Image thumbnails render in *compact* mode** — `max-h-[160px] max-w-[160px]` instead of the default 200×200. Click-to-expand lightbox is unaffected.
 
 ### Drag handle
 
-The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that `InputBar` can position it relative to the input pill (not the outer panel). `InputBar` renders the prop inside a `<div className="relative">` immediately wrapping the pill; the handle uses `absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2` to sit straddling the pill's top edge.
+The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that `InputBar` can position it relative to the input pill (not the outer panel). The handle uses `absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2` to sit straddling the pill's top edge.
 
 ```tsx
 <InputBar
@@ -499,7 +676,11 @@ The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that 
       title="Drag to move · Double-click to reset"
       onPointerDown={(e) => dragControls.start(e)}
       onDoubleClick={handleReset}
-      className="absolute left-1/2 top-0 z-10 -translate-x-1/2 -translate-y-1/2 …"
+      className="absolute left-1/2 top-0 z-10 -translate-x-1/2 -translate-y-1/2
+                 w-12 h-3 flex items-center justify-center
+                 rounded-full bg-(--bg-card) border border-(--border-card)
+                 text-(--color-text-muted) hover:text-(--color-text)
+                 transition-colors"
     >
       <GripHorizontal size={12} aria-hidden="true" />
     </button>
@@ -510,13 +691,11 @@ The grip is passed to `InputBar` via the `renderDragHandle` render-prop so that 
 
 Use framer-motion's `useDragControls` with `dragListener={false}` on the motion wrapper, then start drag manually from the handle's `onPointerDown`. This is the only reliable way to gate drag to a sub-region without breaking pointer events on the rest of the panel.
 
-Why render-prop instead of an outer wrapper: when file previews flip to render above the input pill, an outer-panel-scoped handle drifts up with them. The render-prop puts the handle inside the `InputBar`'s input-pill-scoped `relative` wrapper, which never moves relative to the pill itself.
-
 ---
 
 ## Draggable panes
 
-The same handle-only drag pattern applies to team view agent panes. Drag is gated to a visible `GripVertical`; the whole panel remains a valid drop target via `onDragOver` / `onDrop` on its root. Never make an entire panel draggable — it conflicts with text selection and with any floating controls layered on top.
+The same handle-only drag pattern applies to team view agent panes. Drag is gated to a visible `GripVertical`; the whole panel remains a valid drop target via `onDragOver` / `onDrop` on its root.
 
 ```tsx
 <div onDragOver={handleDragOver} onDrop={handleDrop} className="relative">
@@ -526,7 +705,7 @@ The same handle-only drag pattern applies to team view agent panes. Drag is gate
     className="absolute top-2 left-2 cursor-grab"
     aria-label="Reorder pane"
   >
-    <GripVertical className="w-4 h-4 text-text-muted" />
+    <GripVertical className="w-4 h-4 text-(--color-text-muted)" />
   </div>
   {/* pane content — selectable, clickable, normal */}
 </div>
@@ -536,20 +715,81 @@ The same handle-only drag pattern applies to team view agent panes. Drag is gate
 
 ## Tool-call row
 
-Slides in from below with a spring ([motion.md](./motion.md#tool-call-row-slide-in)).
+Slides in from below with a spring ([motion.md](./motion.md#tool-call-row-slide-in)). Tool calls are role-tagged: the wrench icon picks up the calling agent's chip edge color.
+
+### Collapsed (single line)
 
 ```tsx
 <div
-  className="bg-surface-2 border border-border rounded-md px-3 py-2
-             flex items-center gap-3
+  className="bg-(--bg-card) border border-(--border-card) rounded-md
+             px-3 py-2 flex items-center gap-3
              animate-in slide-in-from-bottom-1 fade-in duration-240 ease-out"
 >
-  <Wrench className="w-4 h-4 text-accent" aria-hidden="true" />
-  <span className="text-sm font-mono text-text-2">read_file</span>
-  <span className="text-sm text-text-muted truncate">app/agent/mode/chat.py</span>
-  <span className="ml-auto text-xs text-text-muted">124ms</span>
+  <Wrench className="w-4 h-4 text-(--accent-blue)" aria-hidden="true" />
+  <span className="text-sm font-mono text-(--color-text-2)">read_file</span>
+  <span className="text-sm text-(--color-text-muted) truncate font-mono">
+    app/agent/mode/chat.py
+  </span>
+  <span className="ml-auto text-xs text-(--color-text-muted)">124ms</span>
+  <ChevronRight
+    className="w-3.5 h-3.5 text-(--color-text-subtle) transition-transform"
+    aria-hidden="true"
+  />
 </div>
 ```
+
+### Expanded (with output)
+
+```tsx
+<div
+  className="bg-(--bg-card) border border-(--border-card) rounded-md
+             flex flex-col
+             animate-in slide-in-from-bottom-1 fade-in duration-240 ease-out"
+>
+  {/* Header row — same as collapsed */}
+  <div className="px-3 py-2 flex items-center gap-3 border-b border-(--border-soft)">
+    <Wrench className="w-4 h-4 text-(--accent-blue)" aria-hidden="true" />
+    <span className="text-sm font-mono text-(--color-text-2)">read_file</span>
+    <span className="text-sm text-(--color-text-muted) truncate font-mono">
+      app/agent/mode/chat.py
+    </span>
+    <span className="ml-auto text-xs text-(--color-text-muted)">124ms</span>
+    <ChevronDown className="w-3.5 h-3.5 text-(--color-text-subtle)" aria-hidden="true" />
+  </div>
+
+  {/* Output — code block on slightly inset surface */}
+  <pre className="px-3 py-2 bg-(--color-tint-mint) text-sm font-mono text-(--color-text) overflow-x-auto">
+    <code>{toolOutput}</code>
+  </pre>
+</div>
+```
+
+The output uses `--color-tint-mint` (very-low-alpha mint) as a subtle "this came back successfully" wash — *only* when the call returned `success`. Errors use `--accent-red` at 8% alpha; pending (still executing) uses `--color-tint-orange`.
+
+---
+
+## Queue banner
+
+When messages are enqueued behind a streaming response, a small banner appears above the input bar.
+
+```tsx
+<div
+  className="flex items-center gap-2 px-3 py-1.5
+             bg-(--accent-orange-soft) text-(--accent-orange-text)
+             rounded-full text-sm font-medium
+             border border-(--accent-orange)/30"
+  role="status"
+  aria-live="polite"
+>
+  <span className="w-1.5 h-1.5 rounded-full bg-(--accent-orange)" aria-hidden="true" />
+  <span>+1 message · enqueued</span>
+  <button className="ml-2 text-(--accent-orange-text)/70 hover:text-(--accent-orange-text)">
+    <X className="w-3 h-3" />
+  </button>
+</div>
+```
+
+Orange (consultant chip) is reused here because "enqueued" is conceptually a *consultation* signal — "this will be considered next, not now". The chip-soft / chip-edge / chip-text triad scales to any small status pill.
 
 ---
 
@@ -560,57 +800,111 @@ For Figma, Storybook, or other design tools:
 ```json
 {
   "mode": {
-    "dark": {
-      "color": {
-        "bg": "#0A0A0B",
-        "surface": "#111113",
-        "surface-2": "#18181B",
-        "surface-3": "#1F1F23",
-        "border": "#27272A",
-        "border-strong": "#3F3F46",
-        "text": "#FAFAFA",
-        "text-2": "#A1A1AA",
-        "text-muted": "#71717A",
-        "text-subtle": "#52525B",
-        "accent": "#E4E4E7",
-        "accent-hover": "#F4F4F5",
-        "success": "#4ADE80",
-        "warning": "#FBBF24",
-        "error": "#F87171",
-        "info": "#93C5FD"
-      },
-      "gradient-accent": "linear-gradient(180deg, #FAFAFA 0%, #D4D4D8 100%)",
-      "focus-ring": "#E4E4E7",
-      "shadow-depth": "none"
-    },
     "light": {
       "color": {
-        "bg": "#FAFAFA",
-        "surface": "#FFFFFF",
-        "surface-2": "#F4F4F5",
-        "surface-3": "#E4E4E7",
-        "border": "#E4E4E7",
-        "border-strong": "#D4D4D8",
-        "text": "#09090B",
-        "text-2": "#52525B",
-        "text-muted": "#71717A",
-        "text-subtle": "#A1A1AA",
-        "accent": "#27272A",
-        "accent-hover": "#18181B",
-        "success": "#16A34A",
-        "warning": "#D97706",
-        "error": "#DC2626",
-        "info": "#2563EB"
+        "bg-page": "#FAF6EC",
+        "bg-sidebar": "#F5EFDD",
+        "bg-card": "#FFFBF1",
+        "bg-input": "#FAF6EC",
+        "bg-key": "#F0E9D4",
+        "bg-send": "#2D241B",
+        "surface": "#FFFDF7",
+        "surface-2": "#F5EBD8",
+        "border-soft": "#E8DFC6",
+        "border-card": "#E0D5B7",
+        "border": "#D7C7AA",
+        "border-strong": "#A89880",
+        "text": "#1A1714",
+        "text-2": "#5F5143",
+        "text-muted": "#7A6B58",
+        "text-subtle": "#A89880",
+        "text-on-accent": "#FFFDF7",
+        "accent": "#3F3429",
+        "accent-blue": "#5AA8E2",
+        "accent-blue-soft": "#DCEEFB",
+        "accent-blue-text": "#2D6FA8",
+        "accent-green": "#3DA66A",
+        "accent-green-soft": "#E2F2E5",
+        "accent-green-text": "#2D7A4F",
+        "accent-orange": "#F59E3B",
+        "accent-orange-soft": "#FFF1D8",
+        "accent-orange-text": "#C26A1E",
+        "accent-pink": "#E63D7A",
+        "accent-pink-soft": "#FBE0EB",
+        "accent-purple": "#7C5BCF",
+        "accent-purple-soft": "#E8DEF8",
+        "accent-red": "#C8333E",
+        "marker-blue": "#0284C7",
+        "marker-mint": "#16A34A",
+        "marker-orange": "#FA8030",
+        "marker-pink": "#DB2777",
+        "marker-yellow": "#B77900",
+        "violet": "#7C3AED",
+        "success": "#3DA66A",
+        "warning": "#F59E3B",
+        "error": "#B91C1C",
+        "info": "#5AA8E2",
+        "overlay": "#1A171466"
       },
-      "gradient-accent": "linear-gradient(180deg, #3F3F46 0%, #18181B 100%)",
-      "focus-ring": "#18181B",
-      "shadow-depth": "0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.04)"
+      "focus-ring": "#3F3429",
+      "shadow-depth": "0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.05)"
+    },
+    "dark": {
+      "color": {
+        "bg-page": "#15110D",
+        "bg-sidebar": "#1C1813",
+        "bg-card": "#1C1813",
+        "bg-input": "#1C1813",
+        "bg-key": "#2A2219",
+        "bg-send": "#F5EBD8",
+        "surface": "#221C16",
+        "surface-2": "#2A2219",
+        "border-soft": "#2C231A",
+        "border-card": "#3A2F23",
+        "border": "#3A2F23",
+        "border-strong": "#5C4B36",
+        "text": "#F5EBD8",
+        "text-2": "#C5B59A",
+        "text-muted": "#9C8A72",
+        "text-subtle": "#7A6B58",
+        "text-on-accent": "#15110D",
+        "accent": "#F5EBD8",
+        "accent-blue": "#7CC2F0",
+        "accent-blue-soft": "#1E3A52",
+        "accent-blue-text": "#9DD0F5",
+        "accent-green": "#5DC487",
+        "accent-green-soft": "#1F3A2A",
+        "accent-green-text": "#92E0B0",
+        "accent-orange": "#FDB75D",
+        "accent-orange-soft": "#3D2D14",
+        "accent-orange-text": "#FCC780",
+        "accent-pink": "#F472B6",
+        "accent-pink-soft": "#3D1F2D",
+        "accent-purple": "#A78BFA",
+        "accent-purple-soft": "#2D2440",
+        "accent-red": "#F87171",
+        "marker-blue": "#38BDF8",
+        "marker-mint": "#4ADE80",
+        "marker-orange": "#FCC352",
+        "marker-pink": "#F472B6",
+        "marker-yellow": "#FBBF24",
+        "violet": "#A78BFA",
+        "success": "#5DC487",
+        "warning": "#FDB75D",
+        "error": "#F87171",
+        "info": "#7CC2F0",
+        "overlay": "#00000099"
+      },
+      "focus-ring": "#F5EBD8",
+      "shadow-depth": "0 1px 2px rgba(0,0,0,0.3), 0 2px 8px rgba(0,0,0,0.25)"
     }
   },
   "typography": {
-    "font-sans": "'Geist Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "font-sans": "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     "font-mono": "'JetBrains Mono', ui-monospace, 'SF Mono', 'Courier New', monospace",
+    "font-hand": "'Caveat', 'Bradley Hand', cursive",
     "size": {
+      "hand": "44px",
       "display": "32px",
       "h1": "28px",
       "h2": "24px",
@@ -625,6 +919,14 @@ For Figma, Storybook, or other design tools:
       "semibold": 600,
       "bold": 700
     }
+  },
+  "radius": {
+    "xs": "6px",
+    "sm": "8px",
+    "md": "10px",
+    "lg": "14px",
+    "2xl": "24px",
+    "pill": "999px"
   },
   "spacing": {
     "base": "4px",
@@ -659,16 +961,18 @@ For Figma, Storybook, or other design tools:
 
 ## Pre-ship checklist
 
-- [ ] Tokens used (`bg-*`, `text-*`, `border-*`) — no raw hex values
+- [ ] Tokens used (`--bg-*`, `--color-*`, `--accent-*`, `--fg-*`) — no raw hex values
 - [ ] Both modes verified (toggle between light/dark — nothing should look broken)
-- [ ] Typography uses Geist Variable; code uses JetBrains Mono
-- [ ] Spacing aligns to 4px base
+- [ ] Body uses Inter; code uses JetBrains Mono; Caveat is opt-in only on hand callouts
+- [ ] Spacing aligns to 4px base; radius uses `--radius-*`
 - [ ] Focus ring visible on `:focus-visible` (tab through the UI to verify)
 - [ ] Contrast ≥ 4.5:1 for body text (Lighthouse / WebAIM)
 - [ ] Icons from lucide-react, sized to the [imagery.md](./imagery.md#sizing) scale
 - [ ] Status colors paired with icon or label (never color alone)
+- [ ] Agent chips use the correct `--accent-{role}-*` triad — soft fill, edge dot, text
+- [ ] Brand pigment (Octobot gold/orange) only on mascot and lockups, never on UI chrome
 - [ ] Motion uses tokens from [motion.md](./motion.md) — no magic ms values
-- [ ] Font-weight transitions on interactive elements only
+- [ ] Font-weight transitions on interactive elements only (not on Caveat)
 - [ ] `prefers-reduced-motion` tested
 - [ ] Keyboard navigation works end-to-end (no traps, logical tab order)
 - [ ] Touch targets ≥ 44×44 on mobile

--- a/documents/styling-specs/colors.md
+++ b/documents/styling-specs/colors.md
@@ -1,133 +1,194 @@
 ---
 title: Color Palette
-description: Octobot Agent palette, semantic colors, syntax highlighting, accessibility compliance
+description: Paper-warm palette, agent-chip identity, semantic tokens, marker chart palette, accessibility compliance
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # Color Palette
 
 ## Overview
 
-OpenAgentd uses an **Octobot Agent** palette: warm mascot pigments for brand identity, paired with restrained neutral UI surfaces for daily product work. Brand pigment is earned, never decorative: saturated color appears in identity, primary moments, and meaningful agent state.
+OpenAgentd is rendered on **warm paper**: a cream `#FAF6EC` page tone in light mode, deep ink `#15110D` in dark. Surfaces, borders, and text all sit on a warm-neutral axis — slightly chromatic, never sterile gray. On top of that quiet base, **agent-chip pastels** (mint / blue / orange / pink) carry agent-role identity, and the **Octobot brand pigments** (Agent Gold, Loop Orange, Kernel Brown) appear in the mascot and brand surfaces.
 
-**Core principle**: color is a communication channel, not a surface treatment. The product UI stays neutral by default; gold/orange is reserved for the octobot brand, active agent affordances, and important calls to action.
+**Core principle**: color is communication. Surfaces stay warm-neutral so prose and code can dominate; saturated color is reserved for agent identity, state signals, and meaningful action.
 
 ---
 
-## Accent philosophy
+## Three palettes, three jobs
 
-The UI accent remains a high-contrast neutral in dense product surfaces, while brand assets use the warm octobot palette.
+| Palette | Job | Where it appears |
+|---|---|---|
+| **Paper neutrals** | The page itself — surfaces, borders, body text | Sidebar, message canvas, input bar, every chrome surface |
+| **Agent chips** | Identifies which agent is talking or selected | Topbar agent toggles, chip badges next to messages |
+| **Octobot brand** | Brand identity — mascot, lockups, hero moments | Logo, splash, marketing, app icon |
 
-- **Dark mode** → accent is `#E4E4E7` (zinc-200). It is the brightest non-text neutral.
-- **Light mode** → accent is `#27272A` (zinc-800). It is the darkest non-text neutral.
+The three palettes do **not** interchange. Brand gold is never used as a chip color. A chip color is never used for body text. Paper neutrals are never used as a chart color.
 
-The mental model is: neutral UI for sustained work, warm brand pigment for identity and agent energy.
+---
 
-### Brand palette
+## Paper neutrals — surfaces, borders, text
+
+The foundation tokens. Every chrome surface, every divider, every line of body text resolves to one of these.
+
+### Surface & background
+
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--bg-page` | `#FAF6EC` | `#15110D` | Page background, message canvas |
+| `--bg-sidebar` | `#F5EFDD` | `#1C1813` | Sidebar background |
+| `--bg-card` | `#FFFBF1` | `#1C1813` | Cards, popovers, dropdowns |
+| `--bg-input` | `#FAF6EC` | `#1C1813` | Text input backgrounds |
+| `--bg-key` | `#F0E9D4` | `#2A2219` | Keyboard cap surfaces, raised pill backgrounds |
+| `--bg-send` | `#2D241B` | `#F5EBD8` | Primary CTA surface (inverted vs page) |
+| `--color-surface` | `#FFFDF7` | `#221C16` | Generic elevated surface |
+| `--color-surface-2` | `#F5EBD8` | `#2A2219` | Generic raised surface |
+| `--color-bg-elevated` | `#FFFDF7` | `#1C1813` | Hover surface for elevated content |
+
+### Borders
+
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--border-soft` | `#E8DFC6` | `#2C231A` | Subtle dividers |
+| `--border-card` | `#E0D5B7` | `#3A2F23` | Card and pill borders |
+| `--color-border-subtle` | `#E8DCC2` | `#2C231A` | Decorative dividers |
+| `--color-border` | `#D7C7AA` | `#3A2F23` | Default borders |
+| `--color-border-strong` | `#A89880` | `#5C4B36` | Section breaks, prominent borders |
+
+### Text & foreground
+
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--color-text` | `#1A1714` | `#F5EBD8` | Primary text, headings |
+| `--color-text-2` | `#5F5143` | `#C5B59A` | Secondary text |
+| `--color-text-muted` | `#7A6B58` | `#9C8A72` | Hints, placeholders, timestamps |
+| `--color-text-subtle` | `#A89880` | `#7A6B58` | Disabled text, faint metadata |
+| `--color-text-on-accent` | `#FFFDF7` | `#15110D` | Text on filled accent surfaces |
+| `--fg-primary` | `#1F1A14` | `#F5EBD8` | Strong foreground (mascot lines, hand text) |
+| `--fg-secondary` | `#6B6253` | `#C5B59A` | Secondary foreground |
+| `--fg-muted` | `#9A9080` | `#9C8A72` | Muted iconography |
+
+### Color accent (UI)
+
+The non-chip accent is a high-contrast warm neutral, used for primary affordances when no agent identity is involved.
+
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--color-accent` | `#3F3429` | `#F5EBD8` | Primary CTA, focus ring, active highlights |
+| `--color-overlay` | `#1A171466` (40%) | `#00000099` (60%) | Modal backdrops |
+
+---
+
+## Agent chip palette
+
+Each agent role gets a soft pastel chip with a saturated edge color and a darker text color for readability. Chips are used in topbar toggles, message author tags, and queue indicators.
+
+| Role | Soft (fill) | Edge (icon, dot) | Text | Pencil token prefix |
+|---|---|---|---|---|
+| `openagentd` (router) | `#E2F2E5` / `#1F3A2A` | `#3DA66A` / `#5DC487` | `#2D7A4F` / `#92E0B0` | `accent-green-*` |
+| `executor` | `#DCEEFB` / `#1E3A52` | `#5AA8E2` / `#7CC2F0` | `#2D6FA8` / `#9DD0F5` | `accent-blue-*` |
+| `consultant` | `#FFF1D8` / `#3D2D14` | `#F59E3B` / `#FDB75D` | `#C26A1E` / `#FCC780` | `accent-orange-*` |
+| `explorer` | `#FBE0EB` / `#3D1F2D` | `#E63D7A` / `#F472B6` | — (use `--color-text` on soft) | `accent-pink-*` |
+| Reserved (memory, scheduler) | `#E8DEF8` / `#2D2440` | `#7C5BCF` / `#A78BFA` | — | `accent-purple-*` |
+| Error / destructive | — | `#C8333E` / `#F87171` | — | `accent-red` |
+
+**Format** for each token: `light-mode-value` / `dark-mode-value`.
+
+**Usage rules:**
+
+- **Soft fill + edge dot + text label** is the canonical chip composition. Color alone never identifies an agent.
+- The same chip color set is used in the topbar role toggle (`OpenagentdChip`, `ExecutorChip`, `ConsultantChip`, `ExplorerChip`) and in the message author badge — same color, same role, no exceptions.
+- Don't use chip colors as page accents, dividers, or chart series. They're identity-reserved.
+- A chip's *edge* color (e.g. `#3DA66A`) is the only place that pigment appears outside the chip — use it for the leading dot in queue banners or status pills tied to that agent.
+
+### CSS implementation
+
+```css
+:root.light {
+  --accent-blue:        #5AA8E2;
+  --accent-blue-soft:   #DCEEFB;
+  --accent-blue-text:   #2D6FA8;
+
+  --accent-green:       #3DA66A;
+  --accent-green-soft:  #E2F2E5;
+  --accent-green-text:  #2D7A4F;
+
+  --accent-orange:      #F59E3B;
+  --accent-orange-soft: #FFF1D8;
+  --accent-orange-text: #C26A1E;
+
+  --accent-pink:        #E63D7A;
+  --accent-pink-soft:   #FBE0EB;
+
+  --accent-purple:      #7C5BCF;
+  --accent-purple-soft: #E8DEF8;
+
+  --accent-red:         #C8333E;
+}
+
+:root.dark {
+  --accent-blue:        #7CC2F0;
+  --accent-blue-soft:   #1E3A52;
+  --accent-blue-text:   #9DD0F5;
+
+  --accent-green:       #5DC487;
+  --accent-green-soft:  #1F3A2A;
+  --accent-green-text:  #92E0B0;
+
+  --accent-orange:      #FDB75D;
+  --accent-orange-soft: #3D2D14;
+  --accent-orange-text: #FCC780;
+
+  --accent-pink:        #F472B6;
+  --accent-pink-soft:   #3D1F2D;
+
+  --accent-purple:      #A78BFA;
+  --accent-purple-soft: #2D2440;
+
+  --accent-red:         #F87171;
+}
+```
+
+---
+
+## Octobot brand pigments
+
+Reserved for brand assets — the mascot, lockups, app icon, splash, hero marketing surfaces. Never used in product chrome.
 
 | Name | Hex | Usage |
-|------|-----|-------|
+|---|---|---|
 | Agent Gold | `#FCC352` | Primary brand surface, badge fills, brand emphasis |
 | Loop Orange | `#FA8030` | Energy accent, mascot details, selected brand emphasis |
 | Kernel Brown | `#5F2511` | Mascot linework, text on gold, warm dark contrast |
 | Shell White | `#FBF8F7` | Light brand surfaces and highlights |
 | Console Ink | `#17120F` | Dark brand surfaces |
 
----
-
-## Token tables (both modes, side-by-side)
-
-### Foundation — surfaces, borders, text
-
-| Token | Dark mode | Light mode | Usage |
-|-------|-----------|------------|-------|
-| `--color-bg` | `#0A0A0B` | `#FAFAFA` | Page background |
-| `--color-surface` | `#111113` | `#FFFFFF` | Panels, popovers, dropdowns |
-| `--color-surface-2` | `#18181B` | `#F4F4F5` | Cards, input backgrounds |
-| `--color-surface-3` | `#1F1F23` | `#E4E4E7` | Elevated/active surfaces |
-| `--color-border` | `#27272A` | `#E4E4E7` | Subtle borders, dividers |
-| `--color-border-strong` | `#3F3F46` | `#D4D4D8` | Prominent borders, separators |
-| `--color-text` | `#FAFAFA` | `#09090B` | Primary text, headings |
-| `--color-text-2` | `#A1A1AA` | `#52525B` | Secondary text, labels |
-| `--color-text-muted` | `#71717A` | `#71717A` | Tertiary text, hints, placeholders |
-| `--color-text-subtle` | `#52525B` | `#A1A1AA` | Disabled text, faint metadata |
-
-### Accent — primary action surface
-
-| Token | Dark mode | Light mode | Usage |
-|-------|-----------|------------|-------|
-| `--color-accent` | `#E4E4E7` | `#27272A` | Primary CTA, focus ring, active highlights |
-| `--color-accent-hover` | `#F4F4F5` | `#18181B` | Hover state on accent |
-| `--color-accent-subtle` | `rgba(228, 228, 231, 0.10)` | `rgba(39, 39, 42, 0.06)` | Subtle tinted backgrounds (selected rows, hover fills) |
-| `--color-accent-dim` | `rgba(228, 228, 231, 0.05)` | `rgba(39, 39, 42, 0.03)` | Very subtle tint (section backgrounds) |
-| `--gradient-accent` | `linear-gradient(180deg, #FAFAFA 0%, #D4D4D8 100%)` | `linear-gradient(180deg, #3F3F46 0%, #18181B 100%)` | Primary CTA only — reads as physical metal, not flat gray |
-
-### Semantic — state colors (muted set)
-
-State colors are the *only* place saturated pigment appears. They shift brightness between modes to maintain WCAG AA on each background.
-
-| Token | Dark mode | Light mode | Usage |
-|-------|-----------|------------|-------|
-| `--color-success` | `#4ADE80` | `#16A34A` | Confirmations, running agents, validation |
-| `--color-warning` | `#FBBF24` | `#D97706` | Alerts, pending states, cautions |
-| `--color-error` | `#F87171` | `#DC2626` | Errors, failures, destructive actions |
-| `--color-info` | `#93C5FD` | `#2563EB` | Information, hints, secondary messaging |
-
-### Syntax highlighting — code
-
-| Token | Dark mode | Light mode | Element |
-|-------|-----------|------------|---------|
-| `--color-syn-comment` | `#71717A` | `#71717A` | Comments |
-| `--color-syn-keyword` | `#C4B5FD` | `#7C3AED` | Keywords, reserved words |
-| `--color-syn-function` | `#93C5FD` | `#2563EB` | Function/method names |
-| `--color-syn-variable` | `#F87171` | `#DC2626` | Variable names |
-| `--color-syn-string` | `#86EFAC` | `#16A34A` | String literals |
-| `--color-syn-number` | `#FBBF24` | `#D97706` | Numeric literals |
-| `--color-syn-type` | `#FCD34D` | `#B45309` | Type annotations |
-| `--color-syn-operator` | `#A1A1AA` | `#52525B` | Operators, punctuation |
-
-### Depth & focus
-
-| Token | Dark mode | Light mode | Usage |
-|-------|-----------|------------|-------|
-| `--focus-ring` | `#E4E4E7` | `#18181B` | 2px ring on `:focus-visible`, 2px offset |
-| `--shadow-depth` | `none` | `0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.04)` | Card elevation |
-
-**Why shadows only in light mode**: on dark, brightness steps between surfaces create perceived depth — shadows add noise. On light, surfaces are all near-white and brightness can't create depth, so shadow does the work.
+The product UI's `--bg-page` (`#FAF6EC`) sits intentionally close to Shell White (`#FBF8F7`) — they're meant to feel continuous when the mascot lands on a product page.
 
 ---
 
-## Chart colors (data visualization)
+## Semantic state colors
 
-Charts may use saturated color. Order matters — series 1 always uses the accent position.
+State colors are **event signals**, not design accents. They overlap deliberately with the agent chip palette: error reuses red, info reuses the blue chip edge, success reuses the green chip edge, warning reuses the orange chip edge. This keeps the system small.
 
-| Index | Dark mode | Light mode |
-|-------|-----------|------------|
-| Chart 1 | `#93C5FD` (blue) | `#2563EB` |
-| Chart 2 | `#86EFAC` (green) | `#16A34A` |
-| Chart 3 | `#FCD34D` (amber) | `#D97706` |
-| Chart 4 | `#C4B5FD` (violet) | `#7C3AED` |
-| Chart 5 | `#F9A8D4` (pink) | `#DB2777` |
-
-**Anti-pattern**: never use brand gold/orange as chart colors unless the data explicitly represents OpenAgentd itself. The brand palette is identity-reserved; charts need their own spectrum.
-
----
-
-## Color as information
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--color-success` | `#3DA66A` (= `accent-green`) | `#5DC487` | Confirmations, running agents, validation |
+| `--color-warning` | `#F59E3B` (= `accent-orange`) | `#FDB75D` | Alerts, pending states, cautions |
+| `--color-error` | `#B91C1C` | `#F87171` | Errors, failures, destructive actions |
+| `--color-info` | `#5AA8E2` (= `accent-blue`) | `#7CC2F0` | Information, hints, secondary messaging |
 
 ### When to use state colors
 
-State colors are **event signals**, not design accents. Use them when something the user needs to notice is happening.
-
 | Signal | Color | Example |
-|--------|-------|---------|
+|---|---|---|
 | Agent is running / streaming | `--color-success` | Pulse dot next to session title |
 | Tool call is pending | `--color-warning` | Dashed border on queued row |
 | Operation failed | `--color-error` | Error banner, destructive button |
 | Informational hint | `--color-info` | First-run tooltip |
 
-**Never use state colors for**:
+### Never use state colors for
+
 - Static branding (logo, heading accents)
 - Decoration (section backgrounds, dividers)
 - Hierarchy (headers are not "info blue")
@@ -141,53 +202,110 @@ Every semantic color pairs with an icon, text label, or both.
 - ❌ Green dot (color only)
 - ✅ Green dot + "Running" label
 
-Accessibility, color-blind users, and grayscale screenshots all require this discipline.
+---
+
+## Marker palette — charts and tints
+
+For data visualization. Marker pigments are slightly more saturated than chip pigments because they need to read against a busy chart background. There is also a low-alpha tint variant for area fills.
+
+| Token | Light mode | Dark mode |
+|---|---|---|
+| `--color-marker-blue` | `#0284C7` | `#38BDF8` |
+| `--color-marker-mint` | `#16A34A` | `#4ADE80` |
+| `--color-marker-orange` | `#FA8030` | `#FCC352` |
+| `--color-marker-pink` | `#DB2777` | `#F472B6` |
+| `--color-marker-yellow` | `#B77900` | `#FBBF24` |
+| `--color-violet` | `#7C3AED` | `#A78BFA` |
+| `--color-tint-mint` | `#16A34A18` | `#4ADE8026` |
+| `--color-tint-orange` | `#FA803018` | `#FCC35226` |
+| `--color-tint-violet` | `#7C3AED18` | `#A78BFA26` |
+
+**Series 1 = blue, Series 2 = mint, Series 3 = orange, Series 4 = pink, Series 5 = yellow.** Never use brand gold/orange or chip colors as chart series unless the series literally represents OpenAgentd or a specific named agent.
+
+---
+
+## Syntax highlighting — code
+
+Syntax tokens use the marker palette plus a softened comment color so prose and code feel continuous.
+
+| Token | Light mode | Dark mode | Element |
+|---|---|---|---|
+| `--color-syn-comment` | `#7A6B58` | `#9C8A72` | Comments — `--color-text-muted` |
+| `--color-syn-keyword` | `#7C3AED` | `#A78BFA` | Keywords, reserved words |
+| `--color-syn-function` | `#0284C7` | `#38BDF8` | Function/method names |
+| `--color-syn-variable` | `#B91C1C` | `#F87171` | Variable names |
+| `--color-syn-string` | `#16A34A` | `#4ADE80` | String literals |
+| `--color-syn-number` | `#B77900` | `#FBBF24` | Numeric literals |
+| `--color-syn-type` | `#C26A1E` | `#FCC780` | Type annotations |
+| `--color-syn-operator` | `#5F5143` | `#C5B59A` | Operators, punctuation — `--color-text-2` |
+
+---
+
+## Depth & focus
+
+| Token | Light mode | Dark mode | Usage |
+|---|---|---|---|
+| `--focus-ring` | `--color-accent` (`#3F3429`) | `--color-accent` (`#F5EBD8`) | 2px ring on `:focus-visible`, 2px offset |
+| `--shadow-depth` | `0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.05)` | `0 1px 2px rgba(0,0,0,0.3), 0 2px 8px rgba(0,0,0,0.25)` | Card elevation |
+
+**Why both modes get a shadow.** Unlike a cool dark theme where brightness steps create depth, the warm dark mode (`#15110D` page, `#1C1813` card) has very compressed surface differences. A subtle outer shadow restores hierarchy on dark just as it does on light. Keep them small — paper isn't supposed to feel glossy.
+
+---
+
+## Radius scale
+
+The paper aesthetic is generous with radius. Cards, pills, and the input bar all sit at `radius-lg` or larger.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--radius-xs` | 6px | Tiny chips, code-inline backgrounds |
+| `--radius-sm` | 8px | Small components, table cells |
+| `--radius-md` | 10px | Standard buttons, inputs |
+| `--radius-lg` | 14px | Cards, popovers, message bubbles |
+| `--radius-2xl` | 24px | Input bar, hero CTAs |
+| `--radius-pill` | 999px | Chip pills, agent role toggles |
 
 ---
 
 ## Gradient usage
 
-The `--gradient-accent` token is the **only** gradient in the system.
+The paper aesthetic intentionally avoids gradients in chrome. The only sanctioned gradient is on the **mascot itself** (the source PNG already contains warm gradient lighting). Do not apply gradients to:
 
-**Use it for**:
-- Primary CTA buttons (one per screen)
-- Hero surfaces on marketing pages
-- Brand mark variant (reserved)
+- Buttons or CTAs
+- Card backgrounds
+- Text
+- Headings
+- Any UI surface
 
-**Do not use it for**:
-- Section backgrounds
-- Card surfaces
-- Headings or text (gradient text breaks on low-DPI displays)
-- Anything repeated more than once per view
-
-A single gradient button on a flat screen reads as "metal, the primary action". Two gradient buttons read as "two primary actions", which is a design bug.
+If a surface needs differentiation from `--bg-page`, use `--bg-card` or `--color-surface` — flat warm neutrals, not gradients.
 
 ---
 
-## Brand Pigment On Light Backgrounds
+## Brand pigment on light backgrounds
 
-Warm brand pigment can lose contrast on light surfaces if used as text. Use Kernel Brown for text on Agent Gold, and use charcoal text on Shell White surfaces.
+When brand pigment lands on the warm page (`#FAF6EC`), use these contrast pairings:
 
-**Rules**:
-- Use `#5F2511` for text on `#FCC352` pills and badges.
-- Use `#27140C` or `#09090B` for large wordmarks on Shell White.
-- Do not use Loop Orange for body text on light backgrounds.
-- Do not recolor the octobot paths to force contrast; choose an appropriate background instead.
+- **Agent Gold pill text** — use `#5F2511` (Kernel Brown), not pure black
+- **Wordmark on Shell White** — use `#1A1714` (`--color-text`)
+- **Loop Orange** — never as body text on light; only as accent strokes or icon fills
+- **Octobot mascot lines** — Kernel Brown is canonical; do not recolor
 
 ---
 
 ## Accessibility (WCAG 2.1 AA)
 
-All token pairs are verified against their own background:
+All token pairs verified against their own background. Spot-check ratios for the most common pairings:
 
-| Pairing | Dark mode ratio | Light mode ratio | WCAG |
-|---------|-----------------|------------------|------|
-| `text` on `bg` | 18.7:1 | 19.3:1 | AAA |
-| `text-2` on `bg` | 7.1:1 | 8.9:1 | AAA |
-| `text-muted` on `bg` | 4.6:1 | 4.7:1 | AA |
-| `accent` on `bg` | 17.8:1 | 14.1:1 | AAA |
-| `success` on `bg` | 10.4:1 | 4.5:1 | AA |
-| `error` on `bg` | 6.7:1 | 5.9:1 | AA |
+| Pairing | Light mode | Dark mode | WCAG |
+|---|---|---|---|
+| `text` on `bg-page` | 14.6:1 | 13.2:1 | AAA |
+| `text-2` on `bg-page` | 6.8:1 | 7.4:1 | AAA |
+| `text-muted` on `bg-page` | 4.7:1 | 4.6:1 | AA |
+| `accent` on `bg-page` | 11.2:1 | 13.0:1 | AAA |
+| `accent-blue-text` on `accent-blue-soft` | 5.1:1 | 8.4:1 | AA |
+| `accent-green-text` on `accent-green-soft` | 5.0:1 | 7.9:1 | AA |
+| `accent-orange-text` on `accent-orange-soft` | 4.6:1 | 7.2:1 | AA |
+| `error` on `bg-page` | 5.4:1 | 5.7:1 | AA |
 
 **Test tools**:
 - WebAIM Contrast Checker: https://webaim.org/resources/contrastchecker/
@@ -198,84 +316,147 @@ All token pairs are verified against their own background:
 
 ## CSS implementation
 
-The token layer uses class-based mode switching on the `<html>` element (`class="dark"` or `class="light"`), with a three-way UI toggle (system / light / dark) persisted to localStorage. An inline script in `index.html` sets the class before paint to prevent flash of unstyled theme.
+Tokens are emitted from a single `@theme` block. Mode is class-based on `<html>` (`class="light"` / `class="dark"`); a three-way toggle (system / light / dark) persists choice to `localStorage`. An inline script in `index.html` sets the class before paint to prevent flash of unstyled theme.
 
 ```css
-/* ── Default = dark (production) ── */
+/* ── Light mode (default) ── */
 :root,
-:root.dark {
-  --color-bg:            #0A0A0B;
-  --color-surface:       #111113;
-  --color-surface-2:     #18181B;
-  --color-surface-3:     #1F1F23;
-  --color-border:        #27272A;
-  --color-border-strong: #3F3F46;
+:root.light {
+  /* Surfaces */
+  --bg-page:        #FAF6EC;
+  --bg-sidebar:     #F5EFDD;
+  --bg-card:        #FFFBF1;
+  --bg-input:       #FAF6EC;
+  --bg-key:         #F0E9D4;
+  --bg-send:        #2D241B;
+  --color-surface:  #FFFDF7;
+  --color-surface-2:#F5EBD8;
+  --color-bg-elevated:#FFFDF7;
 
-  --color-text:          #FAFAFA;
-  --color-text-2:        #A1A1AA;
-  --color-text-muted:    #71717A;
-  --color-text-subtle:   #52525B;
+  /* Borders */
+  --border-soft:        #E8DFC6;
+  --border-card:        #E0D5B7;
+  --color-border-subtle:#E8DCC2;
+  --color-border:       #D7C7AA;
+  --color-border-strong:#A89880;
 
-  --color-accent:        #E4E4E7;
-  --color-accent-hover:  #F4F4F5;
-  --color-accent-subtle: rgba(228, 228, 231, 0.10);
-  --color-accent-dim:    rgba(228, 228, 231, 0.05);
-  --gradient-accent:     linear-gradient(180deg, #FAFAFA 0%, #D4D4D8 100%);
+  /* Text */
+  --color-text:           #1A1714;
+  --color-text-2:         #5F5143;
+  --color-text-muted:     #7A6B58;
+  --color-text-subtle:    #A89880;
+  --color-text-on-accent: #FFFDF7;
+  --fg-primary:           #1F1A14;
+  --fg-secondary:         #6B6253;
+  --fg-muted:             #9A9080;
 
-  --color-success:       #4ADE80;
-  --color-warning:       #FBBF24;
-  --color-error:         #F87171;
-  --color-info:          #93C5FD;
+  /* Accent (UI) */
+  --color-accent:  #3F3429;
+  --color-overlay: #1A171466;
 
-  --color-syn-comment:   #71717A;
-  --color-syn-keyword:   #C4B5FD;
-  --color-syn-function:  #93C5FD;
-  --color-syn-variable:  #F87171;
-  --color-syn-string:    #86EFAC;
-  --color-syn-number:    #FBBF24;
-  --color-syn-type:      #FCD34D;
-  --color-syn-operator:  #A1A1AA;
+  /* Agent chips */
+  --accent-blue:   #5AA8E2;  --accent-blue-soft:   #DCEEFB;  --accent-blue-text:   #2D6FA8;
+  --accent-green:  #3DA66A;  --accent-green-soft:  #E2F2E5;  --accent-green-text:  #2D7A4F;
+  --accent-orange: #F59E3B;  --accent-orange-soft: #FFF1D8;  --accent-orange-text: #C26A1E;
+  --accent-pink:   #E63D7A;  --accent-pink-soft:   #FBE0EB;
+  --accent-purple: #7C5BCF;  --accent-purple-soft: #E8DEF8;
+  --accent-red:    #C8333E;
 
-  --focus-ring:          #E4E4E7;
-  --shadow-depth:        none;
+  /* Markers (charts) */
+  --color-marker-blue:   #0284C7;
+  --color-marker-mint:   #16A34A;
+  --color-marker-orange: #FA8030;
+  --color-marker-pink:   #DB2777;
+  --color-marker-yellow: #B77900;
+  --color-violet:        #7C3AED;
+  --color-tint-mint:     #16A34A18;
+  --color-tint-orange:   #FA803018;
+  --color-tint-violet:   #7C3AED18;
+
+  /* Semantic */
+  --color-success: var(--accent-green);
+  --color-warning: var(--accent-orange);
+  --color-error:   #B91C1C;
+  --color-info:    var(--accent-blue);
+
+  /* Syntax */
+  --color-syn-comment:  #7A6B58;
+  --color-syn-keyword:  #7C3AED;
+  --color-syn-function: #0284C7;
+  --color-syn-variable: #B91C1C;
+  --color-syn-string:   #16A34A;
+  --color-syn-number:   #B77900;
+  --color-syn-type:     #C26A1E;
+  --color-syn-operator: #5F5143;
+
+  /* Focus + depth */
+  --focus-ring:    var(--color-accent);
+  --shadow-depth:  0 1px 2px rgba(0,0,0,0.04), 0 2px 8px rgba(0,0,0,0.05);
 }
 
-/* ── Light mode ── */
-:root.light {
-  --color-bg:            #FAFAFA;
-  --color-surface:       #FFFFFF;
-  --color-surface-2:     #F4F4F5;
-  --color-surface-3:     #E4E4E7;
-  --color-border:        #E4E4E7;
-  --color-border-strong: #D4D4D8;
+/* ── Dark mode ── */
+:root.dark {
+  --bg-page:        #15110D;
+  --bg-sidebar:     #1C1813;
+  --bg-card:        #1C1813;
+  --bg-input:       #1C1813;
+  --bg-key:         #2A2219;
+  --bg-send:        #F5EBD8;
+  --color-surface:  #221C16;
+  --color-surface-2:#2A2219;
+  --color-bg-elevated:#1C1813;
 
-  --color-text:          #09090B;
-  --color-text-2:        #52525B;
-  --color-text-muted:    #71717A;
-  --color-text-subtle:   #A1A1AA;
+  --border-soft:        #2C231A;
+  --border-card:        #3A2F23;
+  --color-border-subtle:#2C231A;
+  --color-border:       #3A2F23;
+  --color-border-strong:#5C4B36;
 
-  --color-accent:        #27272A;
-  --color-accent-hover:  #18181B;
-  --color-accent-subtle: rgba(39, 39, 42, 0.06);
-  --color-accent-dim:    rgba(39, 39, 42, 0.03);
-  --gradient-accent:     linear-gradient(180deg, #3F3F46 0%, #18181B 100%);
+  --color-text:           #F5EBD8;
+  --color-text-2:         #C5B59A;
+  --color-text-muted:     #9C8A72;
+  --color-text-subtle:    #7A6B58;
+  --color-text-on-accent: #15110D;
+  --fg-primary:           #F5EBD8;
+  --fg-secondary:         #C5B59A;
+  --fg-muted:             #9C8A72;
 
-  --color-success:       #16A34A;
-  --color-warning:       #D97706;
-  --color-error:         #DC2626;
-  --color-info:          #2563EB;
+  --color-accent:  #F5EBD8;
+  --color-overlay: #00000099;
 
-  --color-syn-comment:   #71717A;
-  --color-syn-keyword:   #7C3AED;
-  --color-syn-function:  #2563EB;
-  --color-syn-variable:  #DC2626;
-  --color-syn-string:    #16A34A;
-  --color-syn-number:    #D97706;
-  --color-syn-type:      #B45309;
-  --color-syn-operator:  #52525B;
+  --accent-blue:   #7CC2F0;  --accent-blue-soft:   #1E3A52;  --accent-blue-text:   #9DD0F5;
+  --accent-green:  #5DC487;  --accent-green-soft:  #1F3A2A;  --accent-green-text:  #92E0B0;
+  --accent-orange: #FDB75D;  --accent-orange-soft: #3D2D14;  --accent-orange-text: #FCC780;
+  --accent-pink:   #F472B6;  --accent-pink-soft:   #3D1F2D;
+  --accent-purple: #A78BFA;  --accent-purple-soft: #2D2440;
+  --accent-red:    #F87171;
 
-  --focus-ring:          #18181B;
-  --shadow-depth:        0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.04);
+  --color-marker-blue:   #38BDF8;
+  --color-marker-mint:   #4ADE80;
+  --color-marker-orange: #FCC352;
+  --color-marker-pink:   #F472B6;
+  --color-marker-yellow: #FBBF24;
+  --color-violet:        #A78BFA;
+  --color-tint-mint:     #4ADE8026;
+  --color-tint-orange:   #FCC35226;
+  --color-tint-violet:   #A78BFA26;
+
+  --color-success: var(--accent-green);
+  --color-warning: var(--accent-orange);
+  --color-error:   #F87171;
+  --color-info:    var(--accent-blue);
+
+  --color-syn-comment:  #9C8A72;
+  --color-syn-keyword:  #A78BFA;
+  --color-syn-function: #38BDF8;
+  --color-syn-variable: #F87171;
+  --color-syn-string:   #4ADE80;
+  --color-syn-number:   #FBBF24;
+  --color-syn-type:     #FCC780;
+  --color-syn-operator: #C5B59A;
+
+  --focus-ring:    var(--color-accent);
+  --shadow-depth:  0 1px 2px rgba(0,0,0,0.3), 0 2px 8px rgba(0,0,0,0.25);
 }
 ```
 
@@ -285,27 +466,30 @@ The token layer uses class-based mode switching on the `<html>` element (`class=
 
 ### Tailwind classes
 
-Tokens are exposed as Tailwind utilities via the `@theme` block (unprefixed). Use semantic names, not raw hex:
+Tokens are exposed as Tailwind utilities via `@theme`. Use semantic names, never raw hex.
 
 ```tsx
-// Primary CTA (uses the neutral UI accent in dense product surfaces)
-<button className="bg-accent text-bg hover:bg-accent-hover">
-  Start session
+// Page surface
+<main className="bg-(--bg-page) text-(--color-text)">…</main>
+
+// Primary CTA — paper inverted (warm dark surface, cream text)
+<button className="bg-(--bg-send) text-(--color-text-on-accent) hover:brightness-110">
+  Send
 </button>
 
-// Secondary (neutral surface)
-<button className="bg-surface-2 text-text hover:bg-surface-3 border border-border">
-  Cancel
-</button>
+// Agent chip — green = openagentd
+<span className="bg-(--accent-green-soft) text-(--accent-green-text) px-2.5 py-1 rounded-full text-sm font-medium">
+  openagentd
+</span>
 
 // Destructive
-<button className="bg-error text-bg hover:bg-error/90">
+<button className="text-(--color-error) hover:bg-(--accent-red)/10">
   Delete session
 </button>
 
 // Subtle state indicator
-<div className="bg-error-subtle text-error border border-error/20">
-  Agent failed to respond
+<div className="bg-(--accent-orange-soft) text-(--accent-orange-text) border border-(--accent-orange)/30">
+  Tool call queued
 </div>
 ```
 
@@ -314,32 +498,32 @@ Tokens are exposed as Tailwind utilities via the `@theme` block (unprefixed). Us
 ```css
 .agent-running {
   border-color: var(--color-success);
-  background: var(--color-accent-dim);
+  background: var(--accent-green-soft);
 }
 
 .card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-depth);
 }
 
 .cta-primary {
-  background: var(--gradient-accent);
-  color: var(--color-bg);
+  background: var(--bg-send);
+  color: var(--color-text-on-accent);
 }
 ```
 
 ---
 
-## Migration from Gruvbox palette
-
-The previous palette (Gruvbox-inspired, warm gold `#fabd2f` on sepia neutrals) is retired. The rebrand moves OpenAgentd from a **terminal-hobbyist** aesthetic to a **precision-instrument** aesthetic.
+## Migration notes
 
 | Previous | Current | Reason |
-|----------|---------|--------|
-| Generic warm accent | Octobot brand palette + neutral UI accent | Brand color is now source-derived and reserved for identity or agent meaning. |
-| Sepia-warm neutrals (`#1d1b19`, `#ebdbb2`) | Cool zinc neutrals (`#0A0A0B`, `#FAFAFA`) | Removes retro/dotfile association. Reads as contemporary software. |
-| Dark-first, light as afterthought | Dark-first, light-equal | Light mode gets full token spec and testing, not a media-query fallback. |
-| `--color-jb-*` token naming | `--color-*` token naming | Drops project-era prefix. Names now describe function, not origin. |
+|---|---|---|
+| Cool zinc neutrals (`#0A0A0B`, `#FAFAFA`) | Warm paper neutrals (`#FAF6EC`, `#15110D`) | Matches the pencil "notebook" aesthetic. Reads as a calm working surface, not a terminal. |
+| Octobot brand pigment used as UI accent | Octobot pigment reserved for brand assets only | UI accent is now a neutral warm dark; brand pigment stays in mascot/lockup territory. |
+| Single neutral accent for all primary actions | Neutral accent **plus** four agent chips for role identity | Multi-agent product needs a way to identify which role is talking; chips solve it without polluting the chrome. |
+| `--color-jb-*` token naming | `--bg-*`, `--color-*`, `--accent-*`, `--fg-*` named by role | Names describe function (background, text, accent), not project era. |
+| Dark-first defaults | Light-first defaults (paper is the canonical surface) | The product is composed against `#FAF6EC`; dark is a 1:1 themed counterpart. |
 
-**Codebase migration**: the web app currently still uses `--color-jb-*` tokens. A follow-up PR will migrate `web/src/index.css` and all `bg-jb-*` / `text-jb-*` / `border-jb-*` class usages to the unprefixed names. This styling-specs update is intentionally doc-only.
+The web app's existing `--color-jb-*` tokens are tracked for migration in a separate task. This styling-spec rewrite is intentionally doc-only.

--- a/documents/styling-specs/colors.md
+++ b/documents/styling-specs/colors.md
@@ -39,7 +39,7 @@ The foundation tokens. Every chrome surface, every divider, every line of body t
 | `--bg-sidebar` | `#F5EFDD` | `#1C1813` | Sidebar background |
 | `--bg-card` | `#FFFBF1` | `#1C1813` | Cards, popovers, dropdowns |
 | `--bg-input` | `#FAF6EC` | `#1C1813` | Text input backgrounds |
-| `--bg-key` | `#F0E9D4` | `#2A2219` | Keyboard cap surfaces, raised pill backgrounds |
+| `--bg-key` | `#F0E9D4` | `#2A2219` | Keyboard cap surfaces, raised badge backgrounds |
 | `--bg-send` | `#2D241B` | `#F5EBD8` | Primary CTA surface (inverted vs page) |
 | `--color-surface` | `#FFFDF7` | `#221C16` | Generic elevated surface |
 | `--color-surface-2` | `#F5EBD8` | `#2A2219` | Generic raised surface |
@@ -50,7 +50,7 @@ The foundation tokens. Every chrome surface, every divider, every line of body t
 | Token | Light mode | Dark mode | Usage |
 |---|---|---|---|
 | `--border-soft` | `#E8DFC6` | `#2C231A` | Subtle dividers |
-| `--border-card` | `#E0D5B7` | `#3A2F23` | Card and pill borders |
+| `--border-card` | `#E0D5B7` | `#3A2F23` | Card and badge borders |
 | `--color-border-subtle` | `#E8DCC2` | `#2C231A` | Decorative dividers |
 | `--color-border` | `#D7C7AA` | `#3A2F23` | Default borders |
 | `--color-border-strong` | `#A89880` | `#5C4B36` | Section breaks, prominent borders |
@@ -99,7 +99,7 @@ Each agent role gets a soft pastel chip with a saturated edge color and a darker
 - **Soft fill + edge dot + text label** is the canonical chip composition. Color alone never identifies an agent.
 - The same chip color set is used in the topbar role toggle (`OpenagentdChip`, `ExecutorChip`, `ConsultantChip`, `ExplorerChip`) and in the message author badge — same color, same role, no exceptions.
 - Don't use chip colors as page accents, dividers, or chart series. They're identity-reserved.
-- A chip's *edge* color (e.g. `#3DA66A`) is the only place that pigment appears outside the chip — use it for the leading dot in queue banners or status pills tied to that agent.
+- A chip's *edge* color (e.g. `#3DA66A`) is the only place that pigment appears outside the chip — use it for the leading dot in queue banners or status badges tied to that agent.
 
 ### CSS implementation
 
@@ -254,16 +254,15 @@ Syntax tokens use the marker palette plus a softened comment color so prose and 
 
 ## Radius scale
 
-The paper aesthetic is generous with radius. Cards, pills, and the input bar all sit at `radius-lg` or larger.
+The paper aesthetic is generous with radius. Cards and the input bar sit at `radius-lg` or larger. **Full pills (`rounded-full`) are reserved for shapes whose visual job is *to be circular* — dots, avatars, progress-bar endcaps.** Agent chips, role toggles, and status badges use `--radius-md` so they read as soft-cornered tags, not pharmacy capsules.
 
 | Token | Value | Usage |
 |---|---|---|
 | `--radius-xs` | 6px | Tiny chips, code-inline backgrounds |
 | `--radius-sm` | 8px | Small components, table cells |
-| `--radius-md` | 10px | Standard buttons, inputs |
+| `--radius-md` | 10px | Standard buttons, inputs, **agent chips, role toggles, status badges** |
 | `--radius-lg` | 14px | Cards, popovers, message bubbles |
 | `--radius-2xl` | 24px | Input bar, hero CTAs |
-| `--radius-pill` | 999px | Chip pills, agent role toggles |
 
 ---
 
@@ -285,7 +284,7 @@ If a surface needs differentiation from `--bg-page`, use `--bg-card` or `--color
 
 When brand pigment lands on the warm page (`#FAF6EC`), use these contrast pairings:
 
-- **Agent Gold pill text** — use `#5F2511` (Kernel Brown), not pure black
+- **Agent Gold chip text** — use `#5F2511` (Kernel Brown), not pure black
 - **Wordmark on Shell White** — use `#1A1714` (`--color-text`)
 - **Loop Orange** — never as body text on light; only as accent strokes or icon fills
 - **Octobot mascot lines** — Kernel Brown is canonical; do not recolor
@@ -478,7 +477,7 @@ Tokens are exposed as Tailwind utilities via `@theme`. Use semantic names, never
 </button>
 
 // Agent chip — green = openagentd
-<span className="bg-(--accent-green-soft) text-(--accent-green-text) px-2.5 py-1 rounded-full text-sm font-medium">
+<span className="bg-(--accent-green-soft) text-(--accent-green-text) px-2.5 py-1 rounded-md text-sm font-medium">
   openagentd
 </span>
 

--- a/documents/styling-specs/colors.md
+++ b/documents/styling-specs/colors.md
@@ -195,12 +195,13 @@ State colors are **event signals**, not design accents. They overlap deliberatel
 
 ### Never rely on color alone
 
-Every semantic color pairs with an icon, text label, or both.
+Every semantic color pairs with an icon, a text label, or both.
 
-- ❌ Red button (color only)
-- ✅ Red button + trash icon + "Delete" text
-- ❌ Green dot (color only)
-- ✅ Green dot + "Running" label
+- A destructive button is colored red **and** carries a trash icon and a "Delete" label.
+- A running indicator is a green dot **and** the word "Running".
+- An error inline message uses error red **and** the alert glyph.
+
+Colorblind users, low-vision users, and any user glancing at the screen in full sun all rely on the redundant signal.
 
 ---
 
@@ -463,55 +464,15 @@ Tokens are emitted from a single `@theme` block. Mode is class-based on `<html>`
 
 ## Using colors in code
 
-### Tailwind classes
+Tokens are exposed as Tailwind utilities via `@theme`. Always reach for a semantic token name, never a raw hex value.
 
-Tokens are exposed as Tailwind utilities via `@theme`. Use semantic names, never raw hex.
+- Page surfaces use `--bg-page` and `--color-text`. The page never uses `--bg-card` directly — that token is for elevated surfaces inside the page.
+- The primary CTA is the *paper-inverted* recipe: `--bg-send` fill with `--color-text-on-accent` text. This is the only place the paper aesthetic flips contrast.
+- Agent chips compose three tokens at once: `--accent-{role}-soft` (fill), `--accent-{role}` (edge dot), `--accent-{role}-text` (label). Never compose them with anything else.
+- Destructive controls use `--color-error` text on a soft `--color-error-subtle` (or `--accent-red` at low alpha) wash; the rest of the chrome stays neutral.
+- State badges (queued, in-progress, info) reuse the chip soft/edge/text triad of the matching role color, but pair the color with an icon or label so the meaning never lives in pigment alone.
 
-```tsx
-// Page surface
-<main className="bg-(--bg-page) text-(--color-text)">…</main>
-
-// Primary CTA — paper inverted (warm dark surface, cream text)
-<button className="bg-(--bg-send) text-(--color-text-on-accent) hover:brightness-110">
-  Send
-</button>
-
-// Agent chip — green = openagentd
-<span className="bg-(--accent-green-soft) text-(--accent-green-text) px-2.5 py-1 rounded-md text-sm font-medium">
-  openagentd
-</span>
-
-// Destructive
-<button className="text-(--color-error) hover:bg-(--accent-red)/10">
-  Delete session
-</button>
-
-// Subtle state indicator
-<div className="bg-(--accent-orange-soft) text-(--accent-orange-text) border border-(--accent-orange)/30">
-  Tool call queued
-</div>
-```
-
-### CSS custom properties
-
-```css
-.agent-running {
-  border-color: var(--color-success);
-  background: var(--accent-green-soft);
-}
-
-.card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-card);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-depth);
-}
-
-.cta-primary {
-  background: var(--bg-send);
-  color: var(--color-text-on-accent);
-}
-```
+When writing custom CSS or component styles, reference the token via `var(--token)` rather than redeclaring the value. The token map is the single source of truth; component CSS that hard-codes hex is a bug.
 
 ---
 

--- a/documents/styling-specs/imagery.md
+++ b/documents/styling-specs/imagery.md
@@ -1,8 +1,8 @@
 ---
 title: Imagery & Graphics
-description: Icons from lucide, charts with Recharts, data visualization, patterns, and screenshots
+description: Octobot mascot, lucide icons, charts on the marker palette, agent chips, screenshots, patterns
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # Imagery & Graphics
@@ -11,16 +11,18 @@ updated: 2026-04-21
 
 ## Mascot and brand imagery
 
-OpenAgentd uses the octobot mascot from `documents/assets/brand/octobot-agentd-source.png` as the single source of truth. Do not redraw, simplify, or replace the mascot with a generic robot/octopus. Source-faithful lockups live in `documents/assets/brand/`; app-imported copies live in `web/src/assets/brand/`.
+OpenAgentd uses the Octobot mascot from `documents/assets/brand/octobot-agentd-source.png` as the single source of truth. Do not redraw, simplify, or replace the mascot with a generic robot/octopus. Source-faithful lockups live in `documents/assets/brand/`; app-imported copies live in `web/src/assets/brand/`.
 
 Use the full-color mascot for:
 
 - README and social headers
-- Empty states and onboarding moments
-- App icon and avatar-style surfaces
+- Empty states and onboarding moments — paired with a Caveat callout (`what's on your mind?`) on the empty room screen
+- App icon, sidebar logo, and avatar-style surfaces
 - Launch or release graphics
 
-Avoid using the mascot as decoration in dense product chrome. In the app UI, small repeated logo positions should use `openagentd-app-icon.png`; larger quiet empty states can use `octobot-agentd-source.png` at low opacity.
+The mascot's warm gold/orange pigments are designed for the paper page (`--bg-page` / `#FAF6EC`) — they will desaturate on cool gray surfaces. Always render against paper, Shell White, or Console Ink (see [logo.md](./logo.md#palette)).
+
+Avoid using the mascot as decoration in dense product chrome. In the app UI, small repeated logo positions should use `openagentd-app-icon.png`; larger quiet empty states can use `octobot-agentd-source.png` at full opacity (the warm paper provides enough quietness on its own — fading the mascot tends to muddy the linework).
 
 ### Library: lucide-react
 
@@ -46,6 +48,7 @@ import { Play, AlertCircle, CheckCircle } from 'lucide-react';
 |---------|-------|
 | Default | `currentColor` (inherits from text) |
 | Interactive hover | `var(--color-accent)` |
+| Agent role indicator | matching `--accent-{role}` edge color (e.g. `--accent-green` for openagentd) |
 | Status — success | `var(--color-success)` |
 | Status — warning | `var(--color-warning)` |
 | Status — error | `var(--color-error)` |
@@ -77,23 +80,24 @@ import { Play, AlertCircle, CheckCircle } from 'lucide-react';
 
 ## Patterns & textures
 
-### No decorative patterns
+### No decorative patterns, no gradients in chrome
 
-Backgrounds are **solid** or use a single allowed gradient. No grid overlays, no dot patterns, no noise textures, no parallax layers.
+Backgrounds are **solid warm neutrals**. No grid overlays, no dot patterns, no noise textures, no parallax layers. The paper aesthetic intentionally avoids gradients in UI chrome — the only gradients in the system live inside the mascot artwork itself.
 
 | Context | Treatment |
-|---------|-----------|
-| Page background | `var(--color-bg)` solid |
-| Panel / surface | `var(--color-surface)` solid |
-| Elevated card | `var(--color-surface-2)` solid + `var(--shadow-depth)` (light mode only) |
-| Accent tint | `var(--color-accent-dim)` or `var(--color-accent-subtle)` — for section differentiation, never as decoration |
-| Hero / landing only | `var(--gradient-accent)` — one surface per page |
+|---|---|
+| Page background | `var(--bg-page)` solid |
+| Panel / sidebar | `var(--bg-sidebar)` solid |
+| Card / popover | `var(--bg-card)` solid + `var(--shadow-depth)` |
+| Elevated surface | `var(--color-surface)` solid + `var(--shadow-depth)` |
+| Section tint (rare) | `var(--accent-{role}-soft)` — only for content tied to that agent role |
 
 ### Dividers & borders
 
-- **Default divider**: 1px solid `var(--color-border)`
-- **Strong divider**: 1px solid `var(--color-border-strong)` — for major section breaks
-- **Never**: gradient borders, dashed borders for decoration (dashed is reserved for *drag-target* affordances)
+- **Subtle divider**: 1px solid `var(--border-soft)` — between list rows
+- **Default divider**: 1px solid `var(--color-border)` — between sections, on cards
+- **Strong divider**: 1px solid `var(--color-border-strong)` — major section breaks
+- **Never**: gradient borders, dashed borders for decoration (dashed is reserved for *drag-target* affordances and *queued* states)
 
 ### Drag-target highlight
 
@@ -101,7 +105,7 @@ Backgrounds are **solid** or use a single allowed gradient. No grid overlays, no
 .drag-target {
   outline: 2px dashed color-mix(in srgb, var(--color-accent) 55%, transparent);
   outline-offset: 2px;
-  background: var(--color-accent-dim);
+  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
 }
 ```
 
@@ -117,20 +121,27 @@ Backgrounds are **solid** or use a single allowed gradient. No grid overlays, no
 
 ### Color palette
 
-Use chart colors from [colors.md](./colors.md#chart-colors-data-visualization). Series 1 is always the most prominent data, series 5 the least.
+Use the **marker palette** from [colors.md](./colors.md#marker-palette--charts-and-tints). Markers are slightly more saturated than agent chips because they need to read against busy chart backgrounds. Series 1 is always the most prominent data, series 5 the least.
 
 ```ts
-// Dark mode
-const chartColors = {
-  1: '#93C5FD', // blue
-  2: '#86EFAC', // green
-  3: '#FCD34D', // amber
-  4: '#C4B5FD', // violet
-  5: '#F9A8D4', // pink
-};
+// Resolve via CSS custom properties — values flip per mode automatically
+const chartColors = [
+  'var(--color-marker-blue)',   // 1
+  'var(--color-marker-mint)',   // 2
+  'var(--color-marker-orange)', // 3
+  'var(--color-marker-pink)',   // 4
+  'var(--color-marker-yellow)', // 5
+];
+
+// Area fills use the matching tint (low-alpha)
+const tintFills = [
+  'var(--color-tint-mint)',
+  'var(--color-tint-orange)',
+  'var(--color-tint-violet)',
+];
 ```
 
-**Never** use the brand gold/orange as a chart color unless the data explicitly represents OpenAgentd itself. Brand pigment is identity-reserved.
+**Never** use the Octobot brand gold/orange as a chart color unless the data explicitly represents OpenAgentd itself. **Never** use the agent chip colors as chart series — chips are role-identity-reserved, and reusing them in charts will collide perceptually with chip badges on the same screen.
 
 ### Design rules
 
@@ -158,8 +169,8 @@ const chartColors = {
   <Area
     type="monotone"
     dataKey="requests"
-    stroke="var(--chart-1)"
-    fill="var(--chart-1)"
+    stroke="var(--color-marker-blue)"
+    fill="var(--color-marker-blue)"
     fillOpacity={0.2}
   />
 </AreaChart>
@@ -169,19 +180,19 @@ const chartColors = {
 
 ## Markdown & prose
 
-The app uses a custom `.prose` class (previously `.jb-prose`) for rendered markdown.
+The app uses a custom `.prose` class for rendered markdown.
 
 | Element | Style |
-|---------|-------|
-| `h1`–`h3` | `text` color, 600–700 weight, large top margin |
-| Body | `text` color, 1.6 line-height, `max-width: 65ch` |
-| `code` (inline) | `text` color, `surface-2` background, 4px radius, mono font, 0.9em |
-| `pre code` (block) | `surface` background, `border`, scrollable overflow, mono font, syntax highlighted |
-| Links | `text` color with underline; underline thickens on hover |
+|---|---|
+| `h1`–`h3` | `--color-text`, 600–700 weight, large top margin |
+| Body | `--color-text`, 1.6 line-height, `max-width: 65ch` |
+| `code` (inline) | `--color-text` on `--bg-key`, 6px radius (`--radius-xs`), JetBrains Mono, 0.9em |
+| `pre code` (block) | `--color-surface` background, 1px `--color-border`, JetBrains Mono, syntax highlighted |
+| Links | `--color-accent` with underline at 2px offset; weight 400→500 on hover |
 | Lists | 1.5em padding, disc (ul) / decimal (ol) |
-| Blockquote | Left border 3px `border-strong`, `text-2` color, 1em padding |
-| Tables | 1px borders, `surface-2` header background |
-| `hr` | 1px `border` |
+| Blockquote | Left border 3px `--color-border-strong`, `--color-text-2`, 1em padding |
+| Tables | 1px `--color-border`, `--color-surface-2` header background |
+| `hr` | 1px `--color-border-subtle` |
 
 ---
 
@@ -189,21 +200,34 @@ The app uses a custom `.prose` class (previously `.jb-prose`) for rendered markd
 
 ### Structure
 
-1. Icon — 48px, `text-muted` color
-2. Title — Heading 3, `text`
-3. Description — Body, `text-muted`, `max-width: 40ch`
-4. Primary CTA — uses the accent
+The canonical empty state pairs the **mascot** with a **Caveat callout** — this is the "what's on your mind?" moment from the empty room screen.
+
+1. Mascot — 64–96px, `octobot-agentd-source.png`, full color
+2. Callout — Caveat (`--font-hand`), 32–44px, `--color-text`, lowercase, ends with a question mark or period
+3. (Optional) Subtle Inter description — Body, `--color-text-muted`, `max-width: 40ch`
+4. (Optional) Primary CTA only when there's a clear next action
+
+```tsx
+<div className="flex flex-col items-center justify-center py-12 gap-4">
+  <img src="/brand/octobot-agentd-source.png" alt="" className="w-20 h-20" />
+  <h2 className="font-hand text-[40px] leading-none text-(--color-text)">
+    what&apos;s on your mind?
+  </h2>
+</div>
+```
+
+For more utilitarian empty states (no mascot, no Caveat — e.g. "No memory items yet"):
 
 ```tsx
 <div className="flex flex-col items-center justify-center py-12">
-  <Inbox className="w-12 h-12 text-text-muted mb-4" aria-hidden="true" />
-  <h2 className="text-h3 font-semibold text-text mb-2">
+  <Inbox className="w-12 h-12 text-(--color-text-muted) mb-4" aria-hidden="true" />
+  <h2 className="text-h3 font-semibold text-(--color-text) mb-2">
     No sessions yet
   </h2>
-  <p className="text-text-muted text-center mb-6 max-w-[40ch]">
+  <p className="text-(--color-text-muted) text-center mb-6 max-w-[40ch]">
     Create a session to start working with agents.
   </p>
-  <button className="bg-accent text-bg px-4 py-2 rounded hover:bg-accent-hover">
+  <button className="bg-(--bg-send) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110">
     Create session
   </button>
 </div>
@@ -213,7 +237,7 @@ The app uses a custom `.prose` class (previously `.jb-prose`) for rendered markd
 
 For content that will load within a few hundred milliseconds:
 
-- Background: `var(--color-surface-2)`
+- Background: `var(--bg-key)` (warmer than `--color-surface-2`, so skeleton blocks read as "paper waiting for ink")
 - Pulse animation: opacity `0.6 ↔ 1.0` over 1400ms (honors `prefers-reduced-motion`)
 - Shape: match the final content's dimensions to prevent layout shift
 
@@ -224,8 +248,8 @@ For content that will load within a few hundred milliseconds:
 }
 
 .skeleton {
-  background: var(--color-surface-2);
-  border-radius: 4px;
+  background: var(--bg-key);
+  border-radius: var(--radius-sm);
   animation: skeleton-pulse 1400ms ease-in-out infinite;
 }
 ```
@@ -238,14 +262,17 @@ Skeletons longer than ~800ms should be replaced with progressive text (see [moti
 
 ### Mode choice
 
+Light (paper) is the canonical mode and the default everywhere unless there's a specific reason to use dark.
+
 | Context | Mode |
-|---------|------|
-| Product marketing (hero, landing, social cards) | **Dark** |
+|---|---|
+| Product marketing (hero, landing, social cards) | **Light (paper)** — the warm cream is the brand surface |
 | Documentation | **Light** |
 | API reference screenshots | **Light** |
-| README | **Dark** |
+| README | **Light** |
 | Blog posts | Match the blog's theme (usually light for long-form reading) |
-| Conference slides | **Dark** |
+| Conference slides on dark stages | **Dark** — for legibility against a dark venue |
+| "What it looks like at night" feature | **Dark** |
 
 ### Composition
 
@@ -258,4 +285,4 @@ Skeletons longer than ~800ms should be replaced with progressive text (see [moti
 
 - **1× and 2×** PNG for web
 - **SVG** when the screenshot is actually a vector mockup (rare)
-- **Full-bleed** or framed with 24px padding on a `--color-bg` background — pick one convention per surface and stick to it
+- **Full-bleed** or framed with 24px padding on a `--bg-page` background — pick one convention per surface and stick to it

--- a/documents/styling-specs/imagery.md
+++ b/documents/styling-specs/imagery.md
@@ -26,11 +26,7 @@ Avoid using the mascot as decoration in dense product chrome. In the app UI, sma
 
 ### Library: lucide-react
 
-Single icon library, no mixing. `lucide-react` ships with the web stack and provides consistent 24px-native outlined icons with 1.5–2px strokes.
-
-```tsx
-import { Play, AlertCircle, CheckCircle } from 'lucide-react';
-```
+Single icon library, no mixing. `lucide-react` ships with the web stack and provides consistent 24px-native outlined icons with 1.5–2px strokes. Don't blend in icons from another library — even tonally similar sets diverge on weight and proportion under close comparison, which makes the UI feel uneven.
 
 ### Sizing
 
@@ -61,20 +57,6 @@ import { Play, AlertCircle, CheckCircle } from 'lucide-react';
 - **Stroke width**: default (stock lucide). Don't override unless the icon looks visually too thin at a specific size.
 - **Icon + label pairing**: when an icon accompanies text, don't duplicate meaning (`<Delete />` + "Delete" is fine; `<Info />` + "Info" is redundant — use a visible text label or an icon-only button with `aria-label`)
 - **Icon-only buttons**: require `aria-label` or a tooltip for accessibility
-
-### Example
-
-```tsx
-// Default, inherits text color
-<Play className="w-6 h-6" />
-
-// Interactive — shifts to accent on hover
-<Play className="w-6 h-6 text-text hover:text-accent transition-colors" />
-
-// Status
-<CheckCircle className="w-6 h-6 text-success" aria-label="Running" />
-<AlertCircle className="w-6 h-6 text-error" aria-label="Error" />
-```
 
 ---
 
@@ -121,27 +103,11 @@ Backgrounds are **solid warm neutrals**. No grid overlays, no dot patterns, no n
 
 ### Color palette
 
-Use the **marker palette** from [colors.md](./colors.md#marker-palette--charts-and-tints). Markers are slightly more saturated than agent chips because they need to read against busy chart backgrounds. Series 1 is always the most prominent data, series 5 the least.
+Use the **marker palette** from [colors.md](./colors.md#marker-palette--charts-and-tints). Markers are slightly more saturated than agent chips because they need to read against busy chart backgrounds. Series 1 is the most prominent data, series 5 the least.
 
-```ts
-// Resolve via CSS custom properties — values flip per mode automatically
-const chartColors = [
-  'var(--color-marker-blue)',   // 1
-  'var(--color-marker-mint)',   // 2
-  'var(--color-marker-orange)', // 3
-  'var(--color-marker-pink)',   // 4
-  'var(--color-marker-yellow)', // 5
-];
+The fixed series order is: blue, mint, orange, pink, yellow. Resolve colors through CSS custom properties (`var(--color-marker-*)`) so values flip per mode automatically. Area fills use the matching low-alpha tint tokens (`--color-tint-*`).
 
-// Area fills use the matching tint (low-alpha)
-const tintFills = [
-  'var(--color-tint-mint)',
-  'var(--color-tint-orange)',
-  'var(--color-tint-violet)',
-];
-```
-
-**Never** use the Octobot brand gold/orange as a chart color unless the data explicitly represents OpenAgentd itself. **Never** use the agent chip colors as chart series — chips are role-identity-reserved, and reusing them in charts will collide perceptually with chip badges on the same screen.
+Never use the Octobot brand gold/orange as a chart color unless the data explicitly represents OpenAgentd itself. Never use the agent chip colors as chart series — chips are role-identity-reserved, and reusing them in charts will collide perceptually with chip badges on the same screen.
 
 ### Design rules
 
@@ -152,29 +118,14 @@ const tintFills = [
 - **Accessibility**: never rely on color alone. Pair series with patterns, symbols, or direct labels.
 - **Responsive**: scale axis labels down at `< 640px`; hide secondary axes on mobile
 
-### Example (Recharts area chart)
+### Chart chrome
 
-```tsx
-<AreaChart data={data}>
-  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
-  <XAxis dataKey="time" stroke="var(--color-text-muted)" fontSize={12} />
-  <YAxis stroke="var(--color-text-muted)" fontSize={12} />
-  <Tooltip
-    contentStyle={{
-      background: 'var(--color-surface)',
-      border: '1px solid var(--color-border)',
-      borderRadius: 8,
-    }}
-  />
-  <Area
-    type="monotone"
-    dataKey="requests"
-    stroke="var(--color-marker-blue)"
-    fill="var(--color-marker-blue)"
-    fillOpacity={0.2}
-  />
-</AreaChart>
-```
+Whatever charting library renders the visualization, configure its chrome to consume the same tokens as the rest of the app:
+
+- Gridlines: `--color-border`, dashed and faint.
+- Axis labels: `--color-text-muted`, tiny text scale.
+- Tooltips: `--color-surface` fill, 1px `--color-border` outline, the small radius. Same recipe as a tiny popover.
+- Series strokes: marker tokens at full saturation; series fills use the matching tint at low alpha.
 
 ---
 
@@ -198,40 +149,16 @@ The app uses a custom `.prose` class for rendered markdown.
 
 ## Empty states
 
-### Structure
+The canonical empty state pairs the mascot with a Caveat callout — the "what's on your mind?" moment from the empty room screen. See also [applications.md § Empty states](./applications.md#empty-states-hand-drawn-pattern).
 
-The canonical empty state pairs the **mascot** with a **Caveat callout** — this is the "what's on your mind?" moment from the empty room screen.
+The composition is layered top to bottom:
 
-1. Mascot — 64–96px, `octobot-agentd-source.png`, full color
-2. Callout — Caveat (`--font-hand`), 32–44px, `--color-text`, lowercase, ends with a question mark or period
-3. (Optional) Subtle Inter description — Body, `--color-text-muted`, `max-width: 40ch`
-4. (Optional) Primary CTA only when there's a clear next action
+1. **Mascot** — `octobot-agentd-source.png`, full color, sized at the moderate hero scale (around 64–96px). Use the mascot only on full-page empty states; skip it inside narrow popovers and inline empty rows.
+2. **Callout** — Caveat at the hand size, `--color-text` (or `--color-text-subtle` for less-prominent surfaces), lowercase, ends with a question mark or period. The callout is decorative; pair it with an accessible Inter equivalent or mark it `aria-hidden`.
+3. **Optional description** — body Inter at `--color-text-muted`, capped to a comfortable measure (~40ch).
+4. **Optional primary CTA** — only when there is a clear next action.
 
-```tsx
-<div className="flex flex-col items-center justify-center py-12 gap-4">
-  <img src="/brand/octobot-agentd-source.png" alt="" className="w-20 h-20" />
-  <h2 className="font-hand text-[40px] leading-none text-(--color-text)">
-    what&apos;s on your mind?
-  </h2>
-</div>
-```
-
-For more utilitarian empty states (no mascot, no Caveat — e.g. "No memory items yet"):
-
-```tsx
-<div className="flex flex-col items-center justify-center py-12">
-  <Inbox className="w-12 h-12 text-(--color-text-muted) mb-4" aria-hidden="true" />
-  <h2 className="text-h3 font-semibold text-(--color-text) mb-2">
-    No sessions yet
-  </h2>
-  <p className="text-(--color-text-muted) text-center mb-6 max-w-[40ch]">
-    Create a session to start working with agents.
-  </p>
-  <button className="bg-(--bg-send) text-(--color-text-on-accent) px-4 py-2 rounded-md hover:brightness-110">
-    Create session
-  </button>
-</div>
-```
+For utilitarian empty states (lists with no items, search with no results), drop the mascot and the Caveat. Use a small lucide glyph at `--color-text-muted`, an h3-scale Inter heading, an explanation paragraph at `--color-text-muted`, and a single primary CTA. The voice is calmer here — "No sessions yet" is enough.
 
 ### Skeleton placeholders
 

--- a/documents/styling-specs/index.md
+++ b/documents/styling-specs/index.md
@@ -2,7 +2,7 @@
 title: OpenAgentd Styling
 description: Design-system reference for OpenAgentd brand assets, tokens, components, interaction, and motion
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # OpenAgentd Styling
@@ -15,11 +15,12 @@ Design-system reference for OpenAgentd. Brand assets, tokens, components, intera
 
 | | |
 |---|---|
-| **Palette** | Octobot Agent — warm gold/orange brand pigments on disciplined neutral UI surfaces |
-| **Type** | Geist Variable (UI/body) + JetBrains Mono (code) |
-| **Modes** | Dark-first, light-equal — both designed with equal care |
+| **Aesthetic** | Warm paper notebook — cream surfaces, hand-drawn headlines, calm utility chrome |
+| **Palette** | Octobot brand pigments on a warm `#FAF6EC` paper background; pastel agent chips for role identity |
+| **Type** | Inter (UI/body) + JetBrains Mono (code) + Caveat (handwritten headlines) |
+| **Modes** | Light-first paper, dark-equal — both rendered with equal care |
 | **Motion** | Motion is information; every animation conveys state, progress, or causality |
-| **Token prefix** | `--color-*` (codebase migration from `--color-jb-*` pending) |
+| **Token prefix** | `--color-*`, `--accent-*`, `--bg-*`, `--fg-*`, `--font-*`, `--radius-*` |
 
 ---
 
@@ -27,11 +28,19 @@ Design-system reference for OpenAgentd. Brand assets, tokens, components, intera
 
 | | |
 |---|---|
-| [Colors](./colors.md) | Octobot Agent palette, UI tokens for both modes, state colors, syntax highlighting, chart colors |
-| [Typography](./typography.md) | Geist Variable, JetBrains Mono, type scale, font-weight transitions |
+| [Colors](./colors.md) | Paper palette, agent-chip palette, semantic tokens, marker palette for charts, light/dark theme variables |
+| [Typography](./typography.md) | Inter, JetBrains Mono, Caveat hand-drawn headlines, type scale, font-weight transitions |
 | [Motion](./motion.md) | Motion tokens, spring presets, choreography patterns, reduced-motion fallbacks |
 | [Interaction](./interaction.md) | Hover / focus / active model, keyboard shortcuts, state choreography |
-| [Layout](./layout.md) | 4px grid, breakpoints, depth mechanism, accessibility |
-| [Logo](./logo.md) | Source-faithful octobot mascot, lockups, sizing, asset delivery |
-| [Imagery](./imagery.md) | Octobot mascot usage, icons (lucide), charts (Recharts), screenshots, patterns |
-| [Applications](./applications.md) | Component examples in both modes, theme toggle, design-token export |
+| [Layout](./layout.md) | 4px grid, breakpoints, radius scale, depth, accessibility |
+| [Logo](./logo.md) | Source-faithful Octobot mascot, lockups, sizing, asset delivery |
+| [Imagery](./imagery.md) | Octobot mascot usage, icons (lucide), charts, screenshots, patterns |
+| [Applications](./applications.md) | Component examples — sidebar, agent chips, input bar, tool call rows, theme toggle |
+
+---
+
+## What changed in this revision
+
+The styling system was previously specified for a cool zinc/Geist neutral aesthetic with reserved Octobot gold accents. The pencil source design has since converged on a **warm paper notebook** language — cream surfaces (`#FAF6EC`), Caveat handwritten screen headlines, Inter UI, and a four-color **agent chip palette** that gives each agent role a recognizable pastel identity (mint for `openagentd`, blue for `executor`, orange for `consultant`, pink for `explorer`).
+
+Codebase migration from previous token names (`--color-jb-*`, zinc neutrals) to the paper tokens is tracked separately.

--- a/documents/styling-specs/index.md
+++ b/documents/styling-specs/index.md
@@ -35,7 +35,7 @@ Design-system reference for OpenAgentd. Brand assets, tokens, components, intera
 | [Layout](./layout.md) | 4px grid, breakpoints, radius scale, depth, accessibility |
 | [Logo](./logo.md) | Source-faithful Octobot mascot, lockups, sizing, asset delivery |
 | [Imagery](./imagery.md) | Octobot mascot usage, icons (lucide), charts, screenshots, patterns |
-| [Applications](./applications.md) | Component examples — sidebar, agent chips, input bar, tool call rows, theme toggle |
+| [Applications](./applications.md) | Component guidelines — agent chips, sidebar, input bar, tool call rows, modals, topbar, popovers, empty states |
 
 ---
 

--- a/documents/styling-specs/interaction.md
+++ b/documents/styling-specs/interaction.md
@@ -2,7 +2,7 @@
 title: Interaction
 description: Hover, focus, active states, keyboard model, touch adaptation, and state choreography
 status: stable
-updated: 2026-04-29
+updated: 2026-05-09
 ---
 
 # Interaction
@@ -62,30 +62,24 @@ idle  →  hover  →  focus  →  active  →  loading  →  (success | error) 
 | State | Visual change | Motion token |
 |-------|---------------|--------------|
 | **Idle** | Default — border, text, and background at their resting values | — |
-| **Hover** | Font-weight 400 → 500; background → `accent-subtle`; cursor changes to `pointer` | `var(--motion-fast)` + `var(--ease-out)` |
+| **Hover** | Font-weight 400 → 500; background → `--bg-key` (or role-specific `--accent-{role}-soft` for agent-tagged controls); cursor changes to `pointer` | `var(--motion-fast)` + `var(--ease-out)` |
 | **Focus** | 2px `--focus-ring` outline with 2px offset, fades in from opacity 0 → 1 | `var(--motion-fast)` + `var(--ease-out)` |
-| **Active** | Font-weight 500 → 600; background → `accent-hover`; slight scale 1 → 0.98 (buttons only) | `var(--motion-instant)` + `var(--ease-in-out)` |
+| **Active** | Font-weight 500 → 600; background → next-step warm neutral (`--color-surface-2`); slight scale 1 → 0.98 (buttons only) | `var(--motion-instant)` + `var(--ease-in-out)` |
 | **Loading** | Label replaced with progressive text (`Thinking…`, `Saving…`); input locked; keyboard Escape cancels | — |
 | **Success** | Brief opacity pulse (0.6 → 1.0), no color flash, returns to idle | `var(--motion-base)` + `var(--ease-out)` |
 | **Error** | Label updates to error message; border → `--color-error`; no shake, no bounce | `var(--motion-fast)` + `var(--ease-out)` |
 
-### Direction reverses in light mode
+### Direction stays consistent across modes
 
-In dark mode, hover "brightens" (moves toward white). In light mode, hover "darkens" (moves toward black). The perceptual rule is the same ("hover increases contrast with the surrounding surface"), but the direction of the color change reverses.
+In light mode, hover moves to a *slightly warmer/darker* paper tone (`--bg-key` is one shade darker than `--bg-page`). In dark mode, hover moves to a *slightly lighter* warm surface (`--bg-key` is one shade lighter than `--bg-page`). The perceptual rule is the same in both — "hover separates from the surrounding surface" — and because `--bg-key` is mode-aware, a single CSS rule does both:
 
 ```css
-/* Dark mode: hover brightens */
 .button:hover {
-  background: var(--color-accent-subtle);  /* subtle neutral tint */
-}
-
-/* Light mode: hover darkens */
-:root.light .button:hover {
-  background: var(--color-accent-subtle);  /* subtle neutral tint */
+  background: var(--bg-key);
 }
 ```
 
-Because tokens are mode-aware, the same CSS rule produces the correct direction in both modes. Don't write mode-specific rules unless the *behavior* genuinely differs.
+Don't write mode-specific rules unless the *behavior* genuinely differs. Token-based rules give correct light/dark behavior automatically.
 
 ---
 
@@ -115,7 +109,7 @@ A signature of the OpenAgentd interaction language. Text shifts weight under the
 
 - **Width**: 2px
 - **Offset**: 2px (outside the element)
-- **Color**: `var(--focus-ring)` — `#E4E4E7` on dark, `#18181B` on light
+- **Color**: `var(--focus-ring)` — resolves to `var(--color-accent)` (warm dark `#3F3429` on light, cream `#F5EBD8` on dark)
 - **Radius**: matches element's `border-radius`
 - **Fade-in**: opacity 0 → 1, `var(--motion-fast)`, `var(--ease-out)`
 
@@ -168,7 +162,7 @@ function ProximityRow({ mouseY, rowY }: Props) {
   return (
     <div
       style={{
-        backgroundColor: `color-mix(in srgb, var(--color-accent-subtle) ${intensity * 100}%, transparent)`,
+        backgroundColor: `color-mix(in srgb, var(--bg-key) ${intensity * 100}%, transparent)`,
       }}
     />
   );
@@ -229,8 +223,8 @@ Every page has a "Skip to main content" link that appears on the first `Tab` pre
   top: -40px;
   left: 0;
   padding: 8px 16px;
-  background: var(--color-accent);
-  color: var(--color-bg);
+  background: var(--bg-send);
+  color: var(--color-text-on-accent);
   transition: top var(--motion-fast) var(--ease-out);
   z-index: 100;
 }
@@ -311,6 +305,8 @@ Never combine loading + disabled visually — the two states look the same but m
 | **Double-click for primary actions** | Non-standard on web. Keep single-click primary. |
 | **Hover content that isn't also reachable by focus** | Screen reader and keyboard users are locked out. |
 | **Weight shift on static text** | Only interactive elements shift weight. |
+| **Weight shift on Caveat** | Hand-drawn weights aren't perceptually distinct the way Inter weights are. |
+| **Agent chip color used outside its role** | Chip colors are role-identity-reserved — using mint anywhere that isn't the openagentd role breaks the language. |
 | **Sub-44px touch targets** | Fails touch usability guidelines. |
 | **Proximity effects on sparse lists** | Adds complexity without payoff. |
 
@@ -328,5 +324,5 @@ Before shipping an interactive component:
 - [ ] Touch target ≥ 44×44 CSS pixels
 - [ ] `prefers-reduced-motion` honored
 - [ ] No hover-only functionality
-- [ ] Hover direction reverses correctly in light mode
+- [ ] Hover uses `--bg-key` (or role-specific `--accent-{role}-soft`) — works in both modes via tokens
 - [ ] ARIA roles and labels where semantic HTML isn't sufficient

--- a/documents/styling-specs/interaction.md
+++ b/documents/styling-specs/interaction.md
@@ -130,10 +130,10 @@ A signature of the OpenAgentd interaction language. Text shifts weight under the
 
 ### Never do
 
-- ❌ `outline: none` without a replacement
-- ❌ Custom ring that fails 3:1 contrast against the element's background
-- ❌ Ring on `:focus` (shows on mouse click — produces a ring the user didn't ask for)
-- ❌ Ring that's part of the element border (breaks focus visibility for non-rectangular shapes)
+- `outline: none` without a replacement.
+- Custom ring that fails 3:1 contrast against the element's background.
+- Ring on `:focus` — that shows on mouse click and produces a ring the user didn't ask for.
+- Ring that is part of the element's border — breaks focus visibility for non-rectangular shapes.
 
 ---
 
@@ -301,12 +301,15 @@ Never combine loading + disabled visually — the two states look the same but m
 | **Hover-only buttons in tables** | Inaccessible on touch and for keyboard users. Use persistent or menu-based reveal. Exception: secondary desktop-only actions may use `md:opacity-0 md:group-hover:opacity-100` provided they are always visible (`opacity-100`) below `md`. |
 | **Focus ring removed without replacement** | Breaks keyboard accessibility entirely. |
 | **Different focus ring styles per component** | Fragments the visual language. One ring style, system-wide. |
+| **`ring-1 ring-foreground/N` (or `/10`, `/15`) on flat surfaces or floating overlays** | `--color-text` is near-black on cream `--bg-page`, so a low-alpha ring reads as a brown smudge, not separation. Use `border border-(--color-border)` for separation; reserve `ring-*` for focus and decorative chip outlines. |
+| **Drop shadow on a flat card** | The warm border alone carries the elevation. Reserve `--shadow-depth` for genuinely floating chrome (input bar, queue banner, popovers). |
 | **Custom gestures for core functions** | Undiscoverable. Use platform-standard gestures only. |
 | **Double-click for primary actions** | Non-standard on web. Keep single-click primary. |
 | **Hover content that isn't also reachable by focus** | Screen reader and keyboard users are locked out. |
 | **Weight shift on static text** | Only interactive elements shift weight. |
 | **Weight shift on Caveat** | Hand-drawn weights aren't perceptually distinct the way Inter weights are. |
 | **Agent chip color used outside its role** | Chip colors are role-identity-reserved — using mint anywhere that isn't the openagentd role breaks the language. |
+| **Native `<input type="checkbox">` for a feature flag** | Feature flags are runtime state and read as on/off; use the `Switch` primitive. Reserve checkboxes for multi-select and consent. |
 | **Sub-44px touch targets** | Fails touch usability guidelines. |
 | **Proximity effects on sparse lists** | Adds complexity without payoff. |
 

--- a/documents/styling-specs/layout.md
+++ b/documents/styling-specs/layout.md
@@ -1,8 +1,8 @@
 ---
 title: Layout & Spacing
-description: 4px grid system, breakpoints, depth mechanism, focus rings, accessibility
+description: 4px grid, breakpoints, radius scale, depth on warm paper surfaces, focus rings, accessibility
 status: stable
-updated: 2026-04-29
+updated: 2026-05-09
 ---
 
 # Layout & Spacing
@@ -86,34 +86,54 @@ All spacing is a multiple of 4px.
 
 ---
 
+## Radius scale
+
+The paper aesthetic is generous with rounding. Cards, pills, and the input bar all sit at `--radius-lg` or larger; raw rectangles are reserved for code blocks and dense table cells.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--radius-xs` | 6px | Inline code, tiny chips |
+| `--radius-sm` | 8px | Small buttons, table cells |
+| `--radius-md` | 10px | Standard inputs, secondary buttons |
+| `--radius-lg` | 14px | Cards, popovers, message bubbles, sidebar items |
+| `--radius-2xl` | 24px | Input bar, hero CTAs |
+| `--radius-pill` | 999px | Agent chip pills, role toggles, status badges |
+
+```tsx
+<div className="rounded-lg">…</div>           // 14px card
+<button className="rounded-md">Submit</button> // 10px button
+<span className="rounded-full">…</span>        // pill
+```
+
+---
+
 ## Depth mechanism
 
-Perceived depth works differently in each mode because the foundational colors are different.
+Both modes use a subtle `box-shadow` plus a `border` to create hierarchy. Unlike a cool zinc theme where brightness steps alone could carry depth, the warm paper palette compresses surface differences too tightly for brightness to do the work — `--bg-page` (`#FAF6EC`) and `--bg-card` (`#FFFBF1`) are only one shade apart by design. The shadow restores the layer separation; the border keeps the card's edge crisp.
 
-| Mode | Mechanism | Reason |
-|------|-----------|--------|
-| **Dark** | Brightness steps between `bg` → `surface` → `surface-2` → `surface-3` | Shadows are invisible on near-black. Brightness creates the layer hierarchy. |
-| **Light** | `box-shadow` via `var(--shadow-depth)` | Surfaces are all near-white, so brightness can't differentiate layers. Shadow does the work. |
+| Mode | Mechanism |
+|---|---|
+| **Light** | Warm-neutral surfaces sit close in value; `var(--shadow-depth)` adds a soft outer drop, and `var(--color-border)` defines the edge. |
+| **Dark** | Dark warm surfaces are also close in value; a slightly deeper shadow + a warm-toned border do the same job. |
 
 ```css
 .card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  /* Active only in light mode — empty string in dark */
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-depth);
 }
 ```
 
 ### Elevation levels
 
-| Level | Dark mode | Light mode |
-|-------|-----------|------------|
-| Ground | `bg` | `bg` |
-| Raised | `surface` | `surface` + `shadow-depth` |
-| Floating | `surface-2` | `surface` + stronger shadow (`0 4px 12px rgba(0,0,0,0.06)`) |
-| Glass | `surface-2 / 20%` + `backdrop-blur-xl` + `shadow-xl` | `surface / 60%` + `backdrop-blur-xl` + `shadow-xl` |
-| Modal | `surface-2` + backdrop | `surface` + heavy shadow (`0 16px 48px rgba(0,0,0,0.12)`) + backdrop |
+| Level | Light mode | Dark mode |
+|---|---|---|
+| Ground | `--bg-page` | `--bg-page` |
+| Raised | `--bg-card` + `--shadow-depth` | `--bg-card` + `--shadow-depth` |
+| Floating | `--color-surface` + stronger shadow (`0 4px 12px rgba(0,0,0,0.06)`) | `--color-surface` + stronger shadow (`0 4px 12px rgba(0,0,0,0.35)`) |
+| Glass | `--bg-card / 60%` + `backdrop-blur-xl` + `shadow-xl` | `--bg-card / 30%` + `backdrop-blur-xl` + `shadow-xl` |
+| Modal | `--bg-card` + heavy shadow (`0 16px 48px rgba(0,0,0,0.12)`) + `--color-overlay` backdrop | `--bg-card` + heavier shadow (`0 16px 48px rgba(0,0,0,0.5)`) + `--color-overlay` backdrop |
 
 **Glass tier** is reserved for overlay surfaces that hover *above live content* — the floating chat composer is the canonical example. Unlike `Floating`, it is deliberately translucent: the backdrop blur is load-bearing, and the surface tint is kept low so the content underneath reads as "behind glass". Use sparingly — one glass surface per view, maximum.
 
@@ -127,7 +147,7 @@ Focus states are the single most important accessibility affordance. Every inter
 
 - **Width**: 2px
 - **Offset**: 2px (outside the element)
-- **Color**: `var(--focus-ring)` — `#E4E4E7` on dark, `#18181B` on light
+- **Color**: `var(--focus-ring)` — resolves to `var(--color-accent)` (warm dark on light, cream on dark)
 - **Transition**: fade in via `var(--motion-fast)` + `var(--ease-out)`
 - **Radius**: matches the element's own `border-radius`
 
@@ -265,7 +285,7 @@ Full motion guidance in [motion.md](./motion.md).
 
 ## Mode switching
 
-Dark is the default; users can pick `system` / `light` / `dark` via a UI toggle.
+Light is the default (paper is the canonical surface); users can pick `system` / `light` / `dark` via a UI toggle.
 
 ### Implementation
 
@@ -280,11 +300,11 @@ Dark is the default; users can pick `system` / `light` / `dark` via a UI toggle.
       var stored = localStorage.getItem('theme'); // 'system' | 'light' | 'dark'
       var mode = stored || 'system';
       var resolved = mode === 'system'
-        ? (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
+        ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
         : mode;
       document.documentElement.classList.add(resolved);
     } catch (_) {
-      document.documentElement.classList.add('dark');
+      document.documentElement.classList.add('light');
     }
   })();
 </script>
@@ -352,4 +372,5 @@ Panels with a side-by-side list + detail layout (MemoryPanel, WorkspaceFilesPane
 - [ ] `prefers-reduced-motion` honored
 - [ ] No keyboard traps (`Esc` always exits modals/menus)
 - [ ] Touch targets ≥ 44×44px
-- [ ] Depth uses brightness on dark, shadow on light
+- [ ] Depth uses `--shadow-depth` plus border on both modes
+- [ ] Radius scale (`--radius-*`) used — no magic px values

--- a/documents/styling-specs/layout.md
+++ b/documents/styling-specs/layout.md
@@ -88,21 +88,20 @@ All spacing is a multiple of 4px.
 
 ## Radius scale
 
-The paper aesthetic is generous with rounding. Cards, pills, and the input bar all sit at `--radius-lg` or larger; raw rectangles are reserved for code blocks and dense table cells.
+The paper aesthetic is generous with rounding. Cards and the input bar sit at `--radius-lg` or larger; raw rectangles are reserved for code blocks and dense table cells. **Full pills (`rounded-full` on text-bearing elements) are reserved for circular dots, avatars, progress-bar endcaps, and other shapes whose visual job is *to be circular*.** Agent chips, role toggles, and status badges use `--radius-md` so they read as soft-cornered tags, not pharmacy capsules.
 
 | Token | Value | Usage |
 |---|---|---|
 | `--radius-xs` | 6px | Inline code, tiny chips |
 | `--radius-sm` | 8px | Small buttons, table cells |
-| `--radius-md` | 10px | Standard inputs, secondary buttons |
+| `--radius-md` | 10px | Standard inputs, secondary buttons, **agent chips, role toggles, status badges** |
 | `--radius-lg` | 14px | Cards, popovers, message bubbles, sidebar items |
 | `--radius-2xl` | 24px | Input bar, hero CTAs |
-| `--radius-pill` | 999px | Agent chip pills, role toggles, status badges |
 
 ```tsx
-<div className="rounded-lg">…</div>           // 14px card
-<button className="rounded-md">Submit</button> // 10px button
-<span className="rounded-full">…</span>        // pill
+<div className="rounded-lg">…</div>            // 14px card
+<button className="rounded-md">Submit</button>  // 10px button / chip
+<span className="rounded-full size-2">…</span>  // circular dot only
 ```
 
 ---

--- a/documents/styling-specs/layout.md
+++ b/documents/styling-specs/layout.md
@@ -45,7 +45,7 @@ All spacing is a multiple of 4px.
 
 **`md` is the mobile/desktop split.** `useIsMobile()` returns `true` when `window.innerWidth < 768px`. For JS-driven layout branches always use this hook rather than raw CSS breakpoints. CSS `md:` utilities are fine for purely visual changes; use the hook when the branch affects behaviour (panel mode, shortcut availability, etc.).
 
-**Avoid `lg:` or larger inside panels and drawers.** A panel's own width is narrower than the viewport, so `lg:` (1024px viewport) will never fire when the panel is open on a mobile screen. Use `isMobile` branches instead — see [`docs/web/mobile.md`](../docs/web/mobile.md).
+**Avoid `lg:` or larger inside panels and drawers.** A panel's own width is narrower than the viewport, so `lg:` (1024px viewport) will never fire when the panel is open on a mobile screen. Use a viewport-aware mobile flag for any layout branch that affects behavior; reserve CSS-only breakpoints for purely visual changes inside panels.
 
 ---
 
@@ -64,25 +64,11 @@ All spacing is a multiple of 4px.
 
 ### Spacing application
 
-```tsx
-// Button — small component
-<button className="px-3 py-2">Label</button>
+- Buttons sit at the small step (`md` token). Cards sit at the standard step (`lg` token). Sections sit at the large step (`xl` token).
+- Sibling gap inside a row matches the small/medium step depending on density. Grid gap between cards matches the cards' own scale step.
+- Vertical rhythm between paragraph blocks uses the medium step; between major sections uses the large step.
 
-// Card — medium component
-<div className="p-4">…</div>
-
-// Section — large component
-<section className="p-6">…</section>
-
-// Flex gap between siblings
-<div className="flex gap-3">{items}</div>
-
-// Grid gap
-<div className="grid grid-cols-3 gap-4">{cards}</div>
-
-// Vertical rhythm
-<div className="space-y-4">{paragraphs}</div>
-```
+Pick step sizes by walking up the scale together. A row gap should never be smaller than the parent's padding; section spacing should never be smaller than the section's internal padding.
 
 ---
 
@@ -98,11 +84,7 @@ The paper aesthetic is generous with rounding. Cards and the input bar sit at `-
 | `--radius-lg` | 14px | Cards, popovers, message bubbles, sidebar items |
 | `--radius-2xl` | 24px | Input bar, hero CTAs |
 
-```tsx
-<div className="rounded-lg">…</div>            // 14px card
-<button className="rounded-md">Submit</button>  // 10px button / chip
-<span className="rounded-full size-2">…</span>  // circular dot only
-```
+Pick a radius for the family the component belongs to, not for visual taste. Cards that visually feel like a button still get the card radius, and vice-versa — the family is the rule.
 
 ---
 
@@ -115,14 +97,7 @@ Both modes use a subtle `box-shadow` plus a `border` to create hierarchy. Unlike
 | **Light** | Warm-neutral surfaces sit close in value; `var(--shadow-depth)` adds a soft outer drop, and `var(--color-border)` defines the edge. |
 | **Dark** | Dark warm surfaces are also close in value; a slightly deeper shadow + a warm-toned border do the same job. |
 
-```css
-.card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-card);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-depth);
-}
-```
+The card composition is canonical: `--bg-card` fill, `--color-border` 1px outline, the radius for the card family, and `--shadow-depth` only when the surface genuinely floats. Flat cards on the page surface skip the shadow — the border alone carries them.
 
 ### Elevation levels
 

--- a/documents/styling-specs/logo.md
+++ b/documents/styling-specs/logo.md
@@ -1,23 +1,24 @@
 ---
 title: Logo Specifications
-description: Source-faithful octobot mascot, lockups, sizing rules, clear space, and asset delivery formats
+description: Source-faithful Octobot mascot, lockups, sizing rules, clear space, asset delivery — rendered against warm paper surfaces
 status: stable
-updated: 2026-05-07
+updated: 2026-05-09
 ---
 
 # Logo Specifications
 
 ## Primary logo
 
-- **Format**: Original octobot mascot + `OpenAgentd` wordmark
+- **Format**: Original Octobot mascot + `OpenAgentd` wordmark
 - **Mascot source**: `documents/assets/brand/octobot-agentd-source.png`
 - **Canonical assets**: `documents/assets/brand/`
 - **App assets**: `web/src/assets/brand/`
 - **Wordmark casing**: `OpenAgentd`
-- **Wordmark font**: Inter/system sans, 800 weight
+- **Wordmark font**: Inter, 800 weight (`--font-sans`)
 - **Positioning**: mascot left, wordmark and agent-runtime copy right
+- **Default surface**: warm paper (`--bg-page` / `#FAF6EC`). The mascot's warm gold/orange pigments were composed against this tone; rendering on a cool gray neutral will desaturate the mascot perceptually.
 
-The octobot is the brand. Do not redraw it into a generic robot, simplify the tentacles, replace the eyes, or change the proportions. New assets must embed or directly derive from the source PNG.
+The Octobot is the brand. Do not redraw it into a generic robot, simplify the tentacles, replace the eyes, or change the proportions. New assets must embed or directly derive from the source PNG.
 
 ---
 
@@ -60,7 +61,9 @@ When text appears inside a filled pill, badge, or bordered container, center it 
 | Shell White | `#FBF8F7` | Light brand surfaces and mascot highlights |
 | Console Ink | `#17120F` | Dark brand surfaces |
 
-The product UI can remain neutral and restrained; the brand assets carry the warm octobot palette.
+The product UI uses warm-neutral paper tones (see [colors.md](./colors.md)); the brand assets carry the saturated Octobot palette. The two are designed to coexist — `--bg-page` (`#FAF6EC`) sits intentionally close to Shell White (`#FBF8F7`), so a brand asset placed on a product page reads as continuous rather than pasted-on.
+
+**Do not use the Octobot pigments as UI accents.** The warm dark `--color-accent` (`#3F3429`) handles primary affordances; agent identity uses the chip palette (mint / blue / orange / pink) — see [colors.md](./colors.md#agent-chip-palette). Brand pigment is identity-reserved.
 
 ---
 
@@ -68,7 +71,7 @@ The product UI can remain neutral and restrained; the brand assets carry the war
 
 ### Clear Space
 
-Maintain clear space equal to the octobot eye diameter around the mascot or full lockup. Nothing should intersect the tentacles, antenna, or wordmark area.
+Maintain clear space equal to the Octobot eye diameter around the mascot or full lockup. Nothing should intersect the tentacles, antenna, or wordmark area.
 
 ### Minimum Size
 
@@ -94,6 +97,7 @@ Do not:
 - Add unrelated decorative patterns behind the mascot
 - Replace the warm palette with generic blue/purple SaaS colors
 - Use the mascot as a repeated background texture
+- Render the lockup on a cool gray surface — use `--bg-page`, Shell White, or Console Ink
 
 ---
 

--- a/documents/styling-specs/logo.md
+++ b/documents/styling-specs/logo.md
@@ -47,7 +47,7 @@ Prefer agent-centered language:
 
 Do not lead brand assets with implementation technologies such as FastAPI or React. Those belong in technical docs, not identity lockups.
 
-When text appears inside a filled pill, badge, or bordered container, center it both visually and structurally (`text-anchor="middle"`, `dominant-baseline="middle"` in SVG; flex center in UI code).
+When text appears inside a filled tag, badge, or bordered container, center it both visually and structurally (`text-anchor="middle"`, `dominant-baseline="middle"` in SVG; flex center in UI code).
 
 ---
 
@@ -93,7 +93,7 @@ Do not:
 - Use the old `o.` monogram direction
 - Mention implementation technologies in logo lockups
 - Distort, crop, mirror, or recolor the mascot paths
-- Put non-centered text inside filled pills or badges
+- Put non-centered text inside filled tags or badges
 - Add unrelated decorative patterns behind the mascot
 - Replace the warm palette with generic blue/purple SaaS colors
 - Use the mascot as a repeated background texture

--- a/documents/styling-specs/motion.md
+++ b/documents/styling-specs/motion.md
@@ -2,7 +2,7 @@
 title: Motion
 description: Duration tokens, easing functions, choreography patterns, and prefers-reduced-motion fallbacks
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # Motion
@@ -163,7 +163,7 @@ Text label accompanies dots: `Thinking`, `Reading`, `Searching`, etc. — progre
 
 **Meaning**: a message was routed from one team member to another — visible causality in multi-agent orchestration.
 
-**Spec**: sender row briefly glows (accent-subtle background, 300ms fade-out), recipient row slides in as above. The glow is the *cause*, the slide is the *effect*. Order matters.
+**Spec**: sender row briefly glows in the *sender's chip soft color* (`--accent-{role}-soft`, 300ms fade-out), recipient row slides in as above. The glow is the *cause*, the slide is the *effect*. Order matters. Using the role-specific soft tint (mint when openagentd hands off, blue when executor hands off, etc.) makes the causality readable at a glance — the user sees who acted, not just that something moved.
 
 ### Focus ring appear
 

--- a/documents/styling-specs/typography.md
+++ b/documents/styling-specs/typography.md
@@ -63,19 +63,21 @@ font-family: 'Caveat', 'Bradley Hand', cursive;
 
 ### When to use Caveat
 
-✅ **Yes:**
-- Top-of-canvas screen labels in design files (these are typically *outside* the production UI; they label the design context)
-- One reflective prompt on an empty state ("what's on your mind?")
-- Personality moments in marketing surfaces (tagline, hero pull-quote)
+Use Caveat for:
 
-❌ **No:**
-- Body text — always
-- Buttons, labels, nav items, form fields
-- Anything a screen reader needs to read out clearly
-- Multi-line paragraphs
-- Headings inside dense product chrome
+- Top-of-canvas screen labels in design files (typically *outside* production UI — they label the design context).
+- One reflective prompt on an empty state ("what's on your mind?").
+- Personality moments in marketing surfaces — tagline, hero pull-quote.
 
-The "design canvas labels" we see in the pencil (`empty room.`, etc.) are reference labels for the design itself; production app headings are Inter.
+Do not use Caveat for:
+
+- Body text. Ever.
+- Buttons, labels, nav items, form fields.
+- Anything a screen reader must read clearly. Caveat is decorative chrome; pair it with an accessible Inter equivalent or mark it `aria-hidden`.
+- Multi-line paragraphs.
+- Headings inside dense product chrome.
+
+The "design canvas labels" in the pencil source (`empty room.`, etc.) are reference labels for the design file itself; production app headings stay in Inter.
 
 ---
 
@@ -136,11 +138,11 @@ Inter is a variable font, so weight transitions are smooth rather than stepped. 
 
 ### Anti-patterns
 
-- ❌ **Weight shift on idle/static text** — only interactive elements shift
-- ❌ **Weight shift without transition** — produces a layout jump, feels broken
-- ❌ **Shift beyond 600** — 700 Bold is reserved for permanent headings, not hover states
-- ❌ **Different shift amounts within a group** — a nav where some items go 400→500 and others go 400→600 reads as inconsistent
-- ❌ **Weight shift on Caveat** — script weights aren't perceptually different the way Inter weights are; let Caveat sit
+- Weight shift on idle/static text. Only interactive elements shift.
+- Weight shift without a transition. The result is a layout jump that feels broken.
+- Shift beyond 600. Weight 700 (Bold) is reserved for permanent headings, not hover states.
+- Different shift amounts within a group. A nav where some items go 400→500 and others go 400→600 reads as inconsistent.
+- Weight shift on Caveat. Script weights are not perceptually distinct the way Inter weights are; let Caveat sit.
 
 ### When NOT to use weight transitions
 

--- a/documents/styling-specs/typography.md
+++ b/documents/styling-specs/typography.md
@@ -1,54 +1,100 @@
 ---
 title: Typography
-description: Geist Variable and JetBrains Mono, type hierarchy, font-weight transitions on interaction
+description: Inter (UI/body), JetBrains Mono (code), Caveat (handwritten headlines), type scale, font-weight transitions
 status: stable
-updated: 2026-04-21
+updated: 2026-05-09
 ---
 
 # Typography
 
-## Primary typeface: Geist Variable
+Three families, three jobs. Inter does the work, JetBrains Mono renders code and structured data, Caveat carries the handwritten "this is a notebook" voice on a small set of headlines.
 
-- **Usage**: All text — headings, body copy, UI labels, marketing
-- **Weight range**: 400 (Regular) through 700 (Bold) — variable axis
-- **Source**: `@fontsource-variable/geist` (open source, Vercel)
-- **Character**: Modern, geometric sans-serif. Sharp counters, tight tracking. Reads as precision software.
-- **System fallback**: `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`
+---
 
-### Font stack (copy/paste)
+## Three families, three jobs
+
+| Family | Token | Job |
+|---|---|---|
+| **Inter** | `--font-sans` | Every UI surface — body, labels, buttons, nav, prose |
+| **JetBrains Mono** | `--font-mono` | Code blocks, terminal output, file paths, agent IDs, structured data |
+| **Caveat** | `--font-hand` / `--font-script` | Hand-drawn screen titles and reflective callouts only — not body |
+
+Anything that isn't code and isn't a hand-drawn title is Inter. Caveat is reserved — overuse breaks the spell.
+
+---
+
+## Primary typeface: Inter
+
+- **Usage**: All UI text — headings, body copy, labels, buttons, prose
+- **Weights in use**: 400 (Regular), 500 (Medium), 600 (SemiBold), 700 (Bold)
+- **Source**: `@fontsource-variable/inter` (open source)
+- **Character**: Highly legible humanist sans, built for screens. Reads as calm utility against the warm paper.
+- **Token**: `--font-sans`
 
 ```css
-font-family: 'Geist Variable', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 ```
+
+---
 
 ## Secondary typeface: JetBrains Mono
 
-- **Usage**: Code blocks, terminal output, file paths, configuration values, any monospace text
+- **Usage**: Code blocks, terminal output, file paths, agent IDs (`g_abc123`), token meters, anything monospaced or structured
 - **Weights**: 400 (Regular), 500 (Medium), 600 (SemiBold)
 - **Character**: Humanist monospace designed for code. Distinguishes `0O`, `1lI`, `{}()` clearly.
-- **Fallback**: `ui-monospace, "SF Mono", "Courier New", monospace`
-
-### Code font stack (copy/paste)
+- **Token**: `--font-mono`
 
 ```css
-font-family: 'JetBrains Mono', ui-monospace, "SF Mono", "Courier New", monospace;
+font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', 'Courier New', monospace;
 ```
+
+---
+
+## Hand-drawn typeface: Caveat
+
+- **Usage**: Screen titles in design (`empty room.`, `first stream`, `queue armed.`, `idle.`), reflective callouts, the mascot's "what's on your mind?" prompt
+- **Weights**: 400 (Regular), 700 (Bold)
+- **Character**: Casual handwritten script. Carries the notebook voice — a person wrote this, not a system.
+- **Tokens**: `--font-hand` and `--font-script` (alias)
+
+```css
+font-family: 'Caveat', 'Bradley Hand', cursive;
+```
+
+### When to use Caveat
+
+✅ **Yes:**
+- Top-of-canvas screen labels in design files (these are typically *outside* the production UI; they label the design context)
+- One reflective prompt on an empty state ("what's on your mind?")
+- Personality moments in marketing surfaces (tagline, hero pull-quote)
+
+❌ **No:**
+- Body text — always
+- Buttons, labels, nav items, form fields
+- Anything a screen reader needs to read out clearly
+- Multi-line paragraphs
+- Headings inside dense product chrome
+
+The "design canvas labels" we see in the pencil (`empty room.`, etc.) are reference labels for the design itself; production app headings are Inter.
 
 ---
 
 ## Type hierarchy
 
-| Level | Size | Weight | Line height | Letter spacing | Usage |
-|-------|------|--------|-------------|----------------|-------|
-| **Display** | 32px | 700 | 1.25 | -0.5px | Hero titles, main page headers |
-| **Heading 1** | 28px | 700 | 1.30 | -0.3px | Page titles, section headers |
-| **Heading 2** | 24px | 600 | 1.35 | -0.2px | Subsection headers |
-| **Heading 3** | 20px | 600 | 1.40 | 0 | Component titles, subheadings |
-| **Body** | 16px | 400 | 1.50 | 0 | Main content, UI text, paragraphs |
-| **Small** | 14px | 400 | 1.50 | 0.1px | Secondary info, labels, captions |
-| **Tiny** | 12px | 400 | 1.50 | 0.2px | Metadata, timestamps, footnotes |
+| Level | Size | Weight | Line height | Letter spacing | Family | Usage |
+|---|---|---|---|---|---|---|
+| **Hand callout** | 36–48px | 400 | 1.10 | 0 | Caveat | Marketing-only handwritten moment |
+| **Display** | 32px | 700 | 1.25 | -0.5px | Inter | Hero titles, marketing page headers |
+| **Heading 1** | 28px | 700 | 1.30 | -0.3px | Inter | Page titles, section headers |
+| **Heading 2** | 24px | 600 | 1.35 | -0.2px | Inter | Subsection headers |
+| **Heading 3** | 20px | 600 | 1.40 | 0 | Inter | Component titles |
+| **Body** | 16px | 400 | 1.50 | 0 | Inter | Main content, UI text, paragraphs |
+| **Small** | 14px | 400 | 1.50 | 0.1px | Inter | Secondary info, labels, captions, message metadata |
+| **Tiny** | 12px | 400 | 1.50 | 0.2px | Inter | Timestamps, footnotes, token counts |
+| **Code inline** | 14px (0.92em in prose) | 400 | 1.50 | 0 | JetBrains Mono | `inline_code`, file paths |
+| **Code block** | 14px | 400 | 1.55 | 0 | JetBrains Mono | Multi-line code, terminal output |
 
-**Line-height rule**: tighter for display, looser for body. Never go below 1.4 for body text.
+**Line-height rule**: tighter for display, looser for body. Never go below 1.4 for body text. Caveat sets tighter (1.10) because handwritten letters already imply rhythm.
 
 ---
 
@@ -59,7 +105,7 @@ Weight shifts on hover and active states are a signature of the OpenAgentd inter
 ### The rule
 
 | State | Body/label | Interactive (button, link, nav item) |
-|-------|-----------|--------------------------------------|
+|---|---|---|
 | Idle | 400 | 400 |
 | Hover | 400 | 500 |
 | Active / pressed | 400 | 600 |
@@ -67,7 +113,7 @@ Weight shifts on hover and active states are a signature of the OpenAgentd inter
 
 ### CSS implementation
 
-Geist is a variable font, so weight transitions are smooth rather than stepped. Use `font-variation-settings` for sub-weight precision, or `font-weight` with a transition if you don't need in-between values.
+Inter is a variable font, so weight transitions are smooth rather than stepped. Use `font-variation-settings` for sub-weight precision, or `font-weight` with a transition if you don't need in-between values.
 
 ```css
 /* Smooth weight shift on interactive elements */
@@ -76,13 +122,8 @@ Geist is a variable font, so weight transitions are smooth rather than stepped. 
   transition: font-weight 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.interactive:hover {
-  font-weight: 500;
-}
-
-.interactive:active {
-  font-weight: 600;
-}
+.interactive:hover  { font-weight: 500; }
+.interactive:active { font-weight: 600; }
 
 /* Or with variation settings for finer control */
 .interactive {
@@ -90,9 +131,7 @@ Geist is a variable font, so weight transitions are smooth rather than stepped. 
   transition: font-variation-settings 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.interactive:hover {
-  font-variation-settings: 'wght' 500;
-}
+.interactive:hover { font-variation-settings: 'wght' 500; }
 ```
 
 ### Anti-patterns
@@ -101,12 +140,14 @@ Geist is a variable font, so weight transitions are smooth rather than stepped. 
 - ❌ **Weight shift without transition** — produces a layout jump, feels broken
 - ❌ **Shift beyond 600** — 700 Bold is reserved for permanent headings, not hover states
 - ❌ **Different shift amounts within a group** — a nav where some items go 400→500 and others go 400→600 reads as inconsistent
+- ❌ **Weight shift on Caveat** — script weights aren't perceptually different the way Inter weights are; let Caveat sit
 
 ### When NOT to use weight transitions
 
 - Body paragraph links — too much motion in a reading flow
 - Table rows with many cells — shifts the whole row, causes reflow
 - Icon-only buttons — there's no text weight to shift
+- Caveat headlines — the hand-drawn aesthetic doesn't support it
 
 See [interaction.md](./interaction.md) for the full hover/focus/active state model.
 
@@ -119,8 +160,10 @@ The web app exposes typography through the `@theme` inline block in `src/index.c
 ```css
 @theme inline {
   /* Families */
-  --font-sans:    'Geist Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans:    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono:    'JetBrains Mono', ui-monospace, 'SF Mono', 'Courier New', monospace;
+  --font-hand:    'Caveat', 'Bradley Hand', cursive;
+  --font-script:  var(--font-hand);
   --font-heading: var(--font-sans);
 
   /* Sizes */
@@ -131,6 +174,7 @@ The web app exposes typography through the `@theme` inline block in `src/index.c
   --text-body:    16px;
   --text-sm:      14px;
   --text-xs:      12px;
+  --text-hand:    44px;
 
   /* Weights */
   --weight-regular:  400;
@@ -145,13 +189,36 @@ The web app exposes typography through the `@theme` inline block in `src/index.c
 
 ---
 
+## Tailwind utility usage
+
+```tsx
+// Body — Inter, default weight
+<p className="text-base">Body copy in Inter.</p>
+
+// Heading — Inter, semibold
+<h2 className="text-h2 font-semibold">Section heading</h2>
+
+// Code — JetBrains Mono
+<code className="font-mono text-sm bg-(--bg-key) px-1.5 py-0.5 rounded">
+  app/agent/mode/chat.py
+</code>
+
+// Hand callout — Caveat
+<span className="font-hand text-[44px] leading-none text-(--color-text)">
+  what's on your mind?
+</span>
+```
+
+---
+
 ## Web implementation notes
 
-- Geist Variable loads from `@fontsource-variable/geist` — single variable font file, no per-weight imports needed
-- JetBrains Mono is loaded via a separate CSS import or `@fontsource/jetbrains-mono`
+- Inter loads from `@fontsource-variable/inter` — single variable font, no per-weight imports needed
+- JetBrains Mono is loaded via `@fontsource-variable/jetbrains-mono`
+- Caveat is loaded via `@fontsource/caveat` (400 + 700)
 - Code syntax highlighting uses `highlight.js` with the OpenAgentd theme (see [colors.md](./colors.md#syntax-highlighting--code))
-- All UI text inherits `font-family: var(--font-sans)` from the root; code elements (`<code>`, `<pre>`, `.font-mono`) opt in to the mono stack
-- Font-weight transitions are defined in a `.interactive` utility class or applied directly to `<button>`, `<a>`, and `[role="button"]` elements
+- All UI text inherits `font-family: var(--font-sans)` from the root; code elements (`<code>`, `<pre>`, `.font-mono`) opt into the mono stack; Caveat is opt-in only via `.font-hand` or the `--font-hand` variable
+- Font-weight transitions are defined on `<button>`, `<a>`, and `[role="button"]` elements, plus an explicit `.interactive` utility for custom controls
 
 ---
 
@@ -159,6 +226,7 @@ The web app exposes typography through the `@theme` inline block in `src/index.c
 
 - **Minimum body size**: 16px. Never smaller for paragraph text.
 - **Minimum small size**: 14px for secondary info; 12px only for non-essential metadata (timestamps, byte counts)
+- **Caveat is decorative** — every Caveat callout must have an accessible Inter equivalent in the DOM (or be marked `aria-hidden="true"` if it's purely visual). Screen readers should not depend on script-rendering for meaning.
 - **Line length**: aim for 60–75 characters per line in reading contexts. Use `max-width: 65ch` on prose containers.
 - **Weight + contrast**: thin weights (300 or below) are not used; they fail WCAG on low-DPI screens even when contrast math passes
 - **`prefers-reduced-motion`**: font-weight transitions honor reduced-motion (disable the 200ms transition, snap directly to final weight)

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -6,7 +6,9 @@
       "name": "openagentd-web",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
-        "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource/caveat": "^5.2.8",
         "@tanstack/react-query": "^5.96.2",
         "@tanstack/react-query-devtools": "^5.96.2",
         "@tanstack/react-router": "^1.168.10",
@@ -210,7 +212,11 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.2.8", "", {}, "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw=="],
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource/caveat": ["@fontsource/caveat@5.2.8", "", {}, "sha512-9fUUfFE2IQFKbx+xOcaeQxxmh8iJguEb8z+j1PeueO4UUx+XfT4pRm/B04ZDvFA794/iRxY/IibmP8ZKtIf4rw=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.9" } }, "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A=="],
 

--- a/web/index.html
+++ b/web/index.html
@@ -22,8 +22,8 @@
           root.classList.toggle('dark', resolved === 'dark');
           root.classList.toggle('light', resolved === 'light');
         } catch (e) {
-          // Fall back to dark (the default in index.css).
-          document.documentElement.classList.add('dark');
+          // Fall back to light (the canonical default in index.css).
+          document.documentElement.classList.add('light');
         }
       })();
     </script>

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
-    "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource/caveat": "^5.2.8",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-query-devtools": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",

--- a/web/src/__tests__/components/AgentCapabilities.test.tsx
+++ b/web/src/__tests__/components/AgentCapabilities.test.tsx
@@ -333,7 +333,7 @@ describe("CapabilityBadges rendering (via AgentCard)", () => {
 
       // Verify the capability is enabled
       expect(caps.input.vision).toBe(true)
-      // In the component, enabled badges get: 'bg-(--color-accent-subtle) text-(--color-accent)'
+      // In the component, enabled badges get: 'bg-(--bg-key) text-(--color-accent)'
     })
 
     it("disabled badge has muted/opacity styling class", () => {
@@ -344,7 +344,7 @@ describe("CapabilityBadges rendering (via AgentCard)", () => {
 
       // Verify the capability is disabled
       expect(caps.input.vision).toBe(false)
-      // In the component, disabled badges get: 'bg-(--color-bg) text-(--color-text-muted) opacity-40'
+      // In the component, disabled badges get: 'bg-(--bg-page) text-(--color-text-muted) opacity-40'
     })
   })
 

--- a/web/src/__tests__/components/CommandPalette.test.tsx
+++ b/web/src/__tests__/components/CommandPalette.test.tsx
@@ -153,7 +153,7 @@ describe("CommandPalette", () => {
     await user.keyboard("{ArrowDown}")
 
     // Second item (idx=1) should now be active (has accent-subtle bg)
-    const activeItems = container.querySelectorAll("[class*='bg-(--color-accent-subtle)']")
+    const activeItems = container.querySelectorAll("[class*='bg-(--bg-key)']")
     expect(activeItems.length).toBeGreaterThan(0)
   })
 

--- a/web/src/__tests__/components/FloatingInputBar.test.tsx
+++ b/web/src/__tests__/components/FloatingInputBar.test.tsx
@@ -33,10 +33,17 @@ function Harness(props: {
 }
 
 describe('FloatingInputBar', () => {
-  it('renders the inner InputBar textarea', () => {
+  it('keeps the inner InputBar textarea mounted but hidden from AT while minimized', () => {
     render(<Harness />)
-    const textarea = screen.getByRole('textbox', { name: 'Message input' })
+    // The textarea is always in the DOM regardless of minimized state
+    // — visibility is opacity-driven so the ref stays valid and focus
+    // can land instantly on expand. While minimized, the wrapping
+    // ``aria-hidden`` correctly removes it from the accessibility
+    // tree, so we query by label (DOM-level) rather than role
+    // (a11y-tree-level).
+    const textarea = screen.getByLabelText('Message input')
     expect(textarea).toBeTruthy()
+    expect(textarea.getAttribute('disabled')).not.toBeNull()
   })
 
   it('exposes a drag handle labelled for screen readers', () => {
@@ -105,9 +112,17 @@ describe('FloatingInputBar', () => {
     }
   })
 
-  it('forwards the placeholder prop to the inner InputBar', () => {
+  it('forwards the placeholder prop to the inner InputBar when expanded', async () => {
+    const user = userEvent.setup()
     render(<Harness placeholder="Ask the team…" />)
-    const textarea = screen.getByRole('textbox', { name: 'Message input' })
+    // Placeholder is empty while the bar is minimized so its ghost
+    // doesn't bleed through the slot opacity fade. The minimized
+    // strip's Send button (only one with that accessible name) does
+    // double-duty as "expand input bar" — clicking it flips
+    // ``minimized=false`` and the textarea's placeholder updates.
+    const sendBtn = screen.getByRole('button', { name: 'Expand input bar' })
+    await user.click(sendBtn)
+    const textarea = await screen.findByRole('textbox', { name: 'Message input' })
     expect(textarea.getAttribute('placeholder')).toBe('Ask the team…')
   })
 })

--- a/web/src/__tests__/components/TeamChatView.todos.test.ts
+++ b/web/src/__tests__/components/TeamChatView.todos.test.ts
@@ -362,7 +362,9 @@ describe('Todos Popover - Priority Badge Styling', () => {
     expect(classes).toHaveLength(3)
     expect(classes[0]).toContain('red')
     expect(classes[1]).toContain('amber')
-    expect(classes[2]).toContain('accent')
+    // Low priority uses paper neutrals (--bg-key + --color-text-subtle)
+    // rather than a marker accent.
+    expect(classes[2]).toContain('bg-(--bg-key)')
   })
 })
 

--- a/web/src/__tests__/components/TeamChatView.todos.test.ts
+++ b/web/src/__tests__/components/TeamChatView.todos.test.ts
@@ -117,42 +117,47 @@ describe('Todos Popover - Sorting Logic', () => {
 })
 
 // ── Status Icon Mapping ────────────────────────────────────────────────────
+//
+// The popover now renders lucide icons (Check / X / Play / Circle)
+// instead of unicode glyphs so the visuals scale and theme cleanly
+// alongside the rest of the design system. We assert by component
+// identity — referentially comparing the lucide components imported
+// from the same module the production code uses.
 
-/**
- * Maps todo status to its display icon.
- * Extracted as a pure function for testability.
- */
-function getStatusIcon(status: TodoItem['status']): string {
-  const icons: Record<TodoItem['status'], string> = {
-    completed: '✓',
-    cancelled: '✗',
-    in_progress: '▶',
-    pending: '○',
+import { Check, Circle, Play, X } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+function getStatusIcon(status: TodoItem['status']): LucideIcon {
+  const icons: Record<TodoItem['status'], LucideIcon> = {
+    completed: Check,
+    cancelled: X,
+    in_progress: Play,
+    pending: Circle,
   }
   return icons[status]
 }
 
 describe('Todos Popover - Status Icon Mapping', () => {
-  it('maps completed status to checkmark', () => {
-    expect(getStatusIcon('completed')).toBe('✓')
+  it('maps completed status to a tick icon', () => {
+    expect(getStatusIcon('completed')).toBe(Check)
   })
 
-  it('maps cancelled status to X', () => {
-    expect(getStatusIcon('cancelled')).toBe('✗')
+  it('maps cancelled status to an X icon', () => {
+    expect(getStatusIcon('cancelled')).toBe(X)
   })
 
-  it('maps in_progress status to play symbol', () => {
-    expect(getStatusIcon('in_progress')).toBe('▶')
+  it('maps in_progress status to a play icon', () => {
+    expect(getStatusIcon('in_progress')).toBe(Play)
   })
 
-  it('maps pending status to circle', () => {
-    expect(getStatusIcon('pending')).toBe('○')
+  it('maps pending status to a circle icon', () => {
+    expect(getStatusIcon('pending')).toBe(Circle)
   })
 
   it('returns correct icon for all statuses', () => {
     const statuses: TodoItem['status'][] = ['completed', 'cancelled', 'in_progress', 'pending']
     const icons = statuses.map(getStatusIcon)
-    expect(icons).toEqual(['✓', '✗', '▶', '○'])
+    expect(icons).toEqual([Check, X, Play, Circle])
   })
 })
 

--- a/web/src/__tests__/components/TeamChatView.todos.test.ts
+++ b/web/src/__tests__/components/TeamChatView.todos.test.ts
@@ -331,7 +331,7 @@ function getPriorityBadgeClass(priority: TodoItem['priority']): string {
     return 'bg-red-500/10 text-red-500'
   }
   if (priority === 'low') {
-    return 'bg-(--color-accent-dim) text-(--color-text-subtle)'
+    return 'bg-(--bg-key) text-(--color-text-subtle)'
   }
   // medium
   return 'bg-amber-500/10 text-amber-500'
@@ -352,7 +352,7 @@ describe('Todos Popover - Priority Badge Styling', () => {
 
   it('applies accent styling for low priority', () => {
     const classes = getPriorityBadgeClass('low')
-    expect(classes).toContain('bg-(--color-accent-dim)')
+    expect(classes).toContain('bg-(--bg-key)')
     expect(classes).toContain('text-(--color-text-subtle)')
   })
 

--- a/web/src/__tests__/components/ToolCall.generate_image.test.tsx
+++ b/web/src/__tests__/components/ToolCall.generate_image.test.tsx
@@ -121,9 +121,9 @@ describe("ToolCall — generate_image header", () => {
     expect(screen.getByText("generate_image")).toBeTruthy()
   })
 
-  it("shows 'pending' badge when args is undefined", () => {
+  it("does not show a stale pending badge when args is undefined", () => {
     render(<ToolCall name="generate_image" done={false} />)
-    expect(screen.getByText("pending")).toBeTruthy()
+    expect(screen.queryByText("pending")).toBeNull()
   })
 })
 
@@ -447,9 +447,10 @@ describe("ToolCall — generate_image expand/collapse", () => {
 // ---------------------------------------------------------------------------
 
 describe("ToolCall — generate_image status indicators", () => {
-  it("shows pending badge when no args", () => {
+  it("shows start state as just the tool name when no args", () => {
     render(<ToolCall name="generate_image" done={false} />)
-    expect(screen.getByText("pending")).toBeTruthy()
+    expect(screen.getByText("generate_image")).toBeTruthy()
+    expect(screen.queryByText("pending")).toBeNull()
   })
 
   it("shows running indicator when running (args set, not done)", () => {

--- a/web/src/__tests__/components/ToolCall.team_message.test.tsx
+++ b/web/src/__tests__/components/ToolCall.team_message.test.tsx
@@ -112,9 +112,14 @@ describe("ToolCall — team_message header", () => {
     expect(screen.getByText("team_message")).toBeTruthy()
   })
 
-  it("shows 'pending' badge when args is undefined", () => {
+  it("shows no pending badge when args is undefined (start state is name-only)", () => {
     render(<ToolCall name="team_message" done={false} />)
-    expect(screen.getByText("pending")).toBeTruthy()
+    // Lifecycle refactor removed the legacy "pending" text badge; the
+    // start state is communicated by the muted status dot only.
+    expect(screen.queryByText("pending")).toBeNull()
+    const btn = screen.getByRole("button")
+    const dot = btn.querySelector("span.bg-\\(--color-text-muted\\)")
+    expect(dot).toBeTruthy()
   })
 
   it("handles numeric recipient IDs", () => {
@@ -345,9 +350,12 @@ describe("ToolCall — team_message with result", () => {
 // ---------------------------------------------------------------------------
 
 describe("ToolCall — team_message status indicators", () => {
-  it("shows pending badge when no args", () => {
+  it("shows muted start dot when no args (lifecycle 'start' state)", () => {
     render(<ToolCall name="team_message" done={false} />)
-    expect(screen.getByText("pending")).toBeTruthy()
+    expect(screen.queryByText("pending")).toBeNull()
+    const btn = screen.getByRole("button")
+    const dot = btn.querySelector("span.bg-\\(--color-text-muted\\)")
+    expect(dot).toBeTruthy()
   })
 
   it("shows running indicator when running (args set, not done)", () => {

--- a/web/src/__tests__/components/ToolCall.test.tsx
+++ b/web/src/__tests__/components/ToolCall.test.tsx
@@ -54,23 +54,24 @@ describe("ToolCall — header", () => {
     expect(screen.getByText("custom_tool")).toBeTruthy()
   })
 
-  it("shows 'pending' badge when no args", () => {
+  it("shows only the tool name when no args", () => {
     render(<ToolCall name="read" />)
-    expect(screen.getByText("pending")).toBeTruthy()
+    expect(screen.getByText("read")).toBeTruthy()
+    expect(screen.queryByText("pending")).toBeNull()
   })
 
-  it("shows spinner when running (args set, not done)", () => {
+  it("shows running state when args are set and result is not done", () => {
     render(<ToolCall name="read" args='{"path":"x"}' done={false} />)
     expect(screen.queryByText("pending")).toBeNull()
-    // Running state: no pending badge, no done indicator
+    // Running state: no pending badge, no result section until expanded details exist
     const btn = screen.getByRole("button")
     expect(btn).toBeTruthy()
   })
 
-  it("shows check icon when done", () => {
+  it("shows success state when done without failed result", () => {
     render(<ToolCall name="read" args='{"path":"x"}' done={true} />)
     expect(screen.queryByText("pending")).toBeNull()
-    // Done state: no pending badge
+    // Success state: no pending badge
     const btn = screen.getByRole("button")
     expect(btn).toBeTruthy()
   })
@@ -228,12 +229,10 @@ describe("ToolCall — forget display", () => {
 })
 
 describe("ToolCall — recall display", () => {
-  it("shows conversational header when no args", () => {
+  it("shows tool name when no args", () => {
     render(<ToolCall name="recall" done={false} />)
-    const header = getHeader("Checking memory…")
-    expect(header.textContent).toBe("Checking memory…")
-    expect(header.querySelector("em")).toBeNull()
-    expect(screen.queryByText("recall")).toBeNull()
+    expect(screen.getByText("recall")).toBeTruthy()
+    expect(screen.queryByText("Checking memory…")).toBeNull()
   })
 
   it("shows conversational header with args", () => {
@@ -932,6 +931,22 @@ describe("ToolCall — empty args {} show no args section", () => {
     expect(btn.className).not.toContain("cursor-default")
     await user.click(btn)
     expect(screen.getByText("result")).toBeTruthy()
+  })
+
+  it("shows failed result content when a completed tool failed", async () => {
+    const user = userEvent.setup()
+    render(
+      <ToolCall
+        name="shell"
+        args={JSON.stringify({ command: "pytest" })}
+        done={true}
+        result="[Failed — exit code 1]\n\nAssertionError"
+      />,
+    )
+
+    await user.click(screen.getByRole("button"))
+    expect(screen.getByText(/Failed/)).toBeTruthy()
+    expect(screen.getByText(/AssertionError/)).toBeTruthy()
   })
 
   it("date tool with no args shows no args section", async () => {

--- a/web/src/__tests__/components/tool-call-generate-video.test.tsx
+++ b/web/src/__tests__/components/tool-call-generate-video.test.tsx
@@ -140,7 +140,7 @@ describe("ToolCall generate_video display", () => {
 
     // When no args, shows tool name instead of custom header
     expect(screen.getByText(/generate_video/i)).toBeInTheDocument();
-    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+    expect(screen.queryByText(/pending/i)).toBeNull();
   });
 
   it("renders without crashing when running (args, no done)", () => {

--- a/web/src/__tests__/routes/settings.voice.test.tsx
+++ b/web/src/__tests__/routes/settings.voice.test.tsx
@@ -103,7 +103,7 @@ describe('VoiceSettingsPage', () => {
 
     const modelInput = await screen.findByLabelText('Model ID') as HTMLInputElement
     expect(modelInput.value).toBe('local:base')
-    expect((screen.getByRole('checkbox', { name: /enabled/i }) as HTMLInputElement).checked).toBe(false)
+    expect(screen.getByRole('switch', { name: /enabled/i }).getAttribute('aria-checked')).toBe('false')
     expect(screen.getByRole('button', { name: /^save$/i }).hasAttribute('disabled')).toBe(true)
   })
 

--- a/web/src/components/AgentCapabilities.tsx
+++ b/web/src/components/AgentCapabilities.tsx
@@ -229,7 +229,7 @@ function ToolGroupHeader({
         <h4 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
           Built-in
         </h4>
-        <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+        <span className="rounded-md bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
           {count}
         </span>
       </div>
@@ -241,7 +241,7 @@ function ToolGroupHeader({
       <h4 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
         MCP · {server}
       </h4>
-      <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+      <span className="rounded-md bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
         {count}
       </span>
     </div>
@@ -285,7 +285,7 @@ function Tools({
         <h3 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
           Tools
         </h3>
-        <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+        <span className="rounded-md bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
           {tools.length}
         </span>
       </div>

--- a/web/src/components/AgentCapabilities.tsx
+++ b/web/src/components/AgentCapabilities.tsx
@@ -51,8 +51,8 @@ function RolePill({ isLead }: { isLead: boolean }) {
     <span
       className={`rounded-md px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider ${
         isLead
-          ? 'bg-(--color-accent-subtle) text-(--color-accent)'
-          : 'bg-(--color-accent-dim) text-(--color-text-muted)'
+          ? 'bg-(--bg-key) text-(--color-accent)'
+          : 'bg-(--bg-key) text-(--color-text-muted)'
       }`}
     >
       {isLead ? 'Lead' : 'Member'}
@@ -77,7 +77,7 @@ function CapabilityChips({ chips }: { chips: CapabilityChip[] }) {
       {chips.map(({ key, label, icon: Icon }) => (
         <span
           key={key}
-          className="flex items-center gap-1 rounded-md bg-(--color-accent-subtle) px-2 py-0.5 text-xs text-(--color-text-2) ring-1 ring-(--color-border-strong)"
+          className="flex items-center gap-1 rounded-md bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-text-2) ring-1 ring-(--color-border-strong)"
           title={label}
         >
           <Icon size={11} className="text-(--color-text-muted)" />
@@ -141,7 +141,7 @@ function ToolRow({ name, description }: { name: string; description: string }) {
   const [open, setOpen] = useState(false)
   const hasDesc = description.trim().length > 0
   return (
-    <div className="overflow-hidden rounded-lg border border-(--color-border) bg-(--color-bg) transition-colors hover:border-(--color-border-strong)">
+    <div className="overflow-hidden rounded-lg border border-(--color-border) bg-(--bg-page) transition-colors hover:border-(--color-border-strong)">
       <button
         onClick={() => hasDesc && setOpen((v) => !v)}
         className={`flex w-full items-center gap-2.5 px-3 py-2 text-left ${hasDesc ? 'cursor-pointer' : 'cursor-default'}`}
@@ -229,7 +229,7 @@ function ToolGroupHeader({
         <h4 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
           Built-in
         </h4>
-        <span className="rounded-full bg-(--color-accent-dim) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+        <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
           {count}
         </span>
       </div>
@@ -241,7 +241,7 @@ function ToolGroupHeader({
       <h4 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
         MCP · {server}
       </h4>
-      <span className="rounded-full bg-(--color-accent-dim) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+      <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
         {count}
       </span>
     </div>
@@ -285,14 +285,14 @@ function Tools({
         <h3 className="text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
           Tools
         </h3>
-        <span className="rounded-full bg-(--color-accent-dim) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
+        <span className="rounded-full bg-(--bg-key) px-2 py-0.5 text-[10px] text-(--color-text-muted)">
           {tools.length}
         </span>
       </div>
 
       {showSearch && (
         <div className="shrink-0 px-5 pb-2">
-          <div className="flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--color-bg) px-2.5 py-1.5 focus-within:border-(--color-border-strong)">
+          <div className="flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--bg-page) px-2.5 py-1.5 focus-within:border-(--color-border-strong)">
             <Search size={12} className="shrink-0 text-(--color-text-muted)" />
             <input
               type="text"
@@ -350,7 +350,7 @@ function Skills({ skills }: { skills: AgentInfo['skills'] }) {
             <span
               key={s.name}
               title={s.description || undefined}
-              className="flex cursor-default items-center gap-1 rounded-md bg-(--color-accent-subtle) px-2 py-0.5 font-mono text-xs text-(--color-text-2) ring-1 ring-(--color-border-strong)"
+              className="flex cursor-default items-center gap-1 rounded-md bg-(--bg-key) px-2 py-0.5 font-mono text-xs text-(--color-text-2) ring-1 ring-(--color-border-strong)"
             >
               <Sparkles size={10} className="text-(--color-text-muted)" />
               {s.name}
@@ -378,7 +378,7 @@ function AgentSwitcher({
   onSelect: (name: string) => void
 }) {
   return (
-    <div className="shrink-0 border-b border-(--color-border) bg-(--color-surface-2) px-3 py-2">
+    <div className="shrink-0 border-b border-(--color-border) bg-(--bg-key) px-3 py-2">
       <div className="flex flex-wrap items-center gap-1">
         {agents.map((agent) => {
           const active = agent.name === selectedName
@@ -390,8 +390,8 @@ function AgentSwitcher({
               onClick={() => onSelect(agent.name)}
               className={`flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors ${
                 active
-                  ? 'bg-(--color-accent-subtle) text-(--color-text) ring-1 ring-(--color-border-strong)'
-                  : 'text-(--color-text-muted) hover:bg-(--color-accent-dim) hover:text-(--color-text-2)'
+                  ? 'bg-(--bg-key) text-(--color-text) ring-1 ring-(--color-border-strong)'
+                  : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text-2)'
               }`}
               aria-pressed={active}
             >
@@ -496,7 +496,7 @@ export function AgentCapabilities({
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '100%', opacity: 0 }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
-            className="fixed inset-y-0 right-0 z-50 flex w-[min(560px,90vw)] flex-col overflow-hidden border-l border-(--color-border) bg-(--color-surface) shadow-2xl"
+            className="fixed inset-y-0 right-0 z-50 flex w-[min(560px,90vw)] flex-col overflow-hidden border-l border-(--color-border) bg-(--bg-card) shadow-2xl"
             role="dialog"
             aria-modal="true"
             aria-label="Agent details"
@@ -504,7 +504,7 @@ export function AgentCapabilities({
         {/* Header */}
         <header className="flex shrink-0 items-start justify-between gap-3 border-b border-(--color-border) px-5 py-4">
           {isLoading || !selected ? (
-            <div className="h-6 w-48 animate-pulse rounded bg-(--color-accent-dim)" />
+            <div className="h-6 w-48 animate-pulse rounded bg-(--bg-key)" />
           ) : (
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
@@ -523,7 +523,7 @@ export function AgentCapabilities({
           )}
           <button
             onClick={onClose}
-            className="shrink-0 rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+            className="shrink-0 rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
             aria-label="Close (Esc)"
             title="Close (Esc)"
           >
@@ -546,9 +546,9 @@ export function AgentCapabilities({
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {isLoading || !selected ? (
             <div className="flex-1 space-y-3 p-5">
-              <div className="h-16 animate-pulse rounded-xl bg-(--color-accent-dim)" />
-              <div className="h-24 animate-pulse rounded-xl bg-(--color-accent-dim)" />
-              <div className="h-40 animate-pulse rounded-xl bg-(--color-accent-dim)" />
+              <div className="h-16 animate-pulse rounded-xl bg-(--bg-key)" />
+              <div className="h-24 animate-pulse rounded-xl bg-(--bg-key)" />
+              <div className="h-40 animate-pulse rounded-xl bg-(--bg-key)" />
             </div>
           ) : (
             <>

--- a/web/src/components/AgentPane.tsx
+++ b/web/src/components/AgentPane.tsx
@@ -106,7 +106,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
            </div>
          )}
 
-         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-3 py-2 text-xs leading-relaxed text-(--color-bg) overflow-hidden">
+         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-3 py-2 text-xs leading-relaxed text-(--bg-page) overflow-hidden">
            {/* Expand / collapse button — top-right inside bubble (compact) */}
            {needsCollapse && (
              <button
@@ -123,7 +123,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
                ].join(' ')}
                style={{
                  background: 'rgba(0,0,0,0.15)',
-                 color: 'var(--color-bg)',
+                 color: 'var(--bg-page)',
                }}
              >
                {expanded ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
@@ -291,7 +291,7 @@ export function AgentPane({
   const borderClass  = isError
     ? 'border-(--color-error)'
     : isDropTarget
-    ? 'border-(--color-info) bg-(--color-info-subtle)'
+    ? 'border-(--color-info) bg-(--accent-blue-soft)'
     : isFocused
     ? 'border-(--color-accent)'
     : isLead
@@ -311,7 +311,7 @@ export function AgentPane({
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragEnd={onDragEnd}
-      className={`flex h-full flex-col overflow-hidden rounded-xl border bg-(--color-bg) transition-all duration-150 ${borderClass} ${isDragging ? 'opacity-50' : ''}`}
+      className={`flex h-full flex-col overflow-hidden rounded-xl border bg-(--bg-page) transition-all duration-150 ${borderClass} ${isDragging ? 'opacity-50' : ''}`}
       onClick={onFocus}
     >
       {/* Header */}
@@ -335,7 +335,7 @@ export function AgentPane({
              {name}
            </span>
            {isLead && (
-             <span className="shrink-0 rounded-sm bg-(--color-accent-subtle) px-1 py-0.5 text-xs text-(--color-accent)">
+             <span className="shrink-0 rounded-sm bg-(--bg-key) px-1 py-0.5 text-xs text-(--color-accent)">
                lead
              </span>
            )}
@@ -365,7 +365,7 @@ export function AgentPane({
          {onClose && (
            <button
              onClick={(e) => { e.stopPropagation(); onClose() }}
-             className="ml-1 rounded p-0.5 text-(--color-text-subtle) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+             className="ml-1 rounded p-0.5 text-(--color-text-subtle) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
              title="Minimize pane"
              aria-label={`Minimize ${name} pane`}
            >
@@ -449,7 +449,7 @@ export function AgentPane({
       {showScrollBtn && (
         <button
           onClick={() => scrollToBottom(true)}
-          className="absolute bottom-2 left-1/2 z-10 -translate-x-1/2 rounded-full border border-(--color-border) bg-(--color-surface) p-1 text-(--color-text-muted) transition-colors hover:text-(--color-text-2)"
+          className="absolute bottom-2 left-1/2 z-10 -translate-x-1/2 rounded-full border border-(--color-border) bg-(--bg-card) p-1 text-(--color-text-muted) transition-colors hover:text-(--color-text-2)"
           aria-label="Scroll to bottom"
         >
           <ChevronDown size={12} />

--- a/web/src/components/AgentPane.tsx
+++ b/web/src/components/AgentPane.tsx
@@ -106,25 +106,14 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
            </div>
          )}
 
-         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-3 py-2 text-xs leading-relaxed text-(--bg-page) overflow-hidden">
+         <div className="relative overflow-hidden rounded-md border border-(--color-border) bg-(--color-surface) px-3 py-2 text-xs leading-relaxed text-(--color-text)">
            {/* Expand / collapse button — top-right inside bubble (compact) */}
            {needsCollapse && (
              <button
                onClick={() => setExpanded((v) => !v)}
                aria-expanded={expanded}
                title={expanded ? 'Collapse' : 'Expand'}
-               className={[
-                 'absolute top-1 right-1',
-                 'flex items-center justify-center shrink-0',
-                 'rounded-md',
-                 'h-4 w-4',
-                 'transition-all duration-150',
-                 'active:scale-90',
-               ].join(' ')}
-               style={{
-                 background: 'rgba(0,0,0,0.15)',
-                 color: 'var(--bg-page)',
-               }}
+               className="absolute top-1 right-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-(--bg-key) text-(--color-text-2) transition-all duration-150 hover:text-(--color-text) active:scale-90"
              >
                {expanded ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
              </button>
@@ -136,7 +125,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
                className="pointer-events-none absolute inset-x-0 bottom-0"
                style={{
                  height: '1.9rem',
-                 background: 'linear-gradient(to bottom, transparent 0%, var(--color-accent) 90%)',
+                 background: 'linear-gradient(to bottom, transparent 0%, var(--color-surface) 90%)',
                }}
              />
            )}

--- a/web/src/components/AgentTopbar.tsx
+++ b/web/src/components/AgentTopbar.tsx
@@ -1,0 +1,211 @@
+/**
+ * AgentTopbar — reusable right-cluster composite for the chat header.
+ *
+ * Mirrors the right side of the `TeamChatView` header and the design
+ * source `AgentTopbar` (`E8lml9` → right cluster section `BbrKe`) in
+ * `.diagrams/OpenAgentd-ui.pen`. The left side of the header varies a
+ * lot per view mode (agent tabs, split label, unified strip), so this
+ * component encapsulates only the parts that are consistent across all
+ * surfaces:
+ *
+ *   • TokenMeter (desktop only, shown when totals > 0)
+ *   • Optional "Dream…" running indicator
+ *   • Optional unified-view split-pane buttons (desktop only)
+ *   • ViewToggle (desktop only)
+ *   • TopbarAction triplet — Todos / Files / Agents
+ *
+ * Keeping this composite props-driven (rather than reading global state
+ * directly) makes it usable in previews, screenshots, and future
+ * single-agent surfaces — not just `TeamChatView`.
+ */
+
+import {
+  FolderOpen,
+  ListChecks,
+  Moon,
+  SplitSquareHorizontal,
+  SplitSquareVertical,
+  Users,
+  type LucideIcon,
+} from 'lucide-react'
+
+import { TopbarAction } from '@/components/ui/topbar-action'
+import { TokenMeter } from '@/components/ui/token-meter'
+import { ViewToggle, type ViewMode } from '@/components/ui/view-toggle'
+import { cn } from '@/lib/utils'
+
+export interface AgentTopbarTokens {
+  input: number
+  output: number
+  cached?: number
+  pulsing?: boolean
+}
+
+export interface AgentTopbarActionDescriptor {
+  /** Lucide icon component. */
+  Icon: LucideIcon
+  label: string
+  onClick: () => void
+  /** Disable the action (renders muted, blocks click). */
+  disabled?: boolean
+  /** Native `title` attribute / tooltip text. */
+  title?: string
+  /** Override default aria-label. */
+  ariaLabel?: string
+  /** Show a small accent dot to signal an active/in-progress state. */
+  indicator?: boolean
+  /** Override the indicator dot color (e.g. error red). */
+  indicatorClassName?: string
+}
+
+export interface AgentTopbarProps {
+  /** Token totals; when omitted (or all zero) the TokenMeter is hidden. */
+  tokens?: AgentTopbarTokens
+  /** Show "Dream…" indicator when the dream loop is running. */
+  dreamRunning?: boolean
+  /** Current view mode; when undefined the ViewToggle is hidden. */
+  viewMode?: ViewMode
+  onViewModeChange?: (mode: ViewMode) => void
+  /** Show split-pane buttons (only meaningful in unified mode). */
+  showSplitButtons?: boolean
+  onSplitDown?: () => void
+  onSplitRight?: () => void
+  /** Force the mobile/desktop layout. Defaults to desktop. */
+  isMobile?: boolean
+  /**
+   * Custom Todos trigger. The TodosPopover handles its own trigger
+   * (open state, popover wiring), so the consumer passes the rendered
+   * trigger element. When omitted the topbar renders a plain Todos
+   * action driven by `onTodosClick`.
+   */
+  todosSlot?: React.ReactNode
+  todosAction?: AgentTopbarActionDescriptor
+  /** Files action — typically toggles the workspace files panel. */
+  filesAction?: AgentTopbarActionDescriptor
+  /** Agents action — typically toggles the agent capabilities sidebar. */
+  agentsAction?: AgentTopbarActionDescriptor
+  /** Extra actions appended after Agents (rarely needed). */
+  extraActions?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Right-side cluster of the agent chat topbar. Always rendered as a
+ * shrink-0 flex row so it can sit at the trailing edge of a `min-w-0`
+ * left side.
+ */
+export function AgentTopbar({
+  tokens,
+  dreamRunning = false,
+  viewMode,
+  onViewModeChange,
+  showSplitButtons = false,
+  onSplitDown,
+  onSplitRight,
+  isMobile = false,
+  todosSlot,
+  todosAction,
+  filesAction,
+  agentsAction,
+  extraActions,
+  className,
+}: AgentTopbarProps) {
+  const totalAll = tokens
+    ? tokens.input + tokens.output + (tokens.cached ?? 0)
+    : 0
+  const showTokens = !isMobile && tokens && totalAll > 0
+  const showViewToggle = !isMobile && viewMode && onViewModeChange
+  const showSplit =
+    !isMobile && showSplitButtons && (onSplitDown || onSplitRight)
+
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center gap-1.5 py-2',
+        className,
+      )}
+    >
+      {showTokens && tokens && (
+        <TokenMeter
+          input={tokens.input}
+          output={tokens.output}
+          cached={tokens.cached}
+          pulsing={tokens.pulsing}
+        />
+      )}
+
+      {dreamRunning && (
+        <div
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-(--color-text-muted)"
+          title="Dream is running…"
+        >
+          <Moon size={11} className="animate-pulse" aria-hidden="true" />
+          <span className="hidden sm:inline">Dream…</span>
+        </div>
+      )}
+
+      {showSplit && (
+        <div className="flex items-center gap-0.5">
+          {onSplitDown && (
+            <button
+              type="button"
+              onClick={onSplitDown}
+              className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
+              title="Split pane down (Ctrl+J)"
+              aria-label="Split pane down"
+            >
+              <SplitSquareVertical size={12} aria-hidden="true" />
+            </button>
+          )}
+          {onSplitRight && (
+            <button
+              type="button"
+              onClick={onSplitRight}
+              className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
+              title="Split pane right (Ctrl+K)"
+              aria-label="Split pane right"
+            >
+              <SplitSquareHorizontal size={12} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {showViewToggle && viewMode && onViewModeChange && (
+        <ViewToggle value={viewMode} onValueChange={onViewModeChange} />
+      )}
+
+      {todosSlot ?? (todosAction && <AgentTopbarActionButton action={todosAction} fallbackIcon={ListChecks} />)}
+      {filesAction && (
+        <AgentTopbarActionButton action={filesAction} fallbackIcon={FolderOpen} />
+      )}
+      {agentsAction && (
+        <AgentTopbarActionButton action={agentsAction} fallbackIcon={Users} />
+      )}
+
+      {extraActions}
+    </div>
+  )
+}
+
+function AgentTopbarActionButton({
+  action,
+  fallbackIcon,
+}: {
+  action: AgentTopbarActionDescriptor
+  fallbackIcon: LucideIcon
+}) {
+  const Icon = action.Icon ?? fallbackIcon
+  return (
+    <TopbarAction
+      Icon={Icon}
+      label={action.label}
+      onClick={action.onClick}
+      disabled={action.disabled}
+      title={action.title}
+      aria-label={action.ariaLabel ?? action.label}
+      indicator={action.indicator}
+      indicatorClassName={action.indicatorClassName}
+    />
+  )
+}

--- a/web/src/components/AgentView.tsx
+++ b/web/src/components/AgentView.tsx
@@ -106,7 +106,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
            </div>
          )}
 
-         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-4 py-2.5 text-sm leading-relaxed text-(--color-bg) overflow-hidden">
+         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-4 py-2.5 text-sm leading-relaxed text-(--bg-page) overflow-hidden">
            {/* Expand / collapse button — top-right inside bubble */}
            {needsCollapse && (
              <button
@@ -123,7 +123,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
                ].join(' ')}
                style={{
                  background: 'rgba(0,0,0,0.15)',
-                 color: 'var(--color-bg)',
+                 color: 'var(--bg-page)',
                }}
              >
                {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
@@ -359,7 +359,7 @@ export function AgentView({ blocks, currentBlocks, isWorking, isError, lastError
     {showScrollBtn && (
       <button
         onClick={() => scrollToBottom(true)}
-        className="absolute bottom-24 left-1/2 z-30 -translate-x-1/2 rounded-full border border-(--color-border) bg-(--color-surface) p-1.5 text-(--color-text-muted) shadow-sm transition-colors hover:text-(--color-text-2)"
+        className="absolute bottom-24 left-1/2 z-30 -translate-x-1/2 rounded-full border border-(--color-border) bg-(--bg-card) p-1.5 text-(--color-text-muted) shadow-sm transition-colors hover:text-(--color-text-2)"
         aria-label="Scroll to bottom"
       >
         <ChevronDown size={14} />

--- a/web/src/components/AgentView.tsx
+++ b/web/src/components/AgentView.tsx
@@ -283,9 +283,21 @@ export function AgentView({ blocks, currentBlocks, isWorking, isError, lastError
     <div ref={scrollRef} className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-3xl px-4 py-6">
         {isEmpty && (
-           <div className="flex flex-col items-center justify-center gap-3 py-16">
-             <img src={OctobotMascot} className="opacity-25 grayscale" width={72} height={72} alt="Idle octobot" />
-             <p className="text-sm text-(--color-text-subtle)">Waiting for your first message…</p>
+           <div className="flex flex-col items-center justify-center gap-4 py-16">
+             <img
+               src={OctobotMascot}
+               className="opacity-90"
+               width={120}
+               height={120}
+               alt=""
+               aria-hidden="true"
+             />
+             <h2 className="font-hand text-4xl font-bold text-(--color-text)">
+               what&rsquo;s on your mind?
+             </h2>
+             <p className="text-sm text-(--color-text-muted)">
+               Waiting for your first message
+             </p>
            </div>
          )}
 

--- a/web/src/components/AgentView.tsx
+++ b/web/src/components/AgentView.tsx
@@ -106,25 +106,14 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
            </div>
          )}
 
-         <div className="relative rounded-2xl rounded-br-sm bg-(--color-accent) px-4 py-2.5 text-sm leading-relaxed text-(--bg-page) overflow-hidden">
+         <div className="relative overflow-hidden rounded-md border border-(--color-border) bg-(--color-surface) px-4 py-3 text-sm leading-relaxed text-(--color-text)">
            {/* Expand / collapse button — top-right inside bubble */}
            {needsCollapse && (
              <button
                onClick={() => setExpanded((v) => !v)}
                aria-expanded={expanded}
                title={expanded ? 'Collapse' : 'Expand'}
-               className={[
-                 'absolute top-1.5 right-1.5',
-                 'flex items-center justify-center shrink-0',
-                 'rounded-md',
-                 'h-5 w-5',
-                 'transition-all duration-150',
-                 'active:scale-90',
-               ].join(' ')}
-               style={{
-                 background: 'rgba(0,0,0,0.15)',
-                 color: 'var(--bg-page)',
-               }}
+               className="absolute top-1.5 right-1.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-(--bg-key) text-(--color-text-2) transition-all duration-150 hover:text-(--color-text) active:scale-90"
              >
                {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
              </button>
@@ -136,7 +125,7 @@ function UserBubble({ content, timestamp, attachments }: { content: string; time
                className="pointer-events-none absolute inset-x-0 bottom-0"
                style={{
                  height: '2.4rem',
-                 background: 'linear-gradient(to bottom, transparent 0%, var(--color-accent) 90%)',
+                 background: 'linear-gradient(to bottom, transparent 0%, var(--color-surface) 90%)',
                }}
              />
            )}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -134,7 +134,7 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
           exit={{ opacity: 0, scale: 0.97, y: -8 }}
           transition={{ type: 'spring', damping: 30, stiffness: 380 }}
           onClick={(e) => e.stopPropagation()}
-          className="flex w-full max-w-md flex-col overflow-hidden rounded-2xl border border-(--color-border) bg-(--color-surface) shadow-2xl"
+          className="flex w-full max-w-md flex-col overflow-hidden rounded-2xl border border-(--color-border) bg-(--bg-card) shadow-2xl"
           role="dialog"
           aria-modal="true"
           aria-label="Command palette"
@@ -197,11 +197,11 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
 
           {/* Footer hint */}
           <div className="flex items-center gap-2 border-t border-(--color-border) px-4 py-2">
-            <kbd className="rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">↑↓</kbd>
+            <kbd className="rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">↑↓</kbd>
             <span className="text-xs text-(--color-text-muted)">navigate</span>
-            <kbd className="rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">↵</kbd>
+            <kbd className="rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">↵</kbd>
             <span className="text-xs text-(--color-text-muted)">run</span>
-            <kbd className="rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">Esc</kbd>
+            <kbd className="rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-[10px] text-(--color-text-muted)">Esc</kbd>
             <span className="text-xs text-(--color-text-muted)">close</span>
           </div>
         </motion.div>
@@ -241,7 +241,7 @@ function CommandRow({ cmd, idx, isActive, mouseY, onRun, onActivate }: CommandRo
           aria-hidden
           className="pointer-events-none absolute inset-0 -z-10"
           style={{
-            backgroundColor: `color-mix(in srgb, var(--color-accent-dim) ${intensity * 100}%, transparent)`,
+            backgroundColor: `color-mix(in srgb, var(--bg-key) ${intensity * 100}%, transparent)`,
           }}
         />
       )}
@@ -251,8 +251,8 @@ function CommandRow({ cmd, idx, isActive, mouseY, onRun, onActivate }: CommandRo
         onMouseEnter={() => onActivate(idx)}
         className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
           isActive
-            ? 'bg-(--color-accent-subtle) text-(--color-text)'
-            : 'text-(--color-text-2) hover:bg-(--color-accent-dim)'
+            ? 'bg-(--bg-key) text-(--color-text)'
+            : 'text-(--color-text-2) hover:bg-(--bg-key)'
         }`}
       >
         <div className="min-w-0 flex-1">
@@ -264,7 +264,7 @@ function CommandRow({ cmd, idx, isActive, mouseY, onRun, onActivate }: CommandRo
           )}
         </div>
         {cmd.shortcut && (
-          <kbd className="shrink-0 rounded border border-(--color-border) bg-(--color-bg) px-1.5 py-0.5 font-mono text-xs text-(--color-text-muted)">
+          <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1.5 py-0.5 font-mono text-xs text-(--color-text-muted)">
             {cmd.shortcut}
           </kbd>
         )}

--- a/web/src/components/FileCard.tsx
+++ b/web/src/components/FileCard.tsx
@@ -49,8 +49,8 @@ export function FileCard({
       <button
         onClick={handleClick}
         disabled={!clickable}
-        className={`surface-raised flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--color-surface) px-3 py-2 text-xs text-(--color-text) transition-all ${
-          clickable ? 'cursor-pointer hover:border-(--color-accent) hover:bg-(--color-surface-2)' : ''
+        className={`surface-raised flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--bg-card) px-3 py-2 text-xs text-(--color-text) transition-all ${
+          clickable ? 'cursor-pointer hover:border-(--color-accent) hover:bg-(--bg-key)' : ''
         }`}
         title={name}
       >
@@ -66,7 +66,7 @@ export function FileCard({
             e.stopPropagation()
             onRemove()
           }}
-          className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-(--color-surface-2) text-(--color-text-muted) ring-1 ring-(--color-border) shadow-sm transition-opacity opacity-100 hover:text-(--color-text) md:opacity-0 md:group-hover:opacity-100"
+          className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-(--bg-key) text-(--color-text-muted) ring-1 ring-(--color-border) shadow-sm transition-opacity opacity-100 hover:text-(--color-text) md:opacity-0 md:group-hover:opacity-100"
           aria-label="Remove file"
           title="Remove"
         >

--- a/web/src/components/FilePreviewStrip.tsx
+++ b/web/src/components/FilePreviewStrip.tsx
@@ -1,0 +1,132 @@
+/**
+ * FilePreviewStrip — horizontally scrolling row of file previews with an
+ * optional scroll-position hint pill below.
+ *
+ * Used by InputBar when `files.length > 0`. The strip clips at the visible
+ * width and scrolls horizontally; when content overflows, a 3px-tall pill
+ * appears below the strip showing a thumb that mirrors the current scroll
+ * position. The hint matches pencil's `attachmentScrollHint` /
+ * `attachmentScrollThumb` pattern from the `MultiAttachOverflow` variant.
+ *
+ * If the content fits within the visible width (no overflow), the hint
+ * is not rendered — keeping the bar visually quiet for small attachment
+ * counts.
+ */
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { ImageAttachment } from './ImageAttachment'
+import { FileCard } from './FileCard'
+
+interface FilePreviewStripProps {
+  files: File[]
+  blobUrls: Map<number, string>
+  onRemove: (index: number) => void
+  /** Whether to apply top margin (true) or bottom margin (false). */
+  filesBelow: boolean
+}
+
+interface ScrollMetrics {
+  thumbWidthPct: number
+  thumbLeftPct: number
+  hasOverflow: boolean
+}
+
+function computeMetrics(el: HTMLElement): ScrollMetrics {
+  const { scrollLeft, scrollWidth, clientWidth } = el
+  const hasOverflow = scrollWidth > clientWidth + 1
+  if (!hasOverflow) {
+    return { thumbWidthPct: 100, thumbLeftPct: 0, hasOverflow: false }
+  }
+  const thumbWidthPct = Math.max(15, (clientWidth / scrollWidth) * 100)
+  const maxScroll = scrollWidth - clientWidth
+  const scrollPct = maxScroll > 0 ? scrollLeft / maxScroll : 0
+  const thumbLeftPct = scrollPct * (100 - thumbWidthPct)
+  return { thumbWidthPct, thumbLeftPct, hasOverflow }
+}
+
+export function FilePreviewStrip({
+  files,
+  blobUrls,
+  onRemove,
+  filesBelow,
+}: FilePreviewStripProps) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [metrics, setMetrics] = useState<ScrollMetrics>({
+    thumbWidthPct: 100,
+    thumbLeftPct: 0,
+    hasOverflow: false,
+  })
+
+  // Recompute on file count change and window resize.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setMetrics(computeMetrics(el))
+  }, [files.length])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const update = () => setMetrics(computeMetrics(el))
+    el.addEventListener('scroll', update, { passive: true })
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    window.addEventListener('resize', update)
+    return () => {
+      el.removeEventListener('scroll', update)
+      ro.disconnect()
+      window.removeEventListener('resize', update)
+    }
+  }, [])
+
+  if (files.length === 0) return null
+
+  return (
+    <div className={`${filesBelow ? 'mt-3' : 'mb-3'} -mx-2 -my-2`}>
+      <div ref={scrollRef} className="overflow-x-auto px-2 py-2">
+        <div className="flex w-max flex-nowrap items-center gap-2">
+          {files.map((file, idx) => {
+            const isImage = file.type.startsWith('image/')
+            const blobUrl = blobUrls.get(idx) || ''
+            if (isImage) {
+              return (
+                <div key={idx} className="shrink-0">
+                  <ImageAttachment
+                    src={blobUrl}
+                    alt={file.name}
+                    removable
+                    compact
+                    onRemove={() => onRemove(idx)}
+                  />
+                </div>
+              )
+            }
+            return (
+              <div key={idx} className="shrink-0">
+                <FileCard
+                  name={file.name}
+                  mediaType={file.type}
+                  removable
+                  onRemove={() => onRemove(idx)}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      {metrics.hasOverflow && (
+        <div
+          className="mx-2 mt-1 h-[3px] overflow-hidden rounded-full bg-(--color-border-subtle)"
+          aria-hidden="true"
+        >
+          <div
+            className="h-full rounded-full bg-(--color-text-subtle)/60 transition-[left,width] duration-100"
+            style={{
+              width: `${metrics.thumbWidthPct}%`,
+              marginLeft: `${metrics.thumbLeftPct}%`,
+            }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/FloatingInputBar.tsx
+++ b/web/src/components/FloatingInputBar.tsx
@@ -4,6 +4,7 @@ import { GripHorizontal } from 'lucide-react'
 import { InputBar, type InputBarHandle, type SlashCommand } from './InputBar'
 import { PendingMessageQueue } from './PendingMessageQueue'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useTeamStore } from '@/stores/useTeamStore'
 import type { AgentCapabilities } from '@/api/types'
 
 // ── Storage ──────────────────────────────────────────────────────────────────
@@ -109,6 +110,115 @@ export const FloatingInputBar = forwardRef<InputBarHandle, FloatingInputBarProps
     const [offset, setOffset] = useState<StoredOffset>(() => loadOffset())
     const [filesBelow, setFilesBelow] = useState(true)
 
+    // ── Minimize-on-blur (desktop only) ──────────────────────────────────
+    // The bar collapses to the slim icon strip (pencil PKjWT) after the
+    // textarea loses focus while empty, so a blurred composer doesn't
+    // dominate the chat surface. It expands again on focus or whenever
+    // there's any meaningful content (text, attachments, queued messages,
+    // streaming). Mobile keeps the full bar — the soft keyboard already
+    // dictates its own focus/blur cadence and a collapse there would
+    // fight system behavior.
+    const queuedCount = useTeamStore((s) => s._pendingMessages.length)
+    // Start collapsed — the slim icon strip (pencil PKjWT) is the
+    // resting state. The user summons the full pill explicitly via
+    // click, focus, Ctrl/⌘+I, or by attaching a file. This matches
+    // the minimal-chrome aesthetic of the design and prevents an
+    // empty composer from dominating the chat surface on load.
+    const [minimized, setMinimized] = useState(true)
+    const [hasContent, setHasContent] = useState(false)
+    const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const innerRef = useRef<InputBarHandle | null>(null)
+    const setInputRefs = useCallback((handle: InputBarHandle | null) => {
+      innerRef.current = handle
+      if (typeof ref === 'function') ref(handle)
+      else if (ref) ref.current = handle
+    }, [ref])
+
+    const expand = useCallback(() => {
+      if (blurTimerRef.current) {
+        clearTimeout(blurTimerRef.current)
+        blurTimerRef.current = null
+      }
+      setMinimized(false)
+      // Focus is owned by InputBar's auto-focus-on-mount callback ref
+      // — it fires the moment the textarea actually attaches to the
+      // DOM, after AnimatePresence finishes the message-button exit.
+      // A parent-side focus() here would race the unmounted ref.
+    }, [])
+
+    const handleFocus = useCallback(() => {
+      if (blurTimerRef.current) {
+        clearTimeout(blurTimerRef.current)
+        blurTimerRef.current = null
+      }
+      setMinimized(false)
+    }, [])
+
+    const handleBlur = useCallback((canMinimize: boolean) => {
+      if (!canMinimize) return
+      // Short delay so a click on a sibling control inside the bar
+      // (e.g. the attach picker, mic) doesn't trigger a collapse mid-action.
+      blurTimerRef.current = setTimeout(() => {
+        setMinimized(true)
+        blurTimerRef.current = null
+      }, 180)
+    }, [])
+
+    useEffect(() => () => {
+      if (blurTimerRef.current) clearTimeout(blurTimerRef.current)
+    }, [])
+
+    // ── Global summon shortcut: Ctrl+I (⌘I on macOS) ─────────────────
+    // Brings the composer back to the foreground from any focus
+    // context. If the bar is collapsed it expands; either way the
+    // textarea takes focus so the user can immediately start typing.
+    // Mobile is excluded — the soft keyboard owns focus there and a
+    // window-level shortcut would never fire from a virtual keyboard.
+    useEffect(() => {
+      if (isMobile) return
+      const onKeyDown = (e: KeyboardEvent) => {
+        // ``e.key`` is the printed character so the check is layout
+        // safe; we accept upper- and lower-case to cover Caps Lock.
+        if ((e.ctrlKey || e.metaKey) && (e.key === 'i' || e.key === 'I')) {
+          // Don't fight with browser-native Ctrl+I in editable
+          // surfaces *outside* our composer (e.g. a Markdown editor
+          // mounted somewhere on the page). The composer's textarea
+          // doesn't use italics so summoning while focus is already
+          // there is harmless and just refocuses.
+          e.preventDefault()
+          expand()
+        }
+      }
+      window.addEventListener('keydown', onKeyDown)
+      return () => window.removeEventListener('keydown', onKeyDown)
+    }, [isMobile, expand])
+
+    // External signals that should keep the bar expanded regardless of
+    // focus state. ``isStreaming`` and ``queuedCount`` come from props /
+    // store; ``disabled`` covers the "waiting for response" pause;
+    // ``hasContent`` covers text/attachments held inside InputBar so
+    // dropping a file via the slim strip's attach button immediately
+    // re-expands the bar. Derived (not stored) so we don't cascade
+    // renders inside an effect.
+    const forceExpanded =
+      inputProps.isStreaming === true ||
+      inputProps.disabled === true ||
+      queuedCount > 0 ||
+      hasContent
+
+    const handleHasContentChange = useCallback((next: boolean) => {
+      setHasContent(next)
+      // When content arrives while minimized, also cancel any pending
+      // collapse so the bar settles into the expanded state cleanly.
+      if (next && blurTimerRef.current) {
+        clearTimeout(blurTimerRef.current)
+        blurTimerRef.current = null
+      }
+    }, [])
+
+    const effectiveMinimized = !isMobile && minimized && !forceExpanded
+
     const NEAR_BOTTOM_THRESHOLD = 140
 
     const recomputeFilesBelow = useCallback(() => {
@@ -176,8 +286,8 @@ export const FloatingInputBar = forwardRef<InputBarHandle, FloatingInputBarProps
       return (
         // border-t separates from chat content; pb-safe clears the home indicator
         <div className="pointer-events-auto border-t border-(--color-border) bg-(--bg-key)/20 px-3 pb-safe pt-2 backdrop-blur-xl">
-          <PendingMessageQueue inputRef={ref as React.RefObject<InputBarHandle | null>} />
-          <InputBar ref={ref} floating filesBelow={false} {...inputProps} />
+          <PendingMessageQueue inputRef={innerRef} />
+          <InputBar ref={setInputRefs} floating filesBelow={false} {...inputProps} />
         </div>
       )
     }
@@ -197,11 +307,16 @@ export const FloatingInputBar = forwardRef<InputBarHandle, FloatingInputBarProps
         className="pointer-events-auto absolute bottom-4 left-1/2 z-20 w-full max-w-xl -translate-x-1/2 px-4"
         style={{ touchAction: 'none' }}
       >
-        <PendingMessageQueue inputRef={ref as React.RefObject<InputBarHandle | null>} />
+        <PendingMessageQueue inputRef={innerRef} />
         <InputBar
-          ref={ref}
+          ref={setInputRefs}
           floating
           filesBelow={filesBelow}
+          minimized={effectiveMinimized}
+          onUnminimize={expand}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onHasContentChange={handleHasContentChange}
           renderDragHandle={() => (
             <button
               type="button"

--- a/web/src/components/FloatingInputBar.tsx
+++ b/web/src/components/FloatingInputBar.tsx
@@ -175,7 +175,7 @@ export const FloatingInputBar = forwardRef<InputBarHandle, FloatingInputBarProps
     if (isMobile) {
       return (
         // border-t separates from chat content; pb-safe clears the home indicator
-        <div className="pointer-events-auto border-t border-(--color-border) bg-(--color-surface-2)/20 px-3 pb-safe pt-2 backdrop-blur-xl">
+        <div className="pointer-events-auto border-t border-(--color-border) bg-(--bg-key)/20 px-3 pb-safe pt-2 backdrop-blur-xl">
           <PendingMessageQueue inputRef={ref as React.RefObject<InputBarHandle | null>} />
           <InputBar ref={ref} floating filesBelow={false} {...inputProps} />
         </div>
@@ -209,7 +209,7 @@ export const FloatingInputBar = forwardRef<InputBarHandle, FloatingInputBarProps
               title="Drag to move · Double-click to reset"
               onPointerDown={(e) => dragControls.start(e)}
               onDoubleClick={handleReset}
-              className="absolute left-1/2 top-0 z-10 flex h-4 w-10 -translate-x-1/2 -translate-y-1/2 cursor-grab items-center justify-center rounded-full border border-(--color-border) bg-(--color-surface-2) text-(--color-text-muted) shadow-sm transition-colors hover:text-(--color-text) active:cursor-grabbing"
+              className="absolute left-1/2 top-0 z-10 flex h-4 w-10 -translate-x-1/2 -translate-y-1/2 cursor-grab items-center justify-center rounded-full border border-(--color-border) bg-(--bg-key) text-(--color-text-muted) shadow-sm transition-colors hover:text-(--color-text) active:cursor-grabbing"
             >
               <GripHorizontal size={12} aria-hidden="true" />
             </button>

--- a/web/src/components/ImageAttachment.tsx
+++ b/web/src/components/ImageAttachment.tsx
@@ -29,7 +29,7 @@ export function ImageAttachment({ src, alt = 'Image', onRemove, removable, compa
 
   if (imageError) {
     return (
-      <div className={`flex ${errorSizeClass} items-center justify-center rounded-lg border border-(--color-border) bg-(--color-surface) text-xs text-(--color-text-muted)`}>
+      <div className={`flex ${errorSizeClass} items-center justify-center rounded-lg border border-(--color-border) bg-(--bg-card) text-xs text-(--color-text-muted)`}>
         Failed to load image
       </div>
     )
@@ -51,7 +51,7 @@ export function ImageAttachment({ src, alt = 'Image', onRemove, removable, compa
               e.stopPropagation()
               onRemove()
             }}
-            className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-(--color-surface-2) text-(--color-text-muted) ring-1 ring-(--color-border) shadow-sm transition-opacity opacity-100 hover:text-(--color-text) md:opacity-0 md:group-hover:opacity-100"
+            className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-(--bg-key) text-(--color-text-muted) ring-1 ring-(--color-border) shadow-sm transition-opacity opacity-100 hover:text-(--color-text) md:opacity-0 md:group-hover:opacity-100"
             aria-label="Remove image"
             title="Remove"
           >

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -64,14 +64,14 @@ function LightboxIconButton({
     <div className="group relative">
       <button
         onClick={onClick}
-        className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg bg-(--color-surface) text-(--color-text) transition-colors hover:bg-(--color-surface-2) focus-visible:ring-2 focus-visible:ring-(--color-text) focus-visible:outline-none"
+        className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg bg-(--bg-card) text-(--color-text) transition-colors hover:bg-(--bg-key) focus-visible:ring-2 focus-visible:ring-(--color-text) focus-visible:outline-none"
         aria-label={label}
       >
         {icon}
       </button>
       <span
         role="tooltip"
-        className="pointer-events-none absolute top-full right-0 mt-2 whitespace-nowrap rounded-md bg-(--color-surface-2) px-2 py-1 text-xs text-(--color-text) opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute top-full right-0 mt-2 whitespace-nowrap rounded-md bg-(--bg-key) px-2 py-1 text-xs text-(--color-text) opacity-0 shadow-md transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
       >
         {tooltip}
       </span>

--- a/web/src/components/InboxBubble.tsx
+++ b/web/src/components/InboxBubble.tsx
@@ -63,7 +63,7 @@ export function InboxBubble({ content, fromAgent, compact = false }: InboxBubble
            padding,
            textSize,
            'relative rounded-2xl rounded-bl-sm',
-           'border border-(--color-border) bg-(--color-surface-2)',
+           'border border-(--color-border) bg-(--bg-key)',
            'leading-relaxed text-(--color-text)',
            'overflow-hidden',
          ].join(' ')}
@@ -82,7 +82,7 @@ export function InboxBubble({ content, fromAgent, compact = false }: InboxBubble
                className={[
                  'flex items-center justify-center shrink-0',
                  'rounded-md border border-(--color-border)',
-                 'bg-(--color-bg) text-(--color-text-muted)',
+                 'bg-(--bg-page) text-(--color-text-muted)',
                  compact ? 'h-4 w-4' : 'h-5 w-5',
                  'transition-all duration-150',
                  'hover:border-(--color-syn-operator) hover:text-(--color-syn-operator)',
@@ -117,7 +117,7 @@ export function InboxBubble({ content, fromAgent, compact = false }: InboxBubble
              className="pointer-events-none absolute inset-x-0 bottom-0"
              style={{
                height: fadeHeight,
-               background: `linear-gradient(to bottom, transparent 0%, var(--color-surface-2) 90%)`,
+               background: `linear-gradient(to bottom, transparent 0%, var(--bg-key) 90%)`,
              }}
            />
          )}

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState, useCallback, useImperativeHandle, forwardRef, useEffect, useMemo } from 'react'
 import { ArrowUp, Loader2, Paperclip, Square } from 'lucide-react'
-import { ImageAttachment } from './ImageAttachment'
-import { FileCard } from './FileCard'
+import { FilePreviewStrip } from './FilePreviewStrip'
 import { VoiceMicButton } from './VoiceMicButton'
 import type { AgentCapabilities } from '@/api/types'
 
@@ -303,47 +302,15 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   const showCharCount = charCount > CHAR_WARN_THRESHOLD
 
   // Single-row, horizontally scrollable list so many attachments don't push
-  // the input off-screen vertically. `py-2`/`px-2` on the scroll container
-  // give the remove buttons (positioned at `-top-2`/`-right-2` on each
-  // card) room so they're not clipped by `overflow-x-auto` (which forces
-  // the y-axis to clip as well). `-mx-2 -my-2` on the outer wrapper
-  // neutralizes that padding so surrounding layout stays tight.
+  // the input off-screen vertically. The strip owns its own scroll-position
+  // hint (matches pencil's MultiAttachOverflow `attachmentScrollHint`).
   const filePreviews = files.length > 0 ? (
-    <div className={`${filesBelow ? 'mt-3' : 'mb-3'} -mx-2 -my-2`}>
-      <div className="overflow-x-auto px-2 py-2">
-        <div className="flex w-max flex-nowrap items-center gap-2">
-        {files.map((file, idx) => {
-          const isImage = file.type.startsWith('image/')
-          const blobUrl = blobUrls.get(idx) || ''
-
-          if (isImage) {
-            return (
-              <div key={idx} className="shrink-0">
-                <ImageAttachment
-                  src={blobUrl}
-                  alt={file.name}
-                  removable
-                  compact
-                  onRemove={() => removeFile(idx)}
-                />
-              </div>
-            )
-          }
-
-          return (
-            <div key={idx} className="shrink-0">
-              <FileCard
-                name={file.name}
-                mediaType={file.type}
-                removable
-                onRemove={() => removeFile(idx)}
-              />
-            </div>
-          )
-        })}
-        </div>
-      </div>
-    </div>
+    <FilePreviewStrip
+      files={files}
+      blobUrls={blobUrls}
+      onRemove={removeFile}
+      filesBelow={filesBelow}
+    />
   ) : null
 
   // Reusable pill button styles for the action row (attach, mic — pencil

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -429,21 +429,9 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   const actionBtnClass =
     'flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-(--color-border) bg-(--color-surface) text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:cursor-not-allowed disabled:opacity-50'
 
-  // ── Continuous-morph model ─────────────────────────────────────────
-  // The bar has three states that all share the same DOM tree:
-  //
-  //   Minimized:     [attach] [voice] [📝 message btn] [send-btn]
-  //   Expand 1-line: [attach] [voice] [textarea       ] [send]
-  //   Expand multi:  [textarea full-width             ]
-  //                  [attach] [voice]      [count] [send]
-  //
-  // The four buttons stay mounted in the same order in every state.
-  // The "message slot" (3rd child) morphs between an icon button and a
-  // textarea via framer-motion `layout` + AnimatePresence. In multi-
-  // line mode the textarea slot escapes to a full-width row above by
-  // setting `flex-basis: 100%` on its wrapper, which causes the
-  // wrapping flex row to wrap; the buttons settle on the second line
-  // automatically. No DOM reordering — just a width tween.
+  // Three states share one DOM tree: minimized, single-line, multi-line.
+  // Multi-line is triggered by the slot's flex-basis:100% which wraps the
+  // row so action buttons land on the line below — no DOM reordering.
   const handleExpand = () => {
     onUnminimize?.()
   }
@@ -472,9 +460,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
     </div>
   )
 
-  // Send/stop is a single 32×32 button matching the other action
-  // buttons. In minimized mode the click expands the bar instead of
-  // submitting (there's no text yet).
+  // In minimized mode the send button expands the bar instead of submitting.
   const sendOrStopEl = canStop && !hasText ? (
     <button
       type="button"
@@ -505,14 +491,8 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
     </button>
   )
 
-  // Message slot: just the textarea now. The slot's width is driven
-  // entirely by the parent ``motion.div`` wrapper — collapsed to 0
-  // when minimized (textarea slides out between voice and send), and
-  // ``flex-1`` / ``basis-full`` when expanded. The textarea is always
-  // mounted so the ref stays valid; ``opacity-0`` + ``pointer-events-
-  // none`` while minimized hides it without a remount-induced flicker.
-  // Send + click-anywhere on the strip already cover the "expand" tap
-  // target, so a dedicated message button would be redundant.
+  // The textarea stays mounted while minimized (opacity + pointer-events
+  // toggle) so the ref stays valid and there's no remount flicker.
   const messageSlot = (
     <div
       aria-hidden={minimized}
@@ -533,8 +513,6 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
         }}
         disabled={disabled || minimized}
         placeholder={
-          // Clear the placeholder while minimizing so its faint
-          // ghost doesn't bleed through the slot opacity fade.
           minimized
             ? ''
             : disabled
@@ -553,16 +531,11 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
     </div>
   )
 
-  // ── Outer chrome — same in both variants so the AnimatePresence
-  //     swap doesn't reflow the page; only the inner pill changes.
   return (
     <div className={floating ? '' : 'border-t border-(--color-border) bg-(--bg-page) px-4 py-3'}>
       <div className={floating ? 'relative' : 'relative mx-auto max-w-3xl'}>
-        {/* File previews (above when docked at bottom) — only meaningful
-            in expanded mode; hidden during collapse to avoid orphaning. */}
         {!minimized && !filesBelow && filePreviews}
 
-        {/* Slash command menu — floating above the input */}
         {!minimized && slashMenuOpen && filteredSlashCommands.length > 0 && (
           <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border-strong) bg-(--color-surface) shadow-md">
             {filteredSlashCommands.map((cmd, idx) => (
@@ -582,46 +555,27 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           </div>
         )}
 
-        {/* Input pill wrapper — anchors the drag handle to the input
-            itself, so it stays pinned to the pill regardless of file
-            previews. ``flex justify-center`` so the self-sized minimized
-            strip centers within the panel rather than left-aligning. */}
+        {/* ``flex justify-center`` centers the self-sized minimized pill. */}
         <div className={`relative ${minimized ? 'flex justify-center' : ''}`}>
           {renderDragHandle?.()}
-          {/* Continuous-morph card. Padding and width are animated as
-              numeric motion values so framer has a smooth tween across
-              minimized ↔ expanded (the Tailwind class swap is reserved
-              for color/shadow which don't affect layout).
-              ``flex-wrap`` is the trick that powers single ↔ multi-line:
-              when the textarea slot's flex-basis hits 100%, it forces
-              its row to wrap and the four buttons land on the line
-              below. No reordering. */}
           <motion.div
+            layout
             initial={false}
-            animate={{
-              padding: minimized ? 6 : 14,
-              width: minimized ? 'auto' : '100%',
-            }}
+            animate={{ padding: minimized ? 6 : 14 }}
             transition={{ duration: 0.24, ease: [0.32, 0.72, 0, 1] }}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            className={`relative ${minimized ? 'inline-block' : 'block'} rounded-lg border bg-(--color-surface) shadow-sm transition-[border-color,box-shadow,background-color] duration-200 ${
+            className={`relative block rounded-lg border bg-(--color-surface) transition-[border-color,box-shadow,background-color] duration-200 ${
               minimized
-                ? 'border-(--color-border) hover:bg-(--bg-key)'
-                : 'border-(--color-border-strong) shadow-md focus-within:ring-1 focus-within:ring-(--color-accent)'
+                ? 'w-fit border-(--color-border) shadow-sm hover:bg-(--bg-key)'
+                : 'w-full border-(--color-border-strong) shadow-md focus-within:ring-1 focus-within:ring-(--color-accent)'
             }`}
-            style={{ willChange: 'padding, width' }}
           >
-            {/* Click-anywhere-to-expand: the wrapper handles bare
-                clicks (those that bubble up past the action buttons,
-                which call ``stopClick``) so the user can click any
-                whitespace in the minimized strip to summon the full
-                pill. No ARIA role on the wrapper itself — that would
-                hide the descendant interactive controls (button,
-                textarea) from the accessibility tree. The dedicated
-                Send button already provides a keyboard-accessible
+            {/* Click-anywhere-to-expand on bare strip whitespace. Action
+                buttons call stopClick so they don't trigger this. No ARIA
+                role here — the Send button is the keyboard-accessible
                 "Expand input bar" affordance. */}
             <div
               onClick={minimized ? handleExpand : undefined}
@@ -629,69 +583,40 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
                 minimized ? 'cursor-text' : ''
               }`}
             >
-              <motion.div layout className="contents">
-                {attachEl}
-              </motion.div>
-              <motion.div layout className="contents">
-                {voiceEl}
-              </motion.div>
-              {/* Message slot grows to full-row when multi-line via
-                  ``basis-full``, which causes the parent
-                  ``flex-wrap`` to push the remaining buttons to a new
-                  line. The ``order`` keeps the textarea visually
-                  first when wrapped, and the buttons follow. */}
-              {/* Slot wrapper drives the textarea's width and its
-                  collapse-to-zero on minimize. The parent strip has
-                  ``gap-2`` (8px between every flex child); a 0-width
-                  slot still gets that gap on both sides, leaving a
-                  16px ghost gap between voice and send. ``-mx-1``
-                  (negative 4px each side) cancels the half-gap on
-                  each side so the minimized strip reads as a tight
-                  3-button row with no dead space.
-                  ``overflow-hidden`` clips the textarea content
-                  cleanly during the width tween. Multi-line uses
-                  ``basis-full`` to force a wrap onto a new row. */}
-              <motion.div
-                layout
+              {attachEl}
+              {voiceEl}
+              {/* Slot snaps w-0 ↔ flex-1 in lockstep with the card's
+                  w-fit ↔ w-full. ``-ml-2`` absorbs the parent gap-2
+                  when collapsed. */}
+              <div
+                style={{
+                  flexBasis: !minimized && isMultiLine ? '100%' : undefined,
+                  order: !minimized && isMultiLine ? -1 : 0,
+                }}
                 className={`min-w-0 overflow-hidden ${
-                  minimized
-                    ? '-mx-1 w-0 flex-none'
-                    : isMultiLine
-                      ? 'order-first basis-full'
-                      : 'flex-1'
+                  minimized ? 'w-0 -ml-2' : 'flex-1'
                 }`}
               >
                 {messageSlot}
-              </motion.div>
-              {/* Char count surfaces past the warn threshold in any
-                  expanded state — long messages typically wrap to
-                  multi-line in practice but the count is useful even
-                  in single-line for the rare edge case. */}
+              </div>
               {!minimized && showCharCount && (
-                <motion.span
-                  layout
+                <span
                   className={`shrink-0 font-mono text-xs ${
                     charCount > 2000 ? 'text-(--color-error)' : 'text-(--color-text-muted)'
                   }`}
                 >
                   {charCount}
-                </motion.span>
+                </span>
               )}
               {/* Spacer pushes Send to the right edge in multi-line. */}
-              {!minimized && isMultiLine && (
-                <motion.div layout className="flex-1" />
-              )}
-              <motion.div layout className="contents">
-                {sendOrStopEl}
-              </motion.div>
+              {!minimized && isMultiLine && <div className="flex-1" />}
+              {sendOrStopEl}
             </div>
           </motion.div>
         </div>
 
-        {/* File previews (below when floating near top) */}
         {!minimized && filesBelow && filePreviews}
 
-        {/* Hidden file input */}
         <input
           ref={fileInputRef}
           type="file"

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useImperativeHandle, forwardRef, useEffect, useMemo } from 'react'
 import { ArrowUp, Loader2, Paperclip, Square } from 'lucide-react'
+import { motion } from 'framer-motion'
 import { FilePreviewStrip } from './FilePreviewStrip'
 import { VoiceMicButton } from './VoiceMicButton'
 import type { AgentCapabilities } from '@/api/types'
@@ -48,6 +49,32 @@ interface InputBarProps {
    * When true the mic button records, transcribes, and appends to input.
    */
   voiceEnabled?: boolean
+  /**
+   * When true, render the slim icon-only collapsed bar (pencil
+   * `inputBar-collapsed-bar`, node `PKjWT`) instead of the full pill.
+   * Clicking the bar's chat affordance calls `onUnminimize` so the
+   * parent can swap back to the full variant and focus the textarea.
+   */
+  minimized?: boolean
+  /** Called when the user clicks the collapsed bar to expand it. */
+  onUnminimize?: () => void
+  /** Forwarded to the textarea so the parent can drive minimize-on-blur. */
+  onFocus?: () => void
+  /**
+   * Fired when the textarea blurs. ``canMinimize`` is ``false`` when the
+   * input has uncommitted content (text or attachments) the user would
+   * lose visual access to if the bar collapsed; the parent should keep
+   * the bar expanded in that case.
+   */
+  onBlur?: (canMinimize: boolean) => void
+  /**
+   * Called whenever uncommitted content (text or attachments) appears or
+   * disappears. The parent uses this to keep the bar expanded when the
+   * user adds files via the minimized strip's attach button — without
+   * this signal, dropping a file while collapsed would leave the bar
+   * collapsed and the new file invisible.
+   */
+  onHasContentChange?: (hasContent: boolean) => void
 }
 
 export interface InputBarHandle {
@@ -71,6 +98,11 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   filesBelow = false,
   renderDragHandle,
   voiceEnabled = false,
+  minimized = false,
+  onUnminimize,
+  onFocus,
+  onBlur,
+  onHasContentChange,
 }, ref) {
   const [value, setValue] = useState('')
   const [files, setFiles] = useState<File[]>([])
@@ -95,12 +127,53 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
     }
   }, [blobUrls])
 
+  // ``isMultiLine`` is updated as a side-effect of ``resize`` rather
+  // than a separate effect, so the DOM measurement and the React
+  // state stay in lock-step (one render cycle, no cascade).
+  //
+  // Hysteresis on the promote/demote decision:
+  //   - Promote (false → true): textarea's scrollHeight exceeds one
+  //     line height. Record the value length at the moment of
+  //     promotion in ``promoteLengthRef``.
+  //   - Demote (true → false): only when the value has no newlines
+  //     AND its length is now ≤ 80% of the recorded promote-length.
+  //     The 20% guard band absorbs the layout feedback loop where
+  //     promoting widens the textarea (so the same content fits on
+  //     one line again) which would otherwise demote → re-promote.
+  const [isMultiLine, setIsMultiLine] = useState(false)
+  const promoteLengthRef = useRef(0)
   const resize = useCallback(() => {
     const el = textareaRef.current
     if (!el) return
     el.style.height = 'auto'
     // max 6 rows ≈ 144px
     el.style.height = `${Math.min(el.scrollHeight, 144)}px`
+    const computed = window.getComputedStyle(el)
+    const lineHeight = parseFloat(computed.lineHeight) ||
+      parseFloat(computed.fontSize) * 1.5
+    const wrapped = el.scrollHeight > lineHeight * 1.4
+    const currentLen = el.value.length
+    const hasNewline = el.value.includes('\n')
+
+    setIsMultiLine((prev) => {
+      if (!prev && wrapped) {
+        // Promote: remember the length so we know when it's safe to
+        // demote later.
+        promoteLengthRef.current = currentLen
+        return true
+      }
+      if (prev && !wrapped && !hasNewline) {
+        // Demote candidate. Only commit if length has dropped clearly
+        // below the promote-length (80% threshold) — guards against
+        // the wrap-promote-rewrap loop in the boundary band.
+        const demoteThreshold = Math.floor(promoteLengthRef.current * 0.8)
+        if (currentLen <= demoteThreshold) {
+          promoteLengthRef.current = 0
+          return false
+        }
+      }
+      return prev
+    })
   }, [])
 
   useImperativeHandle(ref, () => ({
@@ -111,6 +184,30 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
       requestAnimationFrame(resize)
     },
   }))
+
+  // Auto-focus the textarea whenever the bar transitions from
+  // minimized → expanded. The textarea is always mounted (visibility
+  // is opacity-driven, not mount-driven) so the ref is reliably
+  // populated; we just need to call ``.focus()`` at the transition.
+  const prevMinimizedRef = useRef(minimized)
+  useEffect(() => {
+    const wasMinimized = prevMinimizedRef.current
+    prevMinimizedRef.current = minimized
+    if (!wasMinimized || minimized) return
+    // ``rAF`` lets framer's parent ``layout`` tween start before
+    // focus, so the caret doesn't appear mid-morph at the wrong
+    // position.
+    const id = requestAnimationFrame(() => {
+      textareaRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [minimized])
+
+  // Plain ref now — no auto-focus-on-mount magic needed since the
+  // textarea never unmounts.
+  const setTextareaRef = useCallback((node: HTMLTextAreaElement | null) => {
+    textareaRef.current = node
+  }, [])
 
   const submit = useCallback(() => {
     const trimmed = value.trim()
@@ -301,6 +398,19 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   const charCount = value.length
   const showCharCount = charCount > CHAR_WARN_THRESHOLD
 
+  // Surface "has uncommitted content" to the parent so a minimized bar
+  // can re-expand when the user attaches a file via the slim strip.
+  // Edge-triggered on the boolean — not on the underlying length values —
+  // so we only re-render the parent when crossing 0↔1.
+  const hasContent = hasText || files.length > 0
+  const lastHasContentRef = useRef(hasContent)
+  useEffect(() => {
+    if (lastHasContentRef.current !== hasContent) {
+      lastHasContentRef.current = hasContent
+      onHasContentChange?.(hasContent)
+    }
+  }, [hasContent, onHasContentChange])
+
   // Single-row, horizontally scrollable list so many attachments don't push
   // the input off-screen vertically. The strip owns its own scroll-position
   // hint (matches pencil's MultiAttachOverflow `attachmentScrollHint`).
@@ -319,14 +429,141 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   const actionBtnClass =
     'flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-(--color-border) bg-(--color-surface) text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:cursor-not-allowed disabled:opacity-50'
 
+  // ── Continuous-morph model ─────────────────────────────────────────
+  // The bar has three states that all share the same DOM tree:
+  //
+  //   Minimized:     [attach] [voice] [📝 message btn] [send-btn]
+  //   Expand 1-line: [attach] [voice] [textarea       ] [send]
+  //   Expand multi:  [textarea full-width             ]
+  //                  [attach] [voice]      [count] [send]
+  //
+  // The four buttons stay mounted in the same order in every state.
+  // The "message slot" (3rd child) morphs between an icon button and a
+  // textarea via framer-motion `layout` + AnimatePresence. In multi-
+  // line mode the textarea slot escapes to a full-width row above by
+  // setting `flex-basis: 100%` on its wrapper, which causes the
+  // wrapping flex row to wrap; the buttons settle on the second line
+  // automatically. No DOM reordering — just a width tween.
+  const handleExpand = () => {
+    onUnminimize?.()
+  }
+  const stopClick = (e: React.MouseEvent) => e.stopPropagation()
+
+  const attachEl = (
+    <button
+      type="button"
+      onClick={(e) => { stopClick(e); fileInputRef.current?.click() }}
+      disabled={disabled}
+      aria-label="Attach file"
+      title="Attach file (paste or drag)"
+      className={actionBtnClass}
+    >
+      <Paperclip size={14} aria-hidden="true" />
+    </button>
+  )
+
+  const voiceEl = (
+    <div onClick={stopClick}>
+      <VoiceMicButton
+        voiceEnabled={voiceEnabled}
+        onTranscript={handleVoiceTranscript}
+        disabled={disabled}
+      />
+    </div>
+  )
+
+  // Send/stop is a single 32×32 button matching the other action
+  // buttons. In minimized mode the click expands the bar instead of
+  // submitting (there's no text yet).
+  const sendOrStopEl = canStop && !hasText ? (
+    <button
+      type="button"
+      onClick={(e) => { stopClick(e); onStop?.() }}
+      aria-label="Stop generation"
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-(--color-error) bg-(--color-error) text-(--bg-page) transition-colors hover:opacity-90"
+    >
+      <Square size={12} fill="currentColor" />
+    </button>
+  ) : (
+    <button
+      type="button"
+      onClick={(e) => {
+        stopClick(e)
+        if (minimized) handleExpand()
+        else submit()
+      }}
+      disabled={!minimized && !canSend}
+      aria-label={minimized ? 'Expand input bar' : 'Send message'}
+      title={minimized ? 'Click to write' : 'Send (Enter) · New line (Shift+Enter) · Commands (/)'}
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-(--color-border) bg-(--color-surface) text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {disabled && !minimized ? (
+        <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+      ) : (
+        <ArrowUp size={14} aria-hidden="true" />
+      )}
+    </button>
+  )
+
+  // Message slot: just the textarea now. The slot's width is driven
+  // entirely by the parent ``motion.div`` wrapper — collapsed to 0
+  // when minimized (textarea slides out between voice and send), and
+  // ``flex-1`` / ``basis-full`` when expanded. The textarea is always
+  // mounted so the ref stays valid; ``opacity-0`` + ``pointer-events-
+  // none`` while minimized hides it without a remount-induced flicker.
+  // Send + click-anywhere on the strip already cover the "expand" tap
+  // target, so a dedicated message button would be redundant.
+  const messageSlot = (
+    <div
+      aria-hidden={minimized}
+      className={`flex w-full items-center transition-opacity duration-150 ${
+        minimized ? 'pointer-events-none opacity-0' : 'opacity-100'
+      }`}
+    >
+      <textarea
+        ref={setTextareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onFocus={onFocus}
+        onBlur={() => {
+          const canMinimize = value.trim().length === 0 && files.length === 0
+          onBlur?.(canMinimize)
+        }}
+        disabled={disabled || minimized}
+        placeholder={
+          // Clear the placeholder while minimizing so its faint
+          // ghost doesn't bleed through the slot opacity fade.
+          minimized
+            ? ''
+            : disabled
+              ? 'Waiting for response…'
+              : isStreaming
+                ? 'Type /stop to interrupt, or click stop…'
+                : placeholder
+        }
+        rows={1}
+        autoFocus={autoFocus}
+        tabIndex={minimized ? -1 : 0}
+        className="w-full resize-none bg-transparent text-sm leading-relaxed text-(--color-text) placeholder-(--color-text-subtle) focus:outline-none disabled:opacity-50"
+        style={{ maxHeight: '144px' }}
+        aria-label="Message input"
+      />
+    </div>
+  )
+
+  // ── Outer chrome — same in both variants so the AnimatePresence
+  //     swap doesn't reflow the page; only the inner pill changes.
   return (
     <div className={floating ? '' : 'border-t border-(--color-border) bg-(--bg-page) px-4 py-3'}>
       <div className={floating ? 'relative' : 'relative mx-auto max-w-3xl'}>
-        {/* File previews (above when docked at bottom) */}
-        {!filesBelow && filePreviews}
+        {/* File previews (above when docked at bottom) — only meaningful
+            in expanded mode; hidden during collapse to avoid orphaning. */}
+        {!minimized && !filesBelow && filePreviews}
 
         {/* Slash command menu — floating above the input */}
-        {slashMenuOpen && filteredSlashCommands.length > 0 && (
+        {!minimized && slashMenuOpen && filteredSlashCommands.length > 0 && (
           <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border-strong) bg-(--color-surface) shadow-md">
             {filteredSlashCommands.map((cmd, idx) => (
               <button
@@ -345,105 +582,114 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           </div>
         )}
 
-        {/* Input pill wrapper — anchors the drag handle to the input itself,
-            so it stays pinned to the pill regardless of file previews. */}
-        <div className="relative">
+        {/* Input pill wrapper — anchors the drag handle to the input
+            itself, so it stays pinned to the pill regardless of file
+            previews. ``flex justify-center`` so the self-sized minimized
+            strip centers within the panel rather than left-aligning. */}
+        <div className={`relative ${minimized ? 'flex justify-center' : ''}`}>
           {renderDragHandle?.()}
-
-          {/* Input container — pencil structure: text on top, action row below.
-              Border + drop shadow + --color-surface fill match pencil's
-              `inputBar-*-bar` frame across all variants. */}
-          <div
-            className="relative flex flex-col gap-2.5 rounded-lg border border-(--color-border-strong) bg-(--color-surface) p-3.5 shadow-md transition-all focus-within:ring-1 focus-within:ring-(--color-accent)"
+          {/* Continuous-morph card. Padding and width are animated as
+              numeric motion values so framer has a smooth tween across
+              minimized ↔ expanded (the Tailwind class swap is reserved
+              for color/shadow which don't affect layout).
+              ``flex-wrap`` is the trick that powers single ↔ multi-line:
+              when the textarea slot's flex-basis hits 100%, it forces
+              its row to wrap and the four buttons land on the line
+              below. No reordering. */}
+          <motion.div
+            initial={false}
+            animate={{
+              padding: minimized ? 6 : 14,
+              width: minimized ? 'auto' : '100%',
+            }}
+            transition={{ duration: 0.24, ease: [0.32, 0.72, 0, 1] }}
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
+            className={`relative ${minimized ? 'inline-block' : 'block'} rounded-lg border bg-(--color-surface) shadow-sm transition-[border-color,box-shadow,background-color] duration-200 ${
+              minimized
+                ? 'border-(--color-border) hover:bg-(--bg-key)'
+                : 'border-(--color-border-strong) shadow-md focus-within:ring-1 focus-within:ring-(--color-accent)'
+            }`}
+            style={{ willChange: 'padding, width' }}
           >
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={handleChange}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
-              disabled={disabled}
-              placeholder={
-                disabled
-                  ? 'Waiting for response…'
-                  : isStreaming
-                    ? 'Type /stop to interrupt, or click stop…'
-                    : placeholder
-              }
-              rows={1}
-              autoFocus={autoFocus}
-              className="w-full resize-none bg-transparent text-sm leading-relaxed text-(--color-text) placeholder-(--color-text-subtle) focus:outline-none disabled:opacity-50"
-              style={{ maxHeight: '144px' }}
-              aria-label="Message input"
-            />
-
-            {/* Action row: [attach] [mic] [spacer] [count?] [send] */}
-            <div className="flex items-center gap-2">
-              {/* Attachment button */}
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                disabled={disabled}
-                aria-label="Attach file"
-                title="Attach file (paste or drag)"
-                className={actionBtnClass}
+            {/* Click-anywhere-to-expand: the wrapper handles bare
+                clicks (those that bubble up past the action buttons,
+                which call ``stopClick``) so the user can click any
+                whitespace in the minimized strip to summon the full
+                pill. No ARIA role on the wrapper itself — that would
+                hide the descendant interactive controls (button,
+                textarea) from the accessibility tree. The dedicated
+                Send button already provides a keyboard-accessible
+                "Expand input bar" affordance. */}
+            <div
+              onClick={minimized ? handleExpand : undefined}
+              className={`flex w-full flex-wrap items-center gap-2 ${
+                minimized ? 'cursor-text' : ''
+              }`}
+            >
+              <motion.div layout className="contents">
+                {attachEl}
+              </motion.div>
+              <motion.div layout className="contents">
+                {voiceEl}
+              </motion.div>
+              {/* Message slot grows to full-row when multi-line via
+                  ``basis-full``, which causes the parent
+                  ``flex-wrap`` to push the remaining buttons to a new
+                  line. The ``order`` keeps the textarea visually
+                  first when wrapped, and the buttons follow. */}
+              {/* Slot wrapper drives the textarea's width and its
+                  collapse-to-zero on minimize. The parent strip has
+                  ``gap-2`` (8px between every flex child); a 0-width
+                  slot still gets that gap on both sides, leaving a
+                  16px ghost gap between voice and send. ``-mx-1``
+                  (negative 4px each side) cancels the half-gap on
+                  each side so the minimized strip reads as a tight
+                  3-button row with no dead space.
+                  ``overflow-hidden`` clips the textarea content
+                  cleanly during the width tween. Multi-line uses
+                  ``basis-full`` to force a wrap onto a new row. */}
+              <motion.div
+                layout
+                className={`min-w-0 overflow-hidden ${
+                  minimized
+                    ? '-mx-1 w-0 flex-none'
+                    : isMultiLine
+                      ? 'order-first basis-full'
+                      : 'flex-1'
+                }`}
               >
-                <Paperclip size={14} />
-              </button>
-
-              {/* Voice mic button */}
-              <VoiceMicButton
-                voiceEnabled={voiceEnabled}
-                onTranscript={handleVoiceTranscript}
-                disabled={disabled}
-              />
-
-              <div className="flex-1" />
-
-              {/* Character count */}
-              {showCharCount && (
-                <span
+                {messageSlot}
+              </motion.div>
+              {/* Char count surfaces past the warn threshold in any
+                  expanded state — long messages typically wrap to
+                  multi-line in practice but the count is useful even
+                  in single-line for the rare edge case. */}
+              {!minimized && showCharCount && (
+                <motion.span
+                  layout
                   className={`shrink-0 font-mono text-xs ${
                     charCount > 2000 ? 'text-(--color-error)' : 'text-(--color-text-muted)'
                   }`}
                 >
                   {charCount}
-                </span>
+                </motion.span>
               )}
-
-              {/* Send / Stop button — pill (padding [8,14]) per pencil */}
-              {canStop && !hasText ? (
-                <button
-                  onClick={onStop}
-                  aria-label="Stop generation"
-                  className="flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--color-error) bg-(--color-error) px-3.5 text-(--bg-page) shadow-sm transition-all hover:opacity-90"
-                >
-                  <Square size={12} fill="currentColor" />
-                </button>
-              ) : (
-                <button
-                  onClick={submit}
-                  disabled={!canSend}
-                  aria-label="Send message"
-                  title="Send (Enter) · New line (Shift+Enter) · Commands (/)"
-                  className="flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--color-border-strong) bg-(--color-surface) px-3.5 text-(--color-text) shadow-sm transition-all hover:bg-(--bg-key) disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {disabled ? (
-                    <Loader2 size={14} className="animate-spin" />
-                  ) : (
-                    <ArrowUp size={14} />
-                  )}
-                </button>
+              {/* Spacer pushes Send to the right edge in multi-line. */}
+              {!minimized && isMultiLine && (
+                <motion.div layout className="flex-1" />
               )}
+              <motion.div layout className="contents">
+                {sendOrStopEl}
+              </motion.div>
             </div>
-          </div>
+          </motion.div>
         </div>
 
         {/* File previews (below when floating near top) */}
-        {filesBelow && filePreviews}
+        {!minimized && filesBelow && filePreviews}
 
         {/* Hidden file input */}
         <input

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -346,6 +346,12 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
     </div>
   ) : null
 
+  // Reusable pill button styles for the action row (attach, mic — pencil
+  // calls these `inputBarAttach`, `inputBarMic`: 32×32, rounded-sm border,
+  // --color-surface fill).
+  const actionBtnClass =
+    'flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-(--color-border) bg-(--color-surface) text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:cursor-not-allowed disabled:opacity-50'
+
   return (
     <div className={floating ? '' : 'border-t border-(--color-border) bg-(--bg-page) px-4 py-3'}>
       <div className={floating ? 'relative' : 'relative mx-auto max-w-3xl'}>
@@ -354,7 +360,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
 
         {/* Slash command menu — floating above the input */}
         {slashMenuOpen && filteredSlashCommands.length > 0 && (
-          <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border) bg-(--bg-key) shadow-lg">
+          <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border-strong) bg-(--color-surface) shadow-md">
             {filteredSlashCommands.map((cmd, idx) => (
               <button
                 key={cmd.id}
@@ -377,93 +383,96 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
         <div className="relative">
           {renderDragHandle?.()}
 
-        {/* Input container */}
-        <div
-          className={`relative flex items-center gap-2 rounded-2xl border border-(--color-border) px-4 py-2.5 transition-all focus-within:border-(--color-accent) focus-within:ring-1 focus-within:ring-(--bg-key) ${
-            floating
-              ? 'bg-(--bg-key)/20 shadow-xl backdrop-blur-xl'
-              : 'bg-(--bg-key)'
-          }`}
-          onDragEnter={handleDragEnter}
-          onDragLeave={handleDragLeave}
-          onDragOver={handleDragOver}
-          onDrop={handleDrop}
-        >
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            disabled={disabled}
-            placeholder={
-              disabled
-                ? 'Waiting for response…'
-                : isStreaming
-                  ? 'Type /stop to interrupt, or click stop…'
-                  : placeholder
-            }
-            rows={1}
-            autoFocus={autoFocus}
-            className="flex-1 resize-none bg-transparent py-1 text-sm leading-relaxed text-(--color-text) placeholder-(--color-text-muted) focus:outline-none disabled:opacity-50"
-            style={{ maxHeight: '144px' }}
-            aria-label="Message input"
-          />
-
-          {/* Character count */}
-          {showCharCount && (
-            <span
-              className={`shrink-0 self-end pb-1 text-xs ${
-                charCount > 2000 ? 'text-(--color-error)' : 'text-(--color-text-muted)'
-              }`}
-            >
-              {charCount}
-            </span>
-          )}
-
-          {/* Attachment button */}
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={disabled}
-            aria-label="Attach file"
-            title="Attach file (paste or drag)"
-            className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:opacity-25"
+          {/* Input container — pencil structure: text on top, action row below.
+              Border + drop shadow + --color-surface fill match pencil's
+              `inputBar-*-bar` frame across all variants. */}
+          <div
+            className="relative flex flex-col gap-2.5 rounded-lg border border-(--color-border-strong) bg-(--color-surface) p-3.5 shadow-md transition-all focus-within:ring-1 focus-within:ring-(--color-accent)"
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
           >
-            <Paperclip size={14} />
-          </button>
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              disabled={disabled}
+              placeholder={
+                disabled
+                  ? 'Waiting for response…'
+                  : isStreaming
+                    ? 'Type /stop to interrupt, or click stop…'
+                    : placeholder
+              }
+              rows={1}
+              autoFocus={autoFocus}
+              className="w-full resize-none bg-transparent text-sm leading-relaxed text-(--color-text) placeholder-(--color-text-subtle) focus:outline-none disabled:opacity-50"
+              style={{ maxHeight: '144px' }}
+              aria-label="Message input"
+            />
 
-          {/* Voice mic button */}
-          <VoiceMicButton
-            voiceEnabled={voiceEnabled}
-            onTranscript={handleVoiceTranscript}
-            disabled={disabled}
-          />
+            {/* Action row: [attach] [mic] [spacer] [count?] [send] */}
+            <div className="flex items-center gap-2">
+              {/* Attachment button */}
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={disabled}
+                aria-label="Attach file"
+                title="Attach file (paste or drag)"
+                className={actionBtnClass}
+              >
+                <Paperclip size={14} />
+              </button>
 
-          {/* Send / Stop button */}
-          {canStop && !hasText ? (
-            <button
-              onClick={onStop}
-              aria-label="Stop generation"
-              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-error) text-(--bg-page) shadow-sm transition-all hover:opacity-80 hover:shadow-md"
-            >
-              <Square size={12} fill="currentColor" />
-            </button>
-          ) : (
-            <button
-              onClick={submit}
-              disabled={!canSend}
-              aria-label="Send message"
-              title="Send (Enter) · New line (Shift+Enter) · Commands (/)"
-              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-accent) text-(--bg-page) shadow-sm transition-all hover:bg-(--color-accent) hover:shadow-md disabled:cursor-not-allowed disabled:opacity-25"
-            >
-              {disabled ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <ArrowUp size={14} />
+              {/* Voice mic button */}
+              <VoiceMicButton
+                voiceEnabled={voiceEnabled}
+                onTranscript={handleVoiceTranscript}
+                disabled={disabled}
+              />
+
+              <div className="flex-1" />
+
+              {/* Character count */}
+              {showCharCount && (
+                <span
+                  className={`shrink-0 font-mono text-xs ${
+                    charCount > 2000 ? 'text-(--color-error)' : 'text-(--color-text-muted)'
+                  }`}
+                >
+                  {charCount}
+                </span>
               )}
-            </button>
-          )}
-        </div>
+
+              {/* Send / Stop button — pill (padding [8,14]) per pencil */}
+              {canStop && !hasText ? (
+                <button
+                  onClick={onStop}
+                  aria-label="Stop generation"
+                  className="flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--color-error) bg-(--color-error) px-3.5 text-(--bg-page) shadow-sm transition-all hover:opacity-90"
+                >
+                  <Square size={12} fill="currentColor" />
+                </button>
+              ) : (
+                <button
+                  onClick={submit}
+                  disabled={!canSend}
+                  aria-label="Send message"
+                  title="Send (Enter) · New line (Shift+Enter) · Commands (/)"
+                  className="flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-(--color-border-strong) bg-(--color-surface) px-3.5 text-(--color-text) shadow-sm transition-all hover:bg-(--bg-key) disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {disabled ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <ArrowUp size={14} />
+                  )}
+                </button>
+              )}
+            </div>
+          </div>
         </div>
 
         {/* File previews (below when floating near top) */}

--- a/web/src/components/InputBar.tsx
+++ b/web/src/components/InputBar.tsx
@@ -347,22 +347,22 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   ) : null
 
   return (
-    <div className={floating ? '' : 'border-t border-(--color-border) bg-(--color-bg) px-4 py-3'}>
+    <div className={floating ? '' : 'border-t border-(--color-border) bg-(--bg-page) px-4 py-3'}>
       <div className={floating ? 'relative' : 'relative mx-auto max-w-3xl'}>
         {/* File previews (above when docked at bottom) */}
         {!filesBelow && filePreviews}
 
         {/* Slash command menu — floating above the input */}
         {slashMenuOpen && filteredSlashCommands.length > 0 && (
-          <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border) bg-(--color-surface-2) shadow-lg">
+          <div className="absolute bottom-full left-0 right-0 z-10 mb-1 overflow-hidden rounded-lg border border-(--color-border) bg-(--bg-key) shadow-lg">
             {filteredSlashCommands.map((cmd, idx) => (
               <button
                 key={cmd.id}
                 onMouseDown={(e) => { e.preventDefault(); executeSlashCommand(cmd) }}
                 className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
                   idx === clampedIndex
-                    ? 'bg-(--color-accent-subtle) text-(--color-text)'
-                    : 'text-(--color-text-muted) hover:bg-(--color-accent-dim)'
+                    ? 'bg-(--bg-key) text-(--color-text)'
+                    : 'text-(--color-text-muted) hover:bg-(--bg-key)'
                 }`}
               >
                 <span className="font-mono text-xs text-(--color-accent)">/{cmd.id}</span>
@@ -379,10 +379,10 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
 
         {/* Input container */}
         <div
-          className={`relative flex items-center gap-2 rounded-2xl border border-(--color-border) px-4 py-2.5 transition-all focus-within:border-(--color-accent) focus-within:ring-1 focus-within:ring-(--color-accent-subtle) ${
+          className={`relative flex items-center gap-2 rounded-2xl border border-(--color-border) px-4 py-2.5 transition-all focus-within:border-(--color-accent) focus-within:ring-1 focus-within:ring-(--bg-key) ${
             floating
-              ? 'bg-(--color-surface-2)/20 shadow-xl backdrop-blur-xl'
-              : 'bg-(--color-surface-2)'
+              ? 'bg-(--bg-key)/20 shadow-xl backdrop-blur-xl'
+              : 'bg-(--bg-key)'
           }`}
           onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}
@@ -427,7 +427,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
             disabled={disabled}
             aria-label="Attach file"
             title="Attach file (paste or drag)"
-            className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text) disabled:opacity-25"
+            className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:opacity-25"
           >
             <Paperclip size={14} />
           </button>
@@ -444,7 +444,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
             <button
               onClick={onStop}
               aria-label="Stop generation"
-              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-error) text-(--color-bg) shadow-sm transition-all hover:opacity-80 hover:shadow-md"
+              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-error) text-(--bg-page) shadow-sm transition-all hover:opacity-80 hover:shadow-md"
             >
               <Square size={12} fill="currentColor" />
             </button>
@@ -454,7 +454,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
               disabled={!canSend}
               aria-label="Send message"
               title="Send (Enter) · New line (Shift+Enter) · Commands (/)"
-              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-accent) text-(--color-bg) shadow-sm transition-all hover:bg-(--color-accent-hover) hover:shadow-md disabled:cursor-not-allowed disabled:opacity-25"
+              className="flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full bg-(--color-accent) text-(--bg-page) shadow-sm transition-all hover:bg-(--color-accent) hover:shadow-md disabled:cursor-not-allowed disabled:opacity-25"
             >
               {disabled ? (
                 <Loader2 size={14} className="animate-spin" />

--- a/web/src/components/PendingMessageQueue.tsx
+++ b/web/src/components/PendingMessageQueue.tsx
@@ -30,7 +30,7 @@ export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -4, scale: 0.97 }}
             transition={{ duration: 0.15 }}
-            className="flex items-center gap-2 rounded-xl border border-(--color-border) bg-(--color-surface-2)/60 px-3 py-2 shadow-sm backdrop-blur-sm"
+            className="flex items-center gap-2 rounded-xl border border-(--color-border) bg-(--bg-key)/60 px-3 py-2 shadow-sm backdrop-blur-sm"
           >
             <Clock size={12} className="shrink-0 text-(--color-text-muted)" aria-hidden="true" />
 
@@ -39,7 +39,7 @@ export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
             </span>
 
             {msg.files && msg.files.length > 0 && (
-              <span className="shrink-0 rounded-full bg-(--color-accent-subtle) px-1.5 py-0.5 text-[10px] text-(--color-accent)">
+              <span className="shrink-0 rounded-full bg-(--bg-key) px-1.5 py-0.5 text-[10px] text-(--color-accent)">
                 +{msg.files.length}
               </span>
             )}
@@ -48,7 +48,7 @@ export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
               onClick={() => handleRemove(msg.id, msg.content)}
               aria-label="Cancel queued message and restore to input"
               title="Cancel — restore to input"
-              className="shrink-0 rounded-full p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+              className="shrink-0 rounded-full p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             >
               <X size={12} />
             </button>

--- a/web/src/components/PendingMessageQueue.tsx
+++ b/web/src/components/PendingMessageQueue.tsx
@@ -47,7 +47,7 @@ export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
             </span>
 
             {msg.files && msg.files.length > 0 && (
-              <span className="shrink-0 rounded-full bg-(--bg-key) px-1.5 py-0.5 text-[10px] text-(--color-accent)">
+              <span className="shrink-0 rounded-md bg-(--bg-key) px-1.5 py-0.5 text-[10px] text-(--color-accent)">
                 +{msg.files.length}
               </span>
             )}

--- a/web/src/components/PendingMessageQueue.tsx
+++ b/web/src/components/PendingMessageQueue.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { X, Clock } from 'lucide-react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useTeamStore } from '@/stores/useTeamStore'
+import { QueueBanner } from './ui/queue-banner'
 import type { InputBarHandle } from './InputBar'
 
 interface PendingMessageQueueProps {
@@ -11,6 +13,7 @@ interface PendingMessageQueueProps {
 export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
   const messages = useTeamStore((s) => s._pendingMessages)
   const removePendingMessage = useTeamStore((s) => s.removePendingMessage)
+  const [expanded, setExpanded] = useState(true)
 
   if (messages.length === 0) return null
 
@@ -21,9 +24,14 @@ export function PendingMessageQueue({ inputRef }: PendingMessageQueueProps) {
   }
 
   return (
-    <div className="mb-2 flex flex-col gap-1 px-1">
+    <div className="mb-2 flex flex-col gap-1.5 px-1">
+      <QueueBanner
+        count={messages.length}
+        expanded={expanded}
+        onToggle={() => setExpanded((v) => !v)}
+      />
       <AnimatePresence initial={false}>
-        {messages.map((msg) => (
+        {expanded && messages.map((msg) => (
           <motion.div
             key={msg.id}
             initial={{ opacity: 0, y: 6, scale: 0.97 }}

--- a/web/src/components/SchedulerPanel.tsx
+++ b/web/src/components/SchedulerPanel.tsx
@@ -291,7 +291,7 @@ function TaskListItem({
             {formatScheduleLabel(task)}
           </p>
           <div className="mt-1 flex items-center gap-2">
-            <span className="inline-block rounded-full bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-accent)">
+            <span className="inline-block rounded-md bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-accent)">
               {task.agent}
             </span>
             <span className={`text-xs font-medium ${statusColor}`}>{task.status}</span>

--- a/web/src/components/SchedulerPanel.tsx
+++ b/web/src/components/SchedulerPanel.tsx
@@ -5,7 +5,7 @@
  * backdrop click to close, and X close button.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X, Clock, Play, Pause, Trash2, Plus, Loader2, AlertCircle, CalendarClock, Zap, ArrowLeft, Pencil } from 'lucide-react'
 import { format } from 'date-fns'
@@ -14,7 +14,6 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   useScheduledTasksQuery,
   useCreateScheduledTaskMutation,
@@ -35,6 +34,64 @@ interface SchedulerPanelProps {
 }
 
 // ── Shared utility ──────────────────────────────────────────────────────────
+
+// Form fields sit on a bg-(--bg-card) panel; the shared <Input>/<Textarea>/
+// <SelectTrigger> primitives default to bg-transparent which leaves them
+// indistinguishable from the parent. Give them an explicit fillable surface
+// so the controls read as inputs.
+const FIELD_CLASS = 'bg-(--bg-page) dark:bg-(--bg-page)'
+
+// Inline className for SelectContent — the global default (`bg-popover`)
+// resolves to `--bg-card`, the same surface as this drawer, so the dropdown
+// looks like an outlined frame floating on the same paper. Use the page
+// surface for clear contrast and soften the border.
+const SELECT_CONTENT_CLASS = 'bg-(--bg-page) border-(--color-border-strong)'
+
+// Three-option segmented control used for "Schedule type". The shared Tabs
+// primitive inverts in light mode (track = bg-key which is darker than the
+// active bg-background = bg-page), so we render a flat row of buttons that
+// match the rest of this drawer's surfaces.
+function ScheduleTypeSegmented({
+  value,
+  onChange,
+}: {
+  value: ScheduledTaskCreate['schedule_type']
+  onChange: (v: ScheduledTaskCreate['schedule_type']) => void
+}) {
+  const options: { key: ScheduledTaskCreate['schedule_type']; label: string }[] = [
+    { key: 'every', label: 'Every' },
+    { key: 'cron', label: 'Cron' },
+    { key: 'at', label: 'At' },
+  ]
+  return (
+    <div
+      role="tablist"
+      aria-label="Schedule type"
+      className="mt-2 flex w-full gap-1 rounded-md border border-(--color-border) bg-(--bg-page) p-1"
+    >
+      {options.map((opt) => {
+        const active = value === opt.key
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(opt.key)}
+            className={
+              'flex-1 rounded-sm px-2 py-1 text-xs font-medium transition-colors ' +
+              (active
+                ? 'bg-(--bg-card) text-(--color-text) shadow-sm ring-1 ring-(--color-border-strong)'
+                : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text-2)')
+            }
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 function formatScheduleLabel(task: Pick<ScheduledTaskResponse, 'schedule_type' | 'at_datetime' | 'every_seconds' | 'cron_expression'>): string {
   if (task.schedule_type === 'at' && task.at_datetime) {
@@ -68,6 +125,26 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
   const tasksQuery = useScheduledTasksQuery()
   const agentsQuery = useTeamAgentsQuery()
 
+  // Refresh on open — the drawer is mounted persistently so AnimatePresence
+  // can play exit animations; without this the list goes stale on reopen.
+  useEffect(() => {
+    if (open) {
+      tasksQuery.refetch()
+      agentsQuery.refetch()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Close on Escape (only while open) — matches AgentCapabilities drawer.
+  useEffect(() => {
+    if (!open) return
+    const h = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', h)
+    return () => window.removeEventListener('keydown', h)
+  }, [open, onClose])
+
   const tasks = tasksQuery.data?.tasks ?? []
   const agents = agentsQuery.data?.agents ?? []
 
@@ -89,6 +166,13 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
     if (isMobile) setMobilePane('list')
   }
 
+  // When a task is deleted from the list, drop the selection if it was the
+  // currently-selected one — otherwise the detail pane (mobile especially)
+  // would render an empty state until the user navigates back manually.
+  const handleTaskDeleted = (id: string) => {
+    if (selectedTaskId === id) handleCloseDetail()
+  }
+
   const handleOpenCreate = () => {
     if (isMobile) setMobilePane('create')
   }
@@ -106,6 +190,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
       {open && (
         <>
           <motion.div
+            key="backdrop"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -114,21 +199,25 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
             className="fixed inset-0 z-40 bg-black/40"
           />
 
-          <motion.div
+          <motion.aside
+            key="drawer"
             initial={{ x: '100%', opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '100%', opacity: 0 }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
-            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden bg-(--bg-card) shadow-2xl"
+            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden border-l border-(--color-border) bg-(--bg-card) shadow-2xl"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Scheduled tasks"
           >
             {/* Header */}
-            <header className="flex items-center justify-between border-b border-(--color-border) px-4 py-3">
+            <header className="flex shrink-0 items-center justify-between gap-3 border-b border-(--color-border) px-5 py-4">
               <div className="flex min-w-0 flex-1 items-center gap-2">
                 {/* Mobile back button — shown in detail/create pane */}
                 {isMobile && mobilePane !== 'list' && (
                   <button
                     onClick={handleBackToList}
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
+                    className="shrink-0 rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
                     aria-label="Back to task list"
                   >
                     <ArrowLeft size={14} />
@@ -137,15 +226,15 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
                 <div className="flex min-w-0 items-center gap-2">
                   <CalendarClock size={18} className="shrink-0 text-(--color-accent)" />
                   <div className="min-w-0">
-                    <h2 className="text-sm font-semibold text-(--color-text)">
-                      {isMobile && mobilePane === 'detail' && selectedTask
-                        ? selectedTask.name
-                        : isMobile && mobilePane === 'create'
-                          ? 'Create Task'
+                    <h2 className="truncate text-base font-semibold text-(--color-text)">
+                      {isMobile && mobilePane === 'create'
+                        ? 'Create Task'
+                        : isMobile && mobilePane === 'detail'
+                          ? (selectedTask?.name ?? 'Task')
                           : 'Scheduled Tasks'}
                     </h2>
                     {(!isMobile || mobilePane === 'list') && (
-                      <p className="text-xs text-(--color-text-subtle)">
+                      <p className="mt-0.5 truncate text-xs text-(--color-text-muted)">
                         Manage cron and scheduled agent tasks
                       </p>
                     )}
@@ -155,24 +244,23 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
               <div className="flex shrink-0 items-center gap-1">
                 {/* Mobile: Create button shown in list pane */}
                 {isMobile && mobilePane === 'list' && (
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
+                  <button
                     onClick={handleOpenCreate}
+                    className="rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
                     aria-label="Create new task"
                     title="Create task"
                   >
                     <Plus size={16} />
-                  </Button>
+                  </button>
                 )}
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
+                <button
                   onClick={onClose}
+                  className="rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
                   aria-label="Close scheduler panel"
+                  title="Close (Esc)"
                 >
                   <X size={16} />
-                </Button>
+                </button>
               </div>
             </header>
 
@@ -184,6 +272,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
                   {/* Search bar */}
                   <div className="border-b border-(--color-border) p-3">
                     <Input
+                      className={FIELD_CLASS}
                       placeholder="Search tasks…"
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
@@ -221,6 +310,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
                             task={task}
                             isSelected={selectedTaskId === task.id}
                             onSelect={() => handleSelectTask(task.id)}
+                            onDeleted={() => handleTaskDeleted(task.id)}
                           />
                         ))}
                       </div>
@@ -244,7 +334,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
                 </div>
               )}
             </div>
-          </motion.div>
+          </motion.aside>
         </>
       )}
     </AnimatePresence>
@@ -257,10 +347,12 @@ function TaskListItem({
   task,
   isSelected,
   onSelect,
+  onDeleted,
 }: {
   task: ScheduledTaskResponse
   isSelected: boolean
   onSelect: () => void
+  onDeleted: () => void
 }) {
   const deleteMutation = useDeleteScheduledTaskMutation()
   const pauseMutation = usePauseScheduledTaskMutation()
@@ -281,7 +373,7 @@ function TaskListItem({
       className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
         isSelected
           ? 'border-(--color-accent) bg-(--bg-key)'
-          : 'border-(--color-border) bg-(--bg-key) hover:border-(--color-border-strong)'
+          : 'border-(--color-border) bg-(--bg-page) hover:border-(--color-border-strong)'
       }`}
     >
       <div className="flex items-start justify-between gap-2">
@@ -291,7 +383,7 @@ function TaskListItem({
             {formatScheduleLabel(task)}
           </p>
           <div className="mt-1 flex items-center gap-2">
-            <span className="inline-block rounded-md bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-accent)">
+            <span className="inline-flex items-center rounded-md bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-text-2) ring-1 ring-(--color-border-strong)">
               {task.agent}
             </span>
             <span className={`text-xs font-medium ${statusColor}`}>{task.status}</span>
@@ -352,7 +444,7 @@ function TaskListItem({
             onClick={(e) => {
               e.stopPropagation()
               if (confirm(`Delete task "${task.name}"?`)) {
-                deleteMutation.mutate(task.id)
+                deleteMutation.mutate(task.id, { onSuccess: onDeleted })
               }
             }}
             disabled={deleteMutation.isPending}
@@ -449,21 +541,21 @@ function CreateTaskForm({
   return (
     <div className="flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="border-b border-(--color-border) px-6 py-4">
+      <div className="border-b border-(--color-border) px-5 py-4">
         <div className="flex items-center gap-2">
           <Plus size={18} className="text-(--color-accent)" />
-          <h2 className="text-lg font-semibold text-(--color-text)">Create Task</h2>
+          <h2 className="text-base font-semibold text-(--color-text)">Create Task</h2>
         </div>
       </div>
 
       {/* Form */}
-      <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto p-6">
+      <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto px-5 py-4">
         <div className="space-y-4">
           {/* Name */}
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Task Name</label>
             <Input
-              className="mt-1"
+              className={`mt-1 ${FIELD_CLASS}`}
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               placeholder="e.g., Daily Report"
@@ -477,10 +569,10 @@ function CreateTaskForm({
               value={formData.agent ?? ''}
               onValueChange={(v) => { if (v) setFormData({ ...formData, agent: v }) }}
             >
-              <SelectTrigger className="mt-1 w-full">
+              <SelectTrigger className={`mt-1 w-full ${FIELD_CLASS}`}>
                 <SelectValue placeholder="Select agent" />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className={SELECT_CONTENT_CLASS}>
                 {agents.map((agent) => (
                   <SelectItem key={agent.name} value={agent.name}>
                     {agent.name}
@@ -493,19 +585,10 @@ function CreateTaskForm({
           {/* Schedule Type */}
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Schedule Type</label>
-            <Tabs
+            <ScheduleTypeSegmented
               value={formData.schedule_type}
-              onValueChange={(v) =>
-                setFormData({ ...formData, schedule_type: v as ScheduledTaskCreate['schedule_type'] })
-              }
-              className="mt-2"
-            >
-              <TabsList className="w-full">
-                <TabsTrigger value="every" className="flex-1">Every</TabsTrigger>
-                <TabsTrigger value="cron" className="flex-1">Cron</TabsTrigger>
-                <TabsTrigger value="at" className="flex-1">At</TabsTrigger>
-              </TabsList>
-            </Tabs>
+              onChange={(v) => setFormData({ ...formData, schedule_type: v })}
+            />
           </div>
 
           {/* Schedule value (conditional) */}
@@ -518,13 +601,14 @@ function CreateTaskForm({
                     <DateTimePicker
                       value={formData.at_datetime ?? ''}
                       onChange={(v) => setFormData({ ...formData, at_datetime: v })}
+                      triggerClassName="bg-(--bg-page) hover:bg-(--bg-page)"
                     />
                   </div>
                 </div>
                 <div className="w-44 shrink-0">
                   <label className="block text-sm font-medium text-(--color-text)">Timezone</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.timezone}
                     onChange={(e) => setFormData({ ...formData, timezone: e.target.value })}
                     placeholder={localTz}
@@ -539,7 +623,7 @@ function CreateTaskForm({
             <div>
               <label className="block text-sm font-medium text-(--color-text)">Interval (seconds)</label>
               <Input
-                className="mt-1"
+                className={`mt-1 ${FIELD_CLASS}`}
                 type="number"
                 min="1"
                 value={formData.every_seconds ?? 3600}
@@ -557,7 +641,7 @@ function CreateTaskForm({
                 <div className="flex-1">
                   <label className="block text-sm font-medium text-(--color-text)">Cron Expression</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.cron_expression ?? ''}
                     onChange={(e) => setFormData({ ...formData, cron_expression: e.target.value })}
                     placeholder="e.g., 0 9 * * MON-FRI"
@@ -566,7 +650,7 @@ function CreateTaskForm({
                 <div className="w-44 shrink-0">
                   <label className="block text-sm font-medium text-(--color-text)">Timezone</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.timezone}
                     onChange={(e) => setFormData({ ...formData, timezone: e.target.value })}
                     placeholder={localTz}
@@ -581,7 +665,7 @@ function CreateTaskForm({
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Prompt</label>
             <Textarea
-              className="mt-1"
+              className={`mt-1 ${FIELD_CLASS}`}
               value={formData.prompt}
               onChange={(e) => setFormData({ ...formData, prompt: e.target.value })}
               placeholder="What should the agent do?"
@@ -593,7 +677,7 @@ function CreateTaskForm({
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Session ID (optional)</label>
             <Input
-              className="mt-1"
+              className={`mt-1 ${FIELD_CLASS}`}
               value={formData.session_id ?? ''}
               onChange={(e) => setFormData({ ...formData, session_id: e.target.value || null })}
               placeholder="Leave blank for new session, or enter 'auto'"
@@ -670,147 +754,162 @@ function TaskDetailView({
   return (
     <div className="flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="border-b border-(--color-border) px-6 py-4">
-        <div className="flex items-start justify-between gap-4">
+      <div className="border-b border-(--color-border) px-5 py-4">
+        <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <h2 className="truncate text-lg font-semibold text-(--color-text)">{task.name}</h2>
+            <h2 className="truncate text-base font-semibold text-(--color-text)">{task.name}</h2>
             <p className="mt-1 text-sm text-(--color-text-muted)">{formatScheduleLabel(task)}</p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            <Button variant="ghost" size="icon-sm" onClick={() => setEditing(true)} title="Edit task">
+            <button
+              onClick={() => setEditing(true)}
+              className="rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
+              aria-label="Edit task"
+              title="Edit task"
+            >
               <Pencil size={16} />
-            </Button>
-            <Button variant="ghost" size="icon-sm" onClick={onClose} title="Close">
+            </button>
+            <button
+              onClick={onClose}
+              className="rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
+              aria-label="Close detail"
+              title="Close"
+            >
               <X size={16} />
-            </Button>
+            </button>
           </div>
         </div>
       </div>
 
-      {/* Content */}
-      <div className="flex-1 overflow-y-auto p-6">
-        <div className="space-y-6">
-          {/* Status section */}
-          <div>
-            <h3 className="text-sm font-semibold text-(--color-text)">Status</h3>
-            <div className="mt-2 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-(--color-text-muted)">Current</span>
-                <span className={`text-sm font-medium ${statusColor}`}>{task.status}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-(--color-text-muted)">Enabled</span>
-                <span className="text-sm text-(--color-text)">{task.enabled ? 'Yes' : 'No'}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-(--color-text-muted)">Run Count</span>
-                <span className="text-sm text-(--color-text)">{task.run_count}</span>
-              </div>
-            </div>
+      {/* Content — sectioned layout matches AgentCapabilities drawer:
+          uppercase muted headings, bordered sections, no outer padding. */}
+      <div className="flex-1 overflow-y-auto">
+        <section className="px-5 py-4">
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
+            Status
+          </h3>
+          <div className="space-y-1.5">
+            <DetailRow label="Current">
+              <span className={`text-sm font-medium ${statusColor}`}>{task.status}</span>
+            </DetailRow>
+            <DetailRow label="Enabled">
+              <span className="text-sm text-(--color-text)">{task.enabled ? 'Yes' : 'No'}</span>
+            </DetailRow>
+            <DetailRow label="Run Count">
+              <span className="text-sm text-(--color-text)">{task.run_count}</span>
+            </DetailRow>
           </div>
+        </section>
 
-          {/* Schedule section */}
-          <div>
-            <h3 className="text-sm font-semibold text-(--color-text)">Schedule</h3>
-            <div className="mt-2 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-(--color-text-muted)">Type</span>
-                <span className="text-sm text-(--color-text) capitalize">{task.schedule_type}</span>
-              </div>
-              {task.schedule_type === 'at' && task.at_datetime && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--color-text-muted)">Date/Time</span>
-                  <span className="text-sm text-(--color-text)">
-                    {format(new Date(task.at_datetime), 'dd/MM/yyyy HH:mm')}
-                  </span>
-                </div>
-              )}
-              {task.schedule_type === 'every' && task.every_seconds && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--color-text-muted)">Interval</span>
-                  <span className="text-sm text-(--color-text)">{task.every_seconds}s</span>
-                </div>
-              )}
-              {task.schedule_type === 'cron' && task.cron_expression && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--color-text-muted)">Expression</span>
-                  <span className="text-sm text-(--color-text)">{task.cron_expression}</span>
-                </div>
-              )}
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-(--color-text-muted)">Timezone</span>
-                <span className="text-sm text-(--color-text)">{task.timezone}</span>
-              </div>
-            </div>
+        <section className="border-t border-(--color-border) px-5 py-4">
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
+            Schedule
+          </h3>
+          <div className="space-y-1.5">
+            <DetailRow label="Type">
+              <span className="text-sm text-(--color-text) capitalize">{task.schedule_type}</span>
+            </DetailRow>
+            {task.schedule_type === 'at' && task.at_datetime && (
+              <DetailRow label="Date/Time">
+                <span className="text-sm text-(--color-text)">
+                  {format(new Date(task.at_datetime), 'dd/MM/yyyy HH:mm')}
+                </span>
+              </DetailRow>
+            )}
+            {task.schedule_type === 'every' && task.every_seconds && (
+              <DetailRow label="Interval">
+                <span className="text-sm text-(--color-text)">{task.every_seconds}s</span>
+              </DetailRow>
+            )}
+            {task.schedule_type === 'cron' && task.cron_expression && (
+              <DetailRow label="Expression">
+                <span className="text-sm text-(--color-text)">{task.cron_expression}</span>
+              </DetailRow>
+            )}
+            <DetailRow label="Timezone">
+              <span className="text-sm text-(--color-text)">{task.timezone}</span>
+            </DetailRow>
           </div>
+        </section>
 
-          {/* Agent & Prompt section */}
-          <div>
-            <h3 className="text-sm font-semibold text-(--color-text)">Configuration</h3>
-            <div className="mt-2 space-y-2">
+        <section className="border-t border-(--color-border) px-5 py-4">
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
+            Configuration
+          </h3>
+          <div className="space-y-3">
+            <div>
+              <span className="text-xs text-(--color-text-muted)">Agent</span>
+              <p className="mt-1 rounded-md border border-(--color-border) bg-(--bg-page) px-3 py-2 text-sm text-(--color-text)">
+                {task.agent}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-(--color-text-muted)">Prompt</span>
+              <p className="mt-1 rounded-md border border-(--color-border) bg-(--bg-page) px-3 py-2 text-sm leading-relaxed text-(--color-text) whitespace-pre-wrap">
+                {task.prompt}
+              </p>
+            </div>
+            {task.session_id && (
               <div>
-                <span className="text-sm text-(--color-text-muted)">Agent</span>
-                <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text)">
-                  {task.agent}
+                <span className="text-xs text-(--color-text-muted)">Session ID</span>
+                <p className="mt-1 rounded-md border border-(--color-border) bg-(--bg-page) px-3 py-2 font-mono text-xs text-(--color-text) break-all">
+                  {task.session_id}
                 </p>
               </div>
-              <div>
-                <span className="text-sm text-(--color-text-muted)">Prompt</span>
-                <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text) whitespace-pre-wrap">
-                  {task.prompt}
+            )}
+          </div>
+        </section>
+
+        <section className="border-t border-(--color-border) px-5 py-4">
+          <h3 className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-(--color-text-muted)">
+            Run History
+          </h3>
+          <div className="space-y-1.5">
+            {task.last_run_at && (
+              <DetailRow label="Last Run">
+                <span className="text-sm text-(--color-text)">
+                  {formatRelativeDate(task.last_run_at)}
+                </span>
+              </DetailRow>
+            )}
+            {task.next_fire_at && (
+              <DetailRow label="Next Fire">
+                <span className="text-sm text-(--color-text)">
+                  {formatRelativeDate(task.next_fire_at)}
+                </span>
+              </DetailRow>
+            )}
+            {!task.last_run_at && !task.next_fire_at && !task.last_error && (
+              <p className="text-xs italic text-(--color-text-muted)">No runs yet.</p>
+            )}
+            {task.last_error && (
+              <div className="pt-1">
+                <span className="text-xs text-(--color-text-muted)">Last Error</span>
+                <p className="mt-1 rounded-md border border-(--color-error) bg-(--color-error-subtle) px-3 py-2 text-xs text-(--color-error) whitespace-pre-wrap">
+                  {task.last_error}
                 </p>
               </div>
-              {task.session_id && (
-                <div>
-                  <span className="text-sm text-(--color-text-muted)">Session ID</span>
-                  <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text) break-all font-mono">
-                    {task.session_id}
-                  </p>
-                </div>
-              )}
-            </div>
+            )}
           </div>
+        </section>
 
-          {/* Run history section */}
-          <div>
-            <h3 className="text-sm font-semibold text-(--color-text)">Run History</h3>
-            <div className="mt-2 space-y-2">
-              {task.last_run_at && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--color-text-muted)">Last Run</span>
-                  <span className="text-sm text-(--color-text)">
-                    {formatRelativeDate(task.last_run_at)}
-                  </span>
-                </div>
-              )}
-              {task.next_fire_at && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-(--color-text-muted)">Next Fire</span>
-                  <span className="text-sm text-(--color-text)">
-                    {formatRelativeDate(task.next_fire_at)}
-                  </span>
-                </div>
-              )}
-              {task.last_error && (
-                <div>
-                  <span className="text-sm text-(--color-text-muted)">Last Error</span>
-                  <p className="mt-1 rounded-lg bg-(--color-error-subtle) px-3 py-2 text-sm text-(--color-error) whitespace-pre-wrap">
-                    {task.last_error}
-                  </p>
-                </div>
-              )}
-            </div>
+        <section className="border-t border-(--color-border) px-5 py-3">
+          <div className="space-y-1 text-[11px] text-(--color-text-muted)">
+            <div>Created: {formatRelativeDate(task.created_at)}</div>
+            <div>Updated: {formatRelativeDate(task.updated_at)}</div>
           </div>
-
-          {/* Timestamps */}
-          <div className="border-t border-(--color-border) pt-4">
-            <div className="space-y-2 text-xs text-(--color-text-muted)">
-              <div>Created: {formatRelativeDate(task.created_at)}</div>
-              <div>Updated: {formatRelativeDate(task.updated_at)}</div>
-            </div>
-          </div>
-        </div>
+        </section>
       </div>
+    </div>
+  )
+}
+
+// Compact label/value row used throughout the detail view.
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-xs text-(--color-text-muted)">{label}</span>
+      {children}
     </div>
   )
 }
@@ -884,21 +983,26 @@ function EditTaskForm({
   return (
     <div className="flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="border-b border-(--color-border) px-6 py-4">
-        <div className="flex items-center justify-between gap-4">
+      <div className="border-b border-(--color-border) px-5 py-4">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <Pencil size={18} className="text-(--color-accent)" />
-            <h2 className="text-lg font-semibold text-(--color-text)">Edit Task</h2>
+            <h2 className="text-base font-semibold text-(--color-text)">Edit Task</h2>
           </div>
-          <Button variant="ghost" size="icon-sm" onClick={onCancel} title="Cancel">
+          <button
+            onClick={onCancel}
+            className="rounded-md p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
+            aria-label="Cancel edit"
+            title="Cancel"
+          >
             <X size={16} />
-          </Button>
+          </button>
         </div>
         <p className="mt-1 text-sm text-(--color-text-muted)">{task.name}</p>
       </div>
 
       {/* Form */}
-      <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto p-6">
+      <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-y-auto px-5 py-4">
         <div className="space-y-4">
           {/* Agent */}
           <div>
@@ -907,10 +1011,10 @@ function EditTaskForm({
               value={formData.agent ?? ''}
               onValueChange={(v) => { if (v) setFormData({ ...formData, agent: v }) }}
             >
-              <SelectTrigger className="mt-1 w-full">
+              <SelectTrigger className={`mt-1 w-full ${FIELD_CLASS}`}>
                 <SelectValue placeholder="Select agent" />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className={SELECT_CONTENT_CLASS}>
                 {agents.map((agent) => (
                   <SelectItem key={agent.name} value={agent.name}>
                     {agent.name}
@@ -923,19 +1027,10 @@ function EditTaskForm({
           {/* Schedule Type */}
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Schedule Type</label>
-            <Tabs
+            <ScheduleTypeSegmented
               value={formData.schedule_type}
-              onValueChange={(v) =>
-                setFormData({ ...formData, schedule_type: v as ScheduledTaskCreate['schedule_type'] })
-              }
-              className="mt-2"
-            >
-              <TabsList className="w-full">
-                <TabsTrigger value="every" className="flex-1">Every</TabsTrigger>
-                <TabsTrigger value="cron" className="flex-1">Cron</TabsTrigger>
-                <TabsTrigger value="at" className="flex-1">At</TabsTrigger>
-              </TabsList>
-            </Tabs>
+              onChange={(v) => setFormData({ ...formData, schedule_type: v })}
+            />
           </div>
 
           {/* Schedule value (conditional) */}
@@ -948,13 +1043,14 @@ function EditTaskForm({
                     <DateTimePicker
                       value={formData.at_datetime ?? ''}
                       onChange={(v) => setFormData({ ...formData, at_datetime: v })}
+                      triggerClassName="bg-(--bg-page) hover:bg-(--bg-page)"
                     />
                   </div>
                 </div>
                 <div className="w-44 shrink-0">
                   <label className="block text-sm font-medium text-(--color-text)">Timezone</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.timezone}
                     onChange={(e) => setFormData({ ...formData, timezone: e.target.value })}
                     placeholder={localTz}
@@ -969,7 +1065,7 @@ function EditTaskForm({
             <div>
               <label className="block text-sm font-medium text-(--color-text)">Interval (seconds)</label>
               <Input
-                className="mt-1"
+                className={`mt-1 ${FIELD_CLASS}`}
                 type="number"
                 min="1"
                 value={formData.every_seconds ?? 3600}
@@ -987,7 +1083,7 @@ function EditTaskForm({
                 <div className="flex-1">
                   <label className="block text-sm font-medium text-(--color-text)">Cron Expression</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.cron_expression ?? ''}
                     onChange={(e) => setFormData({ ...formData, cron_expression: e.target.value })}
                     placeholder="e.g., 0 9 * * MON-FRI"
@@ -996,7 +1092,7 @@ function EditTaskForm({
                 <div className="w-44 shrink-0">
                   <label className="block text-sm font-medium text-(--color-text)">Timezone</label>
                   <Input
-                    className="mt-1"
+                    className={`mt-1 ${FIELD_CLASS}`}
                     value={formData.timezone}
                     onChange={(e) => setFormData({ ...formData, timezone: e.target.value })}
                     placeholder={localTz}
@@ -1011,7 +1107,7 @@ function EditTaskForm({
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Prompt</label>
             <Textarea
-              className="mt-1"
+              className={`mt-1 ${FIELD_CLASS}`}
               value={formData.prompt}
               onChange={(e) => setFormData({ ...formData, prompt: e.target.value })}
               placeholder="What should the agent do?"
@@ -1023,7 +1119,7 @@ function EditTaskForm({
           <div>
             <label className="block text-sm font-medium text-(--color-text)">Session ID (optional)</label>
             <Input
-              className="mt-1"
+              className={`mt-1 ${FIELD_CLASS}`}
               value={formData.session_id ?? ''}
               onChange={(e) => setFormData({ ...formData, session_id: e.target.value || undefined })}
               placeholder="Leave blank for new session, or enter 'auto'"

--- a/web/src/components/SchedulerPanel.tsx
+++ b/web/src/components/SchedulerPanel.tsx
@@ -119,7 +119,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '100%', opacity: 0 }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
-            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden bg-(--color-surface) shadow-2xl"
+            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden bg-(--bg-card) shadow-2xl"
           >
             {/* Header */}
             <header className="flex items-center justify-between border-b border-(--color-border) px-4 py-3">
@@ -128,7 +128,7 @@ export function SchedulerPanel({ open, onClose }: SchedulerPanelProps) {
                 {isMobile && mobilePane !== 'list' && (
                   <button
                     onClick={handleBackToList}
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
                     aria-label="Back to task list"
                   >
                     <ArrowLeft size={14} />
@@ -280,8 +280,8 @@ function TaskListItem({
       onClick={onSelect}
       className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
         isSelected
-          ? 'border-(--color-accent) bg-(--color-accent-subtle)'
-          : 'border-(--color-border) bg-(--color-surface-2) hover:border-(--color-border-strong)'
+          ? 'border-(--color-accent) bg-(--bg-key)'
+          : 'border-(--color-border) bg-(--bg-key) hover:border-(--color-border-strong)'
       }`}
     >
       <div className="flex items-start justify-between gap-2">
@@ -291,7 +291,7 @@ function TaskListItem({
             {formatScheduleLabel(task)}
           </p>
           <div className="mt-1 flex items-center gap-2">
-            <span className="inline-block rounded-full bg-(--color-accent-subtle) px-2 py-0.5 text-xs text-(--color-accent)">
+            <span className="inline-block rounded-full bg-(--bg-key) px-2 py-0.5 text-xs text-(--color-accent)">
               {task.agent}
             </span>
             <span className={`text-xs font-medium ${statusColor}`}>{task.status}</span>
@@ -750,20 +750,20 @@ function TaskDetailView({
             <div className="mt-2 space-y-2">
               <div>
                 <span className="text-sm text-(--color-text-muted)">Agent</span>
-                <p className="mt-1 rounded-lg bg-(--color-surface-2) px-3 py-2 text-sm text-(--color-text)">
+                <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text)">
                   {task.agent}
                 </p>
               </div>
               <div>
                 <span className="text-sm text-(--color-text-muted)">Prompt</span>
-                <p className="mt-1 rounded-lg bg-(--color-surface-2) px-3 py-2 text-sm text-(--color-text) whitespace-pre-wrap">
+                <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text) whitespace-pre-wrap">
                   {task.prompt}
                 </p>
               </div>
               {task.session_id && (
                 <div>
                   <span className="text-sm text-(--color-text-muted)">Session ID</span>
-                  <p className="mt-1 rounded-lg bg-(--color-surface-2) px-3 py-2 text-sm text-(--color-text) break-all font-mono">
+                  <p className="mt-1 rounded-lg bg-(--bg-key) px-3 py-2 text-sm text-(--color-text) break-all font-mono">
                     {task.session_id}
                   </p>
                 </div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
   Trash2,
   RefreshCw,
   PanelLeftClose,
-  PanelLeftOpen,
   Search,
   Brain,
   Settings,
@@ -23,6 +22,8 @@ import { WikiPanel } from './WikiPanel'
 import { SchedulerPanel } from './SchedulerPanel'
 import { ThemeToggle } from './ThemeToggle'
 import { HealthDot } from './HealthDot'
+import { BrandHeader } from '@/components/ui/brand-header'
+import { SidebarItem } from '@/components/ui/sidebar-item'
 import {
   Dialog,
   DialogContent,
@@ -206,8 +207,8 @@ export function Sidebar({
       transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
       className={
         isMobile
-          ? 'fixed inset-y-0 left-0 z-40 flex w-[272px] shrink-0 flex-col overflow-hidden bg-(--bg-card) shadow-xl'
-          : 'relative flex shrink-0 flex-col overflow-hidden bg-(--bg-card)'
+          ? 'fixed inset-y-0 left-0 z-40 flex w-[272px] shrink-0 flex-col overflow-hidden bg-(--bg-sidebar) shadow-xl'
+          : 'relative flex shrink-0 flex-col overflow-hidden bg-(--bg-sidebar)'
       }
       style={isMobile ? undefined : { minWidth: desktopWidth }}
     >
@@ -217,145 +218,76 @@ export function Sidebar({
         const showIconOnly = !isMobile && collapsed
         return (
           <>
-            {/* Brand header */}
-            <div className="flex h-14 items-center justify-between px-3">
-              <button
-                onClick={() => navigate({ to: '/' })}
-                className="flex items-center gap-2.5 overflow-hidden rounded-md p-1 -ml-1 transition-colors hover:bg-(--bg-key)"
-                title="Home"
-              >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-(--bg-key) ring-1 ring-(--color-border-strong)">
-                  <img src={OpenAgentdAppIcon} width={28} height={28} alt="OpenAgentd logo" className="rounded-md" />
-                </div>
-                <AnimatePresence>
-                  {!showIconOnly && (
-                    <motion.div
-                      initial={{ opacity: 0, x: -8 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: -8 }}
-                      transition={{ duration: 0.15 }}
-                      className="flex items-center gap-1.5 overflow-hidden"
-                    >
-                      <span className="whitespace-nowrap text-sm font-semibold text-(--color-text)">
-                        OpenAgentd
-                      </span>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </button>
-
-              {/* On mobile: close button (×). On desktop: collapse toggle. */}
-              {isMobile ? (
+            {/* Brand header — full BrandHeader when expanded, mascot + expand toggle when collapsed */}
+            {showIconOnly ? (
+              <div className="flex flex-col items-center gap-1 px-2 pt-2">
                 <button
-                  onClick={onMobileClose}
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
-                  aria-label="Close sidebar"
+                  onClick={() => navigate({ to: '/' })}
+                  className="flex h-10 w-10 items-center justify-center rounded-md transition-colors hover:bg-(--bg-key)"
+                  title="Home"
+                  aria-label="Home"
                 >
-                  <PanelLeftClose size={15} />
+                  <img src={OpenAgentdAppIcon} width={32} height={32} alt="" className="select-none" draggable={false} />
                 </button>
-              ) : (
                 <button
                   onClick={toggleCollapse}
                   className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
-                  aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-                  title={collapsed ? 'Expand sidebar (Ctrl+B)' : 'Collapse sidebar (Ctrl+B)'}
+                  aria-label="Expand sidebar"
+                  title="Expand sidebar (Ctrl+B)"
                 >
-                  {collapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+                  <PanelLeftClose className="rotate-180" size={15} />
                 </button>
-              )}
-            </div>
+              </div>
+            ) : (
+              <div className="px-3">
+                <BrandHeader
+                  expanded
+                  onBrandClick={() => navigate({ to: '/' })}
+                  onToggle={isMobile ? onMobileClose : toggleCollapse}
+                  hideToggle={false}
+                />
+              </div>
+            )}
 
             {/* Nav action buttons */}
-            <div className="px-2 pb-2 space-y-0.5">
-              <button
+            <nav aria-label="Primary" className={`space-y-0.5 pb-2 ${showIconOnly ? 'flex flex-col items-center px-1 pt-1' : 'px-2'}`}>
+              <SidebarItem
+                Icon={Plus}
+                label="New Chat"
+                kbd="^N"
+                collapsed={showIconOnly}
                 onClick={handleNewChat}
-                title="New Chat (Ctrl+N)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text) ${showIconOnly ? 'justify-center' : ''}`}
-              >
-                <Plus size={16} className="shrink-0" />
-                <AnimatePresence>
-                  {!showIconOnly && (
-                    <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.12 }} className="whitespace-nowrap flex-1 text-left">
-                      New Chat
-                    </motion.span>
-                  )}
-                </AnimatePresence>
-                {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^N</kbd>
-                )}
-              </button>
-
+              />
               {onCommandPalette && (
-                <button
+                <SidebarItem
+                  Icon={Search}
+                  label="Commands"
+                  kbd="^P"
+                  collapsed={showIconOnly}
                   onClick={onCommandPalette}
-                  title="Commands (Ctrl+P)"
-                  className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
-                >
-                  <Search size={15} className="shrink-0" />
-                  <AnimatePresence>
-                    {!showIconOnly && (
-                      <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.12 }} className="whitespace-nowrap flex-1 text-left">
-                        Commands
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
-                  {!showIconOnly && (
-                    <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^P</kbd>
-                  )}
-                </button>
+                />
               )}
-
-              <button
+              <SidebarItem
+                Icon={Brain}
+                label="Memory wiki"
+                kbd="^M"
+                collapsed={showIconOnly}
                 onClick={() => setWikiOpen(true)}
-                title="Wiki (Ctrl+M)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
-              >
-                <Brain size={15} className="shrink-0" />
-                <AnimatePresence>
-                  {!showIconOnly && (
-                    <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.12 }} className="whitespace-nowrap flex-1 text-left">
-                      Wiki
-                    </motion.span>
-                  )}
-                </AnimatePresence>
-                {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^M</kbd>
-                )}
-              </button>
-
-              <button
+              />
+              <SidebarItem
+                Icon={CalendarClock}
+                label="Scheduler"
+                kbd="^S"
+                collapsed={showIconOnly}
                 onClick={() => setSchedulerOpen(true)}
-                title="Scheduled Tasks (Ctrl+S)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
-              >
-                <CalendarClock size={15} className="shrink-0" />
-                <AnimatePresence>
-                  {!showIconOnly && (
-                    <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.12 }} className="whitespace-nowrap flex-1 text-left">
-                      Scheduled Tasks
-                    </motion.span>
-                  )}
-                </AnimatePresence>
-                {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^S</kbd>
-                )}
-              </button>
-
-              <button
+              />
+              <SidebarItem
+                Icon={Settings}
+                label="Settings"
+                collapsed={showIconOnly}
                 onClick={() => { navigate({ to: '/settings' }); onMobileClose?.() }}
-                title="Settings"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
-              >
-                <Settings size={15} className="shrink-0" />
-                <AnimatePresence>
-                  {!showIconOnly && (
-                    <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.12 }} className="whitespace-nowrap flex-1 text-left">
-                      Settings
-                    </motion.span>
-                  )}
-                </AnimatePresence>
-              </button>
-            </div>
+              />
+            </nav>
 
             {/* Sessions section — expanded view (desktop expanded or mobile drawer) */}
             <AnimatePresence>
@@ -367,8 +299,10 @@ export function Sidebar({
                   transition={{ duration: 0.15 }}
                   className="flex min-h-0 flex-1 flex-col overflow-hidden"
                 >
-                  <div className="flex items-center justify-between px-3 pb-1 pt-1">
-                    <span className="text-xs font-medium uppercase tracking-wider text-(--color-text-subtle)">Recent</span>
+                  <div className="flex items-center justify-between px-3 pb-1 pt-2">
+                    <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-(--color-text-muted)">
+                      Recent
+                    </span>
                     <button
                       onClick={() => refetchSessions()}
                       className="rounded p-1 text-(--color-text-subtle) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-muted)"

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -206,8 +206,8 @@ export function Sidebar({
       transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
       className={
         isMobile
-          ? 'fixed inset-y-0 left-0 z-40 flex w-[272px] shrink-0 flex-col overflow-hidden bg-(--color-surface) shadow-xl'
-          : 'relative flex shrink-0 flex-col overflow-hidden bg-(--color-surface)'
+          ? 'fixed inset-y-0 left-0 z-40 flex w-[272px] shrink-0 flex-col overflow-hidden bg-(--bg-card) shadow-xl'
+          : 'relative flex shrink-0 flex-col overflow-hidden bg-(--bg-card)'
       }
       style={isMobile ? undefined : { minWidth: desktopWidth }}
     >
@@ -221,10 +221,10 @@ export function Sidebar({
             <div className="flex h-14 items-center justify-between px-3">
               <button
                 onClick={() => navigate({ to: '/' })}
-                className="flex items-center gap-2.5 overflow-hidden rounded-md p-1 -ml-1 transition-colors hover:bg-(--color-accent-subtle)"
+                className="flex items-center gap-2.5 overflow-hidden rounded-md p-1 -ml-1 transition-colors hover:bg-(--bg-key)"
                 title="Home"
               >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-(--color-accent-subtle) ring-1 ring-(--color-border-strong)">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-(--bg-key) ring-1 ring-(--color-border-strong)">
                   <img src={OpenAgentdAppIcon} width={28} height={28} alt="OpenAgentd logo" className="rounded-md" />
                 </div>
                 <AnimatePresence>
@@ -248,7 +248,7 @@ export function Sidebar({
               {isMobile ? (
                 <button
                   onClick={onMobileClose}
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
                   aria-label="Close sidebar"
                 >
                   <PanelLeftClose size={15} />
@@ -256,7 +256,7 @@ export function Sidebar({
               ) : (
                 <button
                   onClick={toggleCollapse}
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
                   aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
                   title={collapsed ? 'Expand sidebar (Ctrl+B)' : 'Collapse sidebar (Ctrl+B)'}
                 >
@@ -270,7 +270,7 @@ export function Sidebar({
               <button
                 onClick={handleNewChat}
                 title="New Chat (Ctrl+N)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-2) hover:bg-(--color-accent-subtle) hover:text-(--color-text) ${showIconOnly ? 'justify-center' : ''}`}
+                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text) ${showIconOnly ? 'justify-center' : ''}`}
               >
                 <Plus size={16} className="shrink-0" />
                 <AnimatePresence>
@@ -281,7 +281,7 @@ export function Sidebar({
                   )}
                 </AnimatePresence>
                 {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^N</kbd>
+                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^N</kbd>
                 )}
               </button>
 
@@ -289,7 +289,7 @@ export function Sidebar({
                 <button
                   onClick={onCommandPalette}
                   title="Commands (Ctrl+P)"
-                  className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--color-accent-subtle) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
+                  className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
                 >
                   <Search size={15} className="shrink-0" />
                   <AnimatePresence>
@@ -300,7 +300,7 @@ export function Sidebar({
                     )}
                   </AnimatePresence>
                   {!showIconOnly && (
-                    <kbd className="shrink-0 rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^P</kbd>
+                    <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^P</kbd>
                   )}
                 </button>
               )}
@@ -308,7 +308,7 @@ export function Sidebar({
               <button
                 onClick={() => setWikiOpen(true)}
                 title="Wiki (Ctrl+M)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--color-accent-subtle) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
+                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
               >
                 <Brain size={15} className="shrink-0" />
                 <AnimatePresence>
@@ -319,14 +319,14 @@ export function Sidebar({
                   )}
                 </AnimatePresence>
                 {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^M</kbd>
+                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^M</kbd>
                 )}
               </button>
 
               <button
                 onClick={() => setSchedulerOpen(true)}
                 title="Scheduled Tasks (Ctrl+S)"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--color-accent-subtle) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
+                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
               >
                 <CalendarClock size={15} className="shrink-0" />
                 <AnimatePresence>
@@ -337,14 +337,14 @@ export function Sidebar({
                   )}
                 </AnimatePresence>
                 {!showIconOnly && (
-                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--color-bg) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^S</kbd>
+                  <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">^S</kbd>
                 )}
               </button>
 
               <button
                 onClick={() => { navigate({ to: '/settings' }); onMobileClose?.() }}
                 title="Settings"
-                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--color-accent-subtle) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
+                className={`interactive-weight flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-all text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-muted) ${showIconOnly ? 'justify-center' : ''}`}
               >
                 <Settings size={15} className="shrink-0" />
                 <AnimatePresence>
@@ -371,7 +371,7 @@ export function Sidebar({
                     <span className="text-xs font-medium uppercase tracking-wider text-(--color-text-subtle)">Recent</span>
                     <button
                       onClick={() => refetchSessions()}
-                      className="rounded p-1 text-(--color-text-subtle) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-muted)"
+                      className="rounded p-1 text-(--color-text-subtle) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-muted)"
                       aria-label="Refresh sessions"
                       title="Refresh sessions (Ctrl+R)"
                     >
@@ -383,7 +383,7 @@ export function Sidebar({
                     {sessions.isLoading && (
                       <div className="space-y-1 px-1 py-2">
                         {[...Array(6)].map((_, i) => (
-                          <div key={i} className="h-8 animate-pulse rounded-md bg-(--color-accent-dim)" />
+                          <div key={i} className="h-8 animate-pulse rounded-md bg-(--bg-key)" />
                         ))}
                       </div>
                     )}
@@ -414,7 +414,7 @@ export function Sidebar({
                         {isFetchingNextPage && (
                           <div className="space-y-1 px-1 pt-1">
                             {[...Array(3)].map((_, i) => (
-                              <div key={i} className="h-8 animate-pulse rounded-md bg-(--color-accent-dim)" />
+                              <div key={i} className="h-8 animate-pulse rounded-md bg-(--bg-key)" />
                             ))}
                           </div>
                         )}
@@ -437,8 +437,8 @@ export function Sidebar({
                       title={session.title || 'Untitled'}
                       className={`flex h-8 w-8 items-center justify-center rounded-md transition-colors ${
                         isActive
-                          ? 'bg-(--color-accent-dim) text-(--color-accent)'
-                          : 'text-(--color-text-subtle) hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)'
+                          ? 'bg-(--bg-key) text-(--color-accent)'
+                          : 'text-(--color-text-subtle) hover:bg-(--bg-key) hover:text-(--color-text-2)'
                       }`}
                     >
                       <div className="h-1.5 w-1.5 rounded-full bg-current" />
@@ -519,7 +519,7 @@ function SessionRow({ session, isActive, mouseY, onSelect, onDelete }: SessionRo
           aria-hidden
           className="pointer-events-none absolute inset-0 -z-10 rounded-md"
           style={{
-            backgroundColor: `color-mix(in srgb, var(--color-accent-dim) ${intensity * 100}%, transparent)`,
+            backgroundColor: `color-mix(in srgb, var(--bg-key) ${intensity * 100}%, transparent)`,
           }}
         />
       )}
@@ -527,8 +527,8 @@ function SessionRow({ session, isActive, mouseY, onSelect, onDelete }: SessionRo
         onClick={() => onSelect(session.id)}
         className={`flex w-full items-start gap-2 rounded-md px-2.5 py-2 text-left transition-colors ${
           isActive
-            ? 'bg-(--color-accent-dim) text-(--color-text)'
-            : 'hover:bg-(--color-accent-dim) text-(--color-text-2)'
+            ? 'bg-(--bg-key) text-(--color-text)'
+            : 'hover:bg-(--bg-key) text-(--color-text-2)'
         }`}
       >
         <div className="min-w-0 flex-1">
@@ -550,7 +550,7 @@ function SessionRow({ session, isActive, mouseY, onSelect, onDelete }: SessionRo
               </motion.p>
             </AnimatePresence>
             {isScheduled && (
-              <span className="shrink-0 rounded px-1 py-px text-[10px] leading-tight bg-(--color-accent-subtle) text-(--color-text-subtle)">
+              <span className="shrink-0 rounded px-1 py-px text-[10px] leading-tight bg-(--bg-key) text-(--color-text-subtle)">
                 sched
               </span>
             )}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -17,7 +17,7 @@ export function StatusBar({
   usage,
 }: StatusBarProps) {
   return (
-    <div className="flex items-center justify-between border-t border-(--color-border) bg-(--color-bg) px-4 py-1 text-xs text-(--color-text-subtle)">
+    <div className="flex items-center justify-between border-t border-(--color-border) bg-(--bg-page) px-4 py-1 text-xs text-(--color-text-subtle)">
       {/* Left: session ID */}
       <div className="flex items-center gap-2">
          {sessionId && (

--- a/web/src/components/TeamChatView/AgentTabStrip.tsx
+++ b/web/src/components/TeamChatView/AgentTabStrip.tsx
@@ -58,8 +58,8 @@ export function AgentTabStrip({
               onClick={() => onFocusOpen(name)}
               className={`interactive-weight group flex shrink-0 items-center gap-1.5 rounded-t-lg border-b-2 px-2.5 py-1.5 text-xs transition-all ${
                 isFocused
-                  ? 'border-b-(--color-accent) bg-(--color-accent-subtle) text-(--color-accent)'
-                  : 'border-b-transparent text-(--color-text-2) hover:bg-(--color-accent-dim) hover:text-(--color-text)'
+                  ? 'border-b-(--color-accent) bg-(--bg-key) text-(--color-accent)'
+                  : 'border-b-transparent text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)'
               }`}
             >
               <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${
@@ -75,7 +75,7 @@ export function AgentTabStrip({
                 title="Minimize pane"
                 className={`flex items-center rounded p-0.5 transition-colors ${
                   isFocused
-                    ? 'text-(--color-accent) hover:bg-(--color-accent-subtle)'
+                    ? 'text-(--color-accent) hover:bg-(--bg-key)'
                     : 'text-(--color-text-subtle) opacity-0 group-hover:opacity-100 hover:text-(--color-text-2)'
                 }`}
               >×</span>
@@ -88,7 +88,7 @@ export function AgentTabStrip({
             key={name}
             onClick={() => onOpenMinimized(name)}
             title={`Open ${name} as new split pane`}
-            className="flex shrink-0 items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-all hover:bg-(--color-accent-dim) hover:text-(--color-text-2)"
+            className="flex shrink-0 items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-all hover:bg-(--bg-key) hover:text-(--color-text-2)"
           >
             <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${
               isError ? 'bg-(--color-error)' : isWorking ? 'animate-pulse bg-(--color-accent)' : 'bg-(--color-border-strong)'

--- a/web/src/components/TeamChatView/TileArea.tsx
+++ b/web/src/components/TeamChatView/TileArea.tsx
@@ -24,9 +24,21 @@ export function TileArea({ tileLayout, agentStreams, leadName }: TileAreaProps) 
 
   if (!root) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3">
-        <img src={OctobotMascot} className="opacity-25 grayscale" width={64} height={64} alt="Idle octobot" />
-        <p className="text-sm text-(--color-text-muted)">No agent panes open · click a tab above to open one</p>
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+        <img
+          src={OctobotMascot}
+          className="opacity-90"
+          width={96}
+          height={96}
+          alt=""
+          aria-hidden="true"
+        />
+        <h2 className="font-hand text-3xl font-bold text-(--color-text)">
+          empty room.
+        </h2>
+        <p className="text-sm text-(--color-text-muted)">
+          Click a tab above to open an agent pane
+        </p>
       </div>
     )
   }

--- a/web/src/components/TeamChatView/index.tsx
+++ b/web/src/components/TeamChatView/index.tsx
@@ -40,20 +40,11 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useTileLayout } from '@/hooks/useTileLayout'
 import { useTeamAgentsQuery } from '@/queries/useAgentsQuery'
 import { useSpeechConfigQuery } from '@/queries/useSpeechConfigQuery'
-import {
-  Users,
-  FolderOpen,
-  SplitSquareHorizontal,
-  SplitSquareVertical,
-  Menu,
-  Moon,
-} from 'lucide-react'
+import { Users, FolderOpen, Menu } from 'lucide-react'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { AgentChip } from '@/components/ui/agent-chip'
 import { isAgentRole } from '@/lib/agent-roles'
-import { TokenMeter } from '@/components/ui/token-meter'
-import { ViewToggle } from '@/components/ui/view-toggle'
-import { TopbarAction } from '@/components/ui/topbar-action'
+import { AgentTopbar } from '@/components/AgentTopbar'
 import { type InputBarHandle, type SlashCommand } from '../InputBar'
 import { FloatingInputBar } from '../FloatingInputBar'
 import type { AgentCapabilities as AgentCapabilitiesType } from '@/api/types'
@@ -440,71 +431,54 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
             )}
           </div>
 
-          {/* Right: tokens (desktop) + view toggle (desktop) + panel toggles */}
-          <div className="flex shrink-0 items-center gap-1.5 py-2">
-
-            {/* Token count — desktop only, too noisy on mobile */}
-            {!isMobile && totalAll > 0 && (
-              <TokenMeter
-                input={totalPrompt}
-                output={totalCompletion}
-                cached={totalCached}
-                pulsing={isTeamWorking}
+          {/* Right: tokens, dream, split-pane, view toggle, panel toggles —
+              owned by the reusable ``AgentTopbar`` composite so this header
+              stays in sync with single-agent surfaces and Pencil's
+              ``AgentTopbar`` (`E8lml9`). */}
+          <AgentTopbar
+            isMobile={isMobile}
+            tokens={
+              totalAll > 0
+                ? {
+                    input: totalPrompt,
+                    output: totalCompletion,
+                    cached: totalCached,
+                    pulsing: isTeamWorking,
+                  }
+                : undefined
+            }
+            dreamRunning={dreamMutation.isPending}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            showSplitButtons={
+              effectiveViewMode === 'unified' && minimizedAgents.length > 0
+            }
+            onSplitDown={handleSplitDown}
+            onSplitRight={handleSplitRight}
+            todosSlot={
+              <TodosPopover
+                open={showTodos}
+                onOpenChange={setShowTodos}
+                todos={todos}
+                sessionId={sessionIdState}
               />
-            )}
-
-            {/* Dream running indicator */}
-            {dreamMutation.isPending && (
-              <div
-                className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-(--color-text-muted)"
-                title="Dream is running…"
-              >
-                <Moon size={11} className="animate-pulse" aria-hidden="true" />
-                <span className="hidden sm:inline">Dream…</span>
-              </div>
-            )}
-
-            {/* Unified-view split buttons — desktop only */}
-            {!isMobile && effectiveViewMode === 'unified' && minimizedAgents.length > 0 && (
-              <div className="flex items-center gap-0.5">
-                <button onClick={handleSplitDown} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)" title="Split pane down (Ctrl+J)" aria-label="Split pane down">
-                  <SplitSquareVertical size={12} aria-hidden="true" />
-                </button>
-                <button onClick={handleSplitRight} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)" title="Split pane right (Ctrl+K)" aria-label="Split pane right">
-                  <SplitSquareHorizontal size={12} aria-hidden="true" />
-                </button>
-              </div>
-            )}
-
-            {/* 3-way view toggle — desktop only. Mobile always uses agent view. */}
-            {!isMobile && (
-              <ViewToggle value={viewMode} onValueChange={setViewMode} />
-            )}
-
-            <TodosPopover
-              open={showTodos}
-              onOpenChange={setShowTodos}
-              todos={todos}
-              sessionId={sessionIdState}
-            />
-
-            <TopbarAction
-              Icon={FolderOpen}
-              label="Files"
-              onClick={() => setShowFilesPanel((v) => !v)}
-              disabled={!sessionIdState}
-              title={sessionIdState ? 'Workspace files (Ctrl+F)' : 'No active session'}
-              aria-label="Workspace files"
-            />
-
-            <TopbarAction
-              Icon={Users}
-              label="Agents"
-              onClick={() => setShowAgentSidebar((v) => !v)}
-              title="Agent Capabilities (Ctrl+A)"
-              aria-label="Agent capabilities"
-            />
-          </div>
+            }
+            filesAction={{
+              Icon: FolderOpen,
+              label: 'Files',
+              onClick: () => setShowFilesPanel((v) => !v),
+              disabled: !sessionIdState,
+              title: sessionIdState ? 'Workspace files (Ctrl+F)' : 'No active session',
+              ariaLabel: 'Workspace files',
+            }}
+            agentsAction={{
+              Icon: Users,
+              label: 'Agents',
+              onClick: () => setShowAgentSidebar((v) => !v),
+              title: 'Agent Capabilities (Ctrl+A)',
+              ariaLabel: 'Agent capabilities',
+            }}
+          />
         </header>
 
         {/* Content area */}

--- a/web/src/components/TeamChatView/index.tsx
+++ b/web/src/components/TeamChatView/index.tsx
@@ -31,7 +31,7 @@ import { AgentView } from '../AgentView'
 import { Sidebar } from '../Sidebar'
 import { CommandPalette } from '../CommandPalette'
 import { WorkspaceFilesPanel } from '../WorkspaceFilesPanel'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { TodosPopover } from '../TodosPopover'
 import { useTodosQuery } from '@/queries/useTodosQuery'
 import { useTriggerDreamMutation } from '@/queries'
 import { useTeamStore } from '@/stores/useTeamStore'
@@ -45,7 +45,6 @@ import {
   FolderOpen,
   SplitSquareHorizontal,
   SplitSquareVertical,
-  ListTodo,
   Menu,
   Moon,
 } from 'lucide-react'
@@ -482,52 +481,12 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
               <ViewToggle value={viewMode} onValueChange={setViewMode} />
             )}
 
-            <Popover open={showTodos} onOpenChange={setShowTodos}>
-              <PopoverTrigger
-                disabled={!sessionIdState}
-                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
-                title={sessionIdState ? 'Task list (Ctrl+T)' : 'No active session'}
-                aria-label="Task list"
-              >
-                <ListTodo size={13} aria-hidden="true" />
-                <span className="hidden md:inline">Todos</span>
-                {todos.some((t) => t.status === 'in_progress') && (
-                  <span className="size-1.5 rounded-full bg-(--color-accent)" />
-                )}
-              </PopoverTrigger>
-              <PopoverContent side="bottom" align="end" className="w-80 p-0">
-                <div className="flex items-center justify-between border-b border-(--color-border) px-3 py-2">
-                  <span className="text-xs font-semibold text-(--color-text)">Tasks</span>
-                  {todos.length > 0 && (
-                    <span className="text-[10px] text-(--color-text-subtle)">
-                      {todos.filter((t) => t.status === 'completed').length}/{todos.length} done
-                    </span>
-                  )}
-                </div>
-                {todos.length === 0 ? (
-                  <p className="px-3 py-4 text-center text-xs text-(--color-text-subtle)">No tasks yet</p>
-                ) : (
-                  <ul className="max-h-80 overflow-y-auto py-1">
-                    {[...todos].sort((a, b) => {
-                        const order = { in_progress: 0, pending: 1, completed: 2, cancelled: 3 }
-                        return order[a.status] - order[b.status]
-                      }).map((todo) => (
-                      <li key={todo.task_id} className="flex items-start gap-2 px-3 py-1.5">
-                        <span className="mt-0.5 shrink-0 text-[10px]">
-                          {todo.status === 'completed' ? '✓' : todo.status === 'cancelled' ? '✗' : todo.status === 'in_progress' ? '▶' : '○'}
-                        </span>
-                        <span className={`flex-1 text-xs leading-snug ${todo.status === 'completed' || todo.status === 'cancelled' ? 'text-(--color-text-subtle) line-through' : 'text-(--color-text)'}`}>
-                          {todo.content}
-                        </span>
-                        <span className={`shrink-0 self-start rounded px-1 py-0.5 text-[9px] font-medium uppercase ${todo.priority === 'high' ? 'bg-red-500/10 text-red-500' : todo.priority === 'low' ? 'bg-(--bg-key) text-(--color-text-subtle)' : 'bg-amber-500/10 text-amber-500'}`}>
-                          {todo.priority}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </PopoverContent>
-            </Popover>
+            <TodosPopover
+              open={showTodos}
+              onOpenChange={setShowTodos}
+              todos={todos}
+              sessionId={sessionIdState}
+            />
 
             <TopbarAction
               Icon={FolderOpen}

--- a/web/src/components/TeamChatView/index.tsx
+++ b/web/src/components/TeamChatView/index.tsx
@@ -345,7 +345,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
   return (
     // h-dvh: accounts for iOS Safari's dynamic toolbar (h-screen is too tall)
-    <div className="flex h-dvh bg-(--color-bg)">
+    <div className="flex h-dvh bg-(--bg-page)">
       {/* On mobile the Sidebar is position:fixed (overlay drawer), so it takes
           no space in this flex row — the main column is always full-width. */}
       <Sidebar
@@ -358,14 +358,14 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
       <div ref={mainColumnRef} className="relative flex min-w-0 flex-1 flex-col">
         {/* Header */}
-        <header className="flex items-center gap-1 border-b border-(--color-border) bg-(--color-bg) px-2 py-0 md:gap-0 md:px-4">
+        <header className="flex items-center gap-1 border-b border-(--color-border) bg-(--bg-page) px-2 py-0 md:gap-0 md:px-4">
 
           {/* Mobile: hamburger to open sidebar drawer */}
           {isMobile && (
             <button
               onClick={() => setMobileSidebarOpen(true)}
               aria-label="Open navigation"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             >
               <Menu size={16} aria-hidden="true" />
             </button>
@@ -383,8 +383,8 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
                   onClick={() => setActiveAgent(name)}
                   className={`flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-all ${
                     isActive
-                      ? 'bg-(--color-accent-subtle) text-(--color-accent)'
-                      : 'text-(--color-text-muted) hover:bg-(--color-accent-dim) hover:text-(--color-text-2)'
+                      ? 'bg-(--bg-key) text-(--color-accent)'
+                      : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text-2)'
                   }`}
                 >
                   <span className={`h-1.5 w-1.5 rounded-full ${
@@ -459,10 +459,10 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
             {/* Unified-view split buttons — desktop only */}
             {!isMobile && effectiveViewMode === 'unified' && minimizedAgents.length > 0 && (
               <div className="flex items-center gap-0.5">
-                <button onClick={handleSplitDown} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-dim) hover:text-(--color-text-2)" title="Split pane down (Ctrl+J)" aria-label="Split pane down">
+                <button onClick={handleSplitDown} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)" title="Split pane down (Ctrl+J)" aria-label="Split pane down">
                   <SplitSquareVertical size={12} aria-hidden="true" />
                 </button>
-                <button onClick={handleSplitRight} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-dim) hover:text-(--color-text-2)" title="Split pane right (Ctrl+K)" aria-label="Split pane right">
+                <button onClick={handleSplitRight} className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)" title="Split pane right (Ctrl+K)" aria-label="Split pane right">
                   <SplitSquareHorizontal size={12} aria-hidden="true" />
                 </button>
               </div>
@@ -470,10 +470,10 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
             {/* 3-way view toggle — desktop only. Mobile always uses agent view. */}
             {!isMobile && (
-              <div className="flex items-center rounded-lg border border-(--color-border) bg-(--color-bg) p-0.5">
+              <div className="flex items-center rounded-lg border border-(--color-border) bg-(--bg-page) p-0.5">
                 <button
                   onClick={() => setViewMode('agent')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'agent' ? 'bg-(--color-accent-subtle) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
+                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'agent' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
                   title="Agent view (Ctrl+V)"
                   aria-label="Agent view"
                   aria-pressed={viewMode === 'agent'}
@@ -482,7 +482,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
                 </button>
                 <button
                   onClick={() => setViewMode('split')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'split' ? 'bg-(--color-accent-subtle) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
+                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'split' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
                   title="Split view (Ctrl+V)"
                   aria-label="Split view"
                   aria-pressed={viewMode === 'split'}
@@ -491,7 +491,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
                 </button>
                 <button
                   onClick={() => setViewMode('unified')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'unified' ? 'bg-(--color-accent-subtle) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
+                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'unified' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
                   title="Unified view (Ctrl+V)"
                   aria-label="Unified view"
                   aria-pressed={viewMode === 'unified'}
@@ -504,7 +504,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
             <Popover open={showTodos} onOpenChange={setShowTodos}>
               <PopoverTrigger
                 disabled={!sessionIdState}
-                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-dim) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
                 title={sessionIdState ? 'Task list (Ctrl+T)' : 'No active session'}
                 aria-label="Task list"
               >
@@ -538,7 +538,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
                         <span className={`flex-1 text-xs leading-snug ${todo.status === 'completed' || todo.status === 'cancelled' ? 'text-(--color-text-subtle) line-through' : 'text-(--color-text)'}`}>
                           {todo.content}
                         </span>
-                        <span className={`shrink-0 self-start rounded px-1 py-0.5 text-[9px] font-medium uppercase ${todo.priority === 'high' ? 'bg-red-500/10 text-red-500' : todo.priority === 'low' ? 'bg-(--color-accent-dim) text-(--color-text-subtle)' : 'bg-amber-500/10 text-amber-500'}`}>
+                        <span className={`shrink-0 self-start rounded px-1 py-0.5 text-[9px] font-medium uppercase ${todo.priority === 'high' ? 'bg-red-500/10 text-red-500' : todo.priority === 'low' ? 'bg-(--bg-key) text-(--color-text-subtle)' : 'bg-amber-500/10 text-amber-500'}`}>
                           {todo.priority}
                         </span>
                       </li>
@@ -551,7 +551,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
             <button
               onClick={() => setShowFilesPanel((v) => !v)}
               disabled={!sessionIdState}
-              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-dim) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
               title={sessionIdState ? 'Workspace files (Ctrl+F)' : 'No active session'}
               aria-label="Workspace files"
             >
@@ -561,7 +561,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
             <button
               onClick={() => setShowAgentSidebar((v) => !v)}
-              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-dim) hover:text-(--color-text-2)"
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
               title="Agent Capabilities (Ctrl+A)"
               aria-label="Agent capabilities"
             >

--- a/web/src/components/TeamChatView/index.tsx
+++ b/web/src/components/TeamChatView/index.tsx
@@ -41,9 +41,6 @@ import { useTileLayout } from '@/hooks/useTileLayout'
 import { useTeamAgentsQuery } from '@/queries/useAgentsQuery'
 import { useSpeechConfigQuery } from '@/queries/useSpeechConfigQuery'
 import {
-  Maximize2,
-  LayoutGrid,
-  Layers,
   Users,
   FolderOpen,
   SplitSquareHorizontal,
@@ -53,7 +50,11 @@ import {
   Moon,
 } from 'lucide-react'
 import { useIsMobile } from '@/hooks/use-mobile'
-import { formatTokens } from '@/utils/format'
+import { AgentChip } from '@/components/ui/agent-chip'
+import { isAgentRole } from '@/lib/agent-roles'
+import { TokenMeter } from '@/components/ui/token-meter'
+import { ViewToggle } from '@/components/ui/view-toggle'
+import { TopbarAction } from '@/components/ui/topbar-action'
 import { type InputBarHandle, type SlashCommand } from '../InputBar'
 import { FloatingInputBar } from '../FloatingInputBar'
 import type { AgentCapabilities as AgentCapabilitiesType } from '@/api/types'
@@ -372,11 +373,33 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
           )}
 
           {/* Left: agent tabs (agent view) or unified tab strip */}
-          <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
             {effectiveViewMode === 'agent' && agentNames.map((name) => {
               const stream = agentStreams[name]
               const isActive = activeAgent === name
               const isWorking = stream?.status === 'working'
+              const isError = stream?.status === 'error'
+
+              // Override dot color when status diverges from idle.
+              const dotClassName = isError
+                ? 'bg-(--color-error)'
+                : isWorking
+                  ? 'animate-pulse bg-(--color-accent)'
+                  : undefined
+
+              if (isAgentRole(name)) {
+                return (
+                  <AgentChip
+                    key={name}
+                    role={name}
+                    active={isActive}
+                    onClick={() => setActiveAgent(name)}
+                    dotClassName={dotClassName}
+                    label={name === leadName ? `${name} ·` : undefined}
+                  />
+                )
+              }
+
               return (
                 <button
                   key={name}
@@ -388,8 +411,8 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
                   }`}
                 >
                   <span className={`h-1.5 w-1.5 rounded-full ${
-                    isWorking ? 'animate-pulse bg-(--color-accent)'
-                    : stream?.status === 'error' ? 'bg-(--color-error)'
+                    isError ? 'bg-(--color-error)'
+                    : isWorking ? 'animate-pulse bg-(--color-accent)'
                     : 'bg-(--color-success)'
                   }`} />
                   {name}
@@ -423,26 +446,12 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
             {/* Token count — desktop only, too noisy on mobile */}
             {!isMobile && totalAll > 0 && (
-              <div
-                className="flex items-center gap-2 rounded-md px-2 py-1 text-xs text-(--color-text-muted)"
-                title={`Prompt: ${totalPrompt.toLocaleString()} · Output: ${totalCompletion.toLocaleString()}${totalCached > 0 ? ` · Cached: ${totalCached.toLocaleString()}` : ''}`}
-              >
-                <span className="text-(--color-text-muted)">tokens</span>
-                <span className="font-mono text-(--color-text-2)">
-                  {formatTokens(totalPrompt)}
-                  <span className="mx-0.5 text-(--color-text-subtle)">/</span>
-                  {formatTokens(totalCompletion)}
-                  {totalCached > 0 && (
-                    <>
-                      <span className="mx-0.5 text-(--color-text-subtle)">/</span>
-                      <span className="text-(--color-syn-operator)">{formatTokens(totalCached)}</span>
-                    </>
-                  )}
-                </span>
-                {isTeamWorking && (
-                  <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-(--color-accent)" />
-                )}
-              </div>
+              <TokenMeter
+                input={totalPrompt}
+                output={totalCompletion}
+                cached={totalCached}
+                pulsing={isTeamWorking}
+              />
             )}
 
             {/* Dream running indicator */}
@@ -470,35 +479,7 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
 
             {/* 3-way view toggle — desktop only. Mobile always uses agent view. */}
             {!isMobile && (
-              <div className="flex items-center rounded-lg border border-(--color-border) bg-(--bg-page) p-0.5">
-                <button
-                  onClick={() => setViewMode('agent')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'agent' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
-                  title="Agent view (Ctrl+V)"
-                  aria-label="Agent view"
-                  aria-pressed={viewMode === 'agent'}
-                >
-                  <Maximize2 size={12} aria-hidden="true" />Agent
-                </button>
-                <button
-                  onClick={() => setViewMode('split')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'split' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
-                  title="Split view (Ctrl+V)"
-                  aria-label="Split view"
-                  aria-pressed={viewMode === 'split'}
-                >
-                  <LayoutGrid size={12} aria-hidden="true" />Split
-                </button>
-                <button
-                  onClick={() => setViewMode('unified')}
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-all ${viewMode === 'unified' ? 'bg-(--bg-key) text-(--color-accent)' : 'text-(--color-text-muted) hover:text-(--color-text-2)'}`}
-                  title="Unified view (Ctrl+V)"
-                  aria-label="Unified view"
-                  aria-pressed={viewMode === 'unified'}
-                >
-                  <Layers size={12} aria-hidden="true" />Unified
-                </button>
-              </div>
+              <ViewToggle value={viewMode} onValueChange={setViewMode} />
             )}
 
             <Popover open={showTodos} onOpenChange={setShowTodos}>
@@ -548,26 +529,22 @@ export function TeamChatView({ sessionId }: TeamChatViewProps) {
               </PopoverContent>
             </Popover>
 
-            <button
+            <TopbarAction
+              Icon={FolderOpen}
+              label="Files"
               onClick={() => setShowFilesPanel((v) => !v)}
               disabled={!sessionIdState}
-              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-50"
               title={sessionIdState ? 'Workspace files (Ctrl+F)' : 'No active session'}
               aria-label="Workspace files"
-            >
-              <FolderOpen size={13} aria-hidden="true" />
-              <span className="hidden md:inline">Files</span>
-            </button>
+            />
 
-            <button
+            <TopbarAction
+              Icon={Users}
+              label="Agents"
               onClick={() => setShowAgentSidebar((v) => !v)}
-              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
               title="Agent Capabilities (Ctrl+A)"
               aria-label="Agent capabilities"
-            >
-              <Users size={13} aria-hidden="true" />
-              <span className="hidden md:inline">Agents</span>
-            </button>
+            />
           </div>
         </header>
 

--- a/web/src/components/TeamStatusBar.tsx
+++ b/web/src/components/TeamStatusBar.tsx
@@ -33,7 +33,7 @@ export function TeamStatusBar({
   error,
 }: TeamStatusBarProps) {
   return (
-    <div className="flex items-center justify-between border-t border-(--color-border) bg-(--color-bg) px-4 py-1 text-xs text-(--color-text-muted)">
+    <div className="flex items-center justify-between border-t border-(--color-border) bg-(--bg-page) px-4 py-1 text-xs text-(--color-text-muted)">
       {/* Left */}
       <div className="flex items-center gap-2">
         {sessionId && (
@@ -64,7 +64,7 @@ export function TeamStatusBar({
         {Object.entries(agentStreams).map(([name, stream]) => (
           <div
             key={name}
-            className="flex items-center gap-1 rounded-md bg-(--color-surface-2) px-1.5 py-0.5"
+            className="flex items-center gap-1 rounded-md bg-(--bg-key) px-1.5 py-0.5"
           >
             <StatusDot status={stream.status} />
             <span className="text-(--color-text-2)">{name}</span>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,7 +1,8 @@
 /**
  * ThemeToggle — three-way preference control (System / Light / Dark).
  *
- * Expanded: segmented control with all three options visible.
+ * Expanded: segmented control of three icon-only buttons. Labels live on
+ * `aria-label` and `title` only — same density rule as `ViewToggle`.
  * Collapsed: single icon button showing the current preference; click cycles
  * `system -> light -> dark -> system`.
  */
@@ -48,7 +49,7 @@ export function ThemeToggle({ collapsed = false }: { collapsed?: boolean }) {
     <div
       role="radiogroup"
       aria-label="Theme preference"
-      className="flex items-center gap-0.5 rounded-lg border border-(--color-border) bg-(--bg-page) p-0.5"
+      className="inline-flex items-center overflow-hidden rounded-md border border-(--color-border-subtle) p-0.5"
     >
       {OPTIONS.map(({ value, label, Icon }) => {
         const active = preference === value
@@ -58,16 +59,16 @@ export function ThemeToggle({ collapsed = false }: { collapsed?: boolean }) {
             type="button"
             role="radio"
             aria-checked={active}
-            onClick={() => setPreference(value)}
+            aria-label={label}
             title={label}
-            className={`interactive-weight flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors ${
+            onClick={() => setPreference(value)}
+            className={`interactive-weight inline-flex h-7 w-7 items-center justify-center rounded-sm transition-colors ${
               active
-                ? 'bg-(--bg-key) text-(--color-text)'
-                : 'text-(--color-text-muted) hover:text-(--color-text)'
+                ? 'bg-(--color-surface-2) text-(--color-text)'
+                : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text-2)'
             }`}
           >
-            <Icon size={12} />
-            <span>{label}</span>
+            <Icon size={14} aria-hidden="true" />
           </button>
         )
       })}

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -37,7 +37,7 @@ export function ThemeToggle({ collapsed = false }: { collapsed?: boolean }) {
         onClick={() => setPreference(NEXT[preference])}
         title={`Theme: ${current.label} (click to cycle)`}
         aria-label={`Theme: ${current.label}. Click to cycle.`}
-        className="interactive-weight flex h-8 w-8 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+        className="interactive-weight flex h-8 w-8 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
       >
         <Icon size={14} />
       </button>
@@ -48,7 +48,7 @@ export function ThemeToggle({ collapsed = false }: { collapsed?: boolean }) {
     <div
       role="radiogroup"
       aria-label="Theme preference"
-      className="flex items-center gap-0.5 rounded-lg border border-(--color-border) bg-(--color-bg) p-0.5"
+      className="flex items-center gap-0.5 rounded-lg border border-(--color-border) bg-(--bg-page) p-0.5"
     >
       {OPTIONS.map(({ value, label, Icon }) => {
         const active = preference === value
@@ -62,7 +62,7 @@ export function ThemeToggle({ collapsed = false }: { collapsed?: boolean }) {
             title={label}
             className={`interactive-weight flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors ${
               active
-                ? 'bg-(--color-accent-subtle) text-(--color-text)'
+                ? 'bg-(--bg-key) text-(--color-text)'
                 : 'text-(--color-text-muted) hover:text-(--color-text)'
             }`}
           >

--- a/web/src/components/Thinking.tsx
+++ b/web/src/components/Thinking.tsx
@@ -1,12 +1,16 @@
 /**
- * Thinking — quiet, aside-style reasoning trace.
+ * Thinking — paper-card reasoning trace.
  *
- * Visual language:
- *   - No container/background/border chrome. A single left rule
- *     (`border-l` in `--color-border`) with left padding marks the block as
- *     a margin note, not a card.
- *   - Trigger is text-only: chevron + label + optional streaming dots.
- *     No brain/icon clichés.
+ * Visual language follows the pencil source (node ``ptE8V``,
+ * ``ThinkingCollapsed``):
+ *
+ *   - Outer card: 1px ``--color-border`` outline, ``rounded-md``, padded
+ *     ``px-3 py-2.5``. Sits on the ambient surface (no fill of its own).
+ *   - Header: chevron + label in Inter 13/500 ``--color-text-2`` plus a
+ *     mono 11px ``--color-text-muted`` sub-hint ("tap to read" /
+ *     "tap to collapse") that mirrors the pencil layout.
+ *   - Streaming: dots replace the sub-hint while content is still
+ *     arriving so the label stays the visual anchor.
  *
  * Label behaviour:
  *   - Default: "Reasoning".
@@ -133,29 +137,36 @@ export function Thinking({ content, isStreaming }: ThinkingProps) {
   }, [content, isStreaming])
 
   return (
-    <div className="my-2 border-l border-(--color-border) pl-3">
-      {/* Trigger — text-only, no card chrome */}
+    <div className="my-2 overflow-hidden rounded-md border border-(--color-border)">
+      {/* Trigger — paper card per pencil ptE8V */}
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="group -ml-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-(--color-text-muted) transition-colors duration-(--motion-fast) ease-(--ease-out) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
+        className="group flex w-full items-center gap-2.5 px-3 py-2.5 text-left transition-colors duration-(--motion-fast) ease-(--ease-out) hover:bg-(--bg-key) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
         aria-expanded={expanded}
         aria-label={expanded ? 'Collapse reasoning' : 'Expand reasoning'}
       >
         <ChevronRight
-          size={12}
-          className={`shrink-0 transition-transform duration-(--motion-fast) ease-(--ease-out) ${expanded ? 'rotate-90' : ''}`}
+          size={14}
+          className={`shrink-0 text-(--color-text-muted) transition-transform duration-(--motion-fast) ease-(--ease-out) ${expanded ? 'rotate-90' : ''}`}
           aria-hidden
         />
-        <span className="flex items-center gap-1.5 font-medium">
-          <span>{label}</span>
-          {isStreaming && (
-            <ThinkingDots className="text-(--color-text-muted)" aria-label={`${label}…`} />
-          )}
+        <span className="flex-1 truncate text-[13px] font-medium text-(--color-text-2)">
+          {label}
         </span>
+        {isStreaming ? (
+          <ThinkingDots
+            className="shrink-0 text-(--color-text-muted)"
+            aria-label={`${label}…`}
+          />
+        ) : (
+          <span className="shrink-0 font-mono text-[11px] text-(--color-text-muted)">
+            {expanded ? 'tap to collapse' : 'tap to read'}
+          </span>
+        )}
       </button>
 
-      {/* Expanded body — indented muted italic, no extra container */}
+      {/* Expanded body — divider then warm paper wash, mono italic prose */}
       <AnimatePresence initial={false}>
         {expanded && (
           <motion.div
@@ -166,9 +177,11 @@ export function Thinking({ content, isStreaming }: ThinkingProps) {
             transition={{ duration: DURATIONS_S.base, ease: EASINGS.out }}
             className="overflow-hidden"
           >
-            <p className="mt-1 whitespace-pre-wrap pb-1 pl-1 font-mono text-xs italic leading-relaxed text-(--color-text-muted)">
-              {body}
-            </p>
+            <div className="border-t border-(--color-border) bg-(--bg-key) px-3 py-2.5">
+              <p className="whitespace-pre-wrap font-mono text-xs italic leading-relaxed text-(--color-text-muted)">
+                {body}
+              </p>
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/web/src/components/Thinking.tsx
+++ b/web/src/components/Thinking.tsx
@@ -138,7 +138,7 @@ export function Thinking({ content, isStreaming }: ThinkingProps) {
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="group -ml-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-(--color-text-muted) transition-colors duration-(--motion-fast) ease-(--ease-out) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--color-focus-ring)"
+        className="group -ml-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-(--color-text-muted) transition-colors duration-(--motion-fast) ease-(--ease-out) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
         aria-expanded={expanded}
         aria-label={expanded ? 'Collapse reasoning' : 'Expand reasoning'}
       >

--- a/web/src/components/ToastStack.tsx
+++ b/web/src/components/ToastStack.tsx
@@ -74,7 +74,7 @@ function ToastItem({ t, dismiss }: ToastItemProps) {
       dragMomentum={false}
       onDragEnd={handleDragEnd}
       whileDrag={{ cursor: 'grabbing' }}
-      className="pointer-events-auto flex cursor-grab items-start gap-3 rounded-xl bg-(--color-surface-2) p-3 shadow-xl ring-1 ring-(--color-border) select-none"
+      className="pointer-events-auto flex cursor-grab items-start gap-3 rounded-xl bg-(--bg-key) p-3 shadow-xl ring-1 ring-(--color-border) select-none"
       role="status"
       aria-live="polite"
     >
@@ -88,7 +88,7 @@ function ToastItem({ t, dismiss }: ToastItemProps) {
       <button
         onClick={() => dismiss(t.id)}
         aria-label="Dismiss"
-        className="shrink-0 rounded-md p-1 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+        className="shrink-0 rounded-md p-1 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
       >
         <X size={12} />
       </button>

--- a/web/src/components/TodosPopover.tsx
+++ b/web/src/components/TodosPopover.tsx
@@ -1,0 +1,178 @@
+/**
+ * TodosPopover — task-list popover surfaced from the team-chat topbar.
+ *
+ * Trigger uses the ``TopbarAction`` primitive for visual consistency
+ * with Files/Agents in the same row. The popover content follows the
+ * paper-card chrome: ``--color-surface`` body, ``--color-border``
+ * outline, ``rounded-md`` corners, mono-uppercase header to match
+ * other panel titles in the app (Sidebar "Recent", etc.).
+ *
+ * Status icons are lucide outlines (``Check``/``X``/``Play``/``Circle``)
+ * sized at 12px, colored by role:
+ *   - completed  → ``--color-success``
+ *   - cancelled  → ``--color-text-subtle``
+ *   - in_progress → ``--color-accent``
+ *   - pending    → ``--color-text-muted``
+ *
+ * Priority badges drop the raw red/amber Tailwind colors in favor of
+ * design tokens — ``--color-error`` (high), ``--color-warning``
+ * (medium), ``--bg-key`` (low) — so the panel respects light/dark
+ * theme without per-color overrides.
+ *
+ * Empty state borrows the hand-drawn Caveat idiom used by AgentView
+ * and TileArea so the visual voice stays consistent.
+ */
+
+import { Check, Circle, ListTodo, Play, X } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { TopbarAction } from '@/components/ui/topbar-action'
+import type { TodoItem } from '@/api/types'
+
+// ── Status icon mapping ──────────────────────────────────────────────────────
+
+const STATUS_ICON: Record<TodoItem['status'], LucideIcon> = {
+  completed: Check,
+  cancelled: X,
+  in_progress: Play,
+  pending: Circle,
+}
+
+const STATUS_ICON_COLOR: Record<TodoItem['status'], string> = {
+  completed: 'text-(--color-success)',
+  cancelled: 'text-(--color-text-subtle)',
+  in_progress: 'text-(--color-accent)',
+  pending: 'text-(--color-text-muted)',
+}
+
+// Sort: in_progress first, then pending, completed, cancelled.
+const STATUS_ORDER: Record<TodoItem['status'], number> = {
+  in_progress: 0,
+  pending: 1,
+  completed: 2,
+  cancelled: 3,
+}
+
+// ── Priority badge mapping ───────────────────────────────────────────────────
+
+const PRIORITY_BADGE_CLASS: Record<TodoItem['priority'], string> = {
+  high: 'bg-(--color-error)/10 text-(--color-error)',
+  medium: 'bg-(--color-warning)/10 text-(--color-warning)',
+  low: 'bg-(--bg-key) text-(--color-text-subtle)',
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface TodosPopoverProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  todos: TodoItem[]
+  /** When null/undefined the trigger is disabled (no active session). */
+  sessionId: string | null
+}
+
+export function TodosPopover({
+  open,
+  onOpenChange,
+  todos,
+  sessionId,
+}: TodosPopoverProps) {
+  const completedCount = todos.filter((t) => t.status === 'completed').length
+  const hasInProgress = todos.some((t) => t.status === 'in_progress')
+  const sorted = [...todos].sort(
+    (a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status],
+  )
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      {/* base-ui composes via the ``render`` prop (not Radix's
+          ``asChild``). Passing the TopbarAction element here lets
+          base-ui forward its trigger props onto the primitive button
+          we already styled, so the topbar control matches Files /
+          Agents one-for-one. */}
+      <PopoverTrigger
+        render={
+          <TopbarAction
+            Icon={ListTodo}
+            label="Todos"
+            indicator={hasInProgress}
+            title={sessionId ? 'Task list (Ctrl+T)' : 'No active session'}
+            aria-label="Task list"
+          />
+        }
+        disabled={!sessionId}
+      />
+      <PopoverContent
+        side="bottom"
+        align="end"
+        // ``ring-0`` cancels the shadcn PopoverContent default
+        // ``ring-1 ring-foreground/10`` (a near-black hairline that
+        // clashes with the paper-card aesthetic). Outline is owned by
+        // the ``--color-border`` ring instead, matching the rest of
+        // the restyled surfaces.
+        className="w-80 overflow-hidden rounded-md bg-(--color-surface) p-0 shadow-md ring-1 ring-(--color-border)"
+      >
+        {/* Header: mono-uppercase title + completion counter. */}
+        <div className="flex items-center justify-between border-b border-(--color-border) px-3 py-2">
+          <span className="font-mono text-[10px] font-medium uppercase tracking-wider text-(--color-text-muted)">
+            Tasks
+          </span>
+          {todos.length > 0 && (
+            <span className="font-mono text-[10px] text-(--color-text-subtle)">
+              {completedCount}/{todos.length} done
+            </span>
+          )}
+        </div>
+
+        {todos.length === 0 ? (
+          // Hand-drawn Caveat empty state — matches AgentView /
+          // TileArea idiom for the rest of the restyled empty surfaces.
+          <div className="px-3 py-8 text-center">
+            <p className="font-(family-name:--font-hand) text-base text-(--color-text-subtle)">
+              No tasks yet —
+              <br />
+              ask the agent to plan
+            </p>
+          </div>
+        ) : (
+          <ul className="max-h-80 overflow-y-auto py-1">
+            {sorted.map((todo) => {
+              const Icon = STATUS_ICON[todo.status]
+              const iconColor = STATUS_ICON_COLOR[todo.status]
+              const isDone =
+                todo.status === 'completed' || todo.status === 'cancelled'
+              return (
+                <li
+                  key={todo.task_id}
+                  className="flex items-start gap-2 px-3 py-1.5"
+                >
+                  <Icon
+                    size={12}
+                    aria-hidden="true"
+                    className={`mt-0.5 shrink-0 ${iconColor}`}
+                  />
+                  <span
+                    className={`flex-1 text-xs leading-snug ${
+                      isDone
+                        ? 'text-(--color-text-subtle) line-through'
+                        : 'text-(--color-text)'
+                    }`}
+                  >
+                    {todo.content}
+                  </span>
+                  <span
+                    className={`shrink-0 self-start rounded px-1 py-0.5 font-mono text-[9px] font-medium uppercase ${
+                      PRIORITY_BADGE_CLASS[todo.priority]
+                    }`}
+                  >
+                    {todo.priority}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/web/src/components/ToolCall/StatusDot.tsx
+++ b/web/src/components/ToolCall/StatusDot.tsx
@@ -7,11 +7,13 @@ import type { ToolCallState } from './types'
 
 export function StatusDot({ state }: { state: ToolCallState }) {
   const cls =
-    state === 'pending'
+    state === 'start'
       ? 'bg-(--color-text-muted)'
       : state === 'running'
-        ? 'bg-(--color-accent) shadow-[0_0_5px_var(--color-accent)] animate-pulse'
-        : 'bg-(--color-success)'
+        ? 'animate-pulse bg-(--color-marker-orange) shadow-[0_0_5px_var(--color-marker-orange)]'
+        : state === 'failed'
+          ? 'bg-(--color-error)'
+          : 'bg-(--color-success)'
   return (
     <span
       className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${cls}`}

--- a/web/src/components/ToolCall/index.tsx
+++ b/web/src/components/ToolCall/index.tsx
@@ -80,7 +80,7 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
       <button
         type="button"
         onClick={() => hasDetails && setExpanded((v) => !v)}
-        className={`group -ml-1 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs transition-colors duration-(--motion-fast) ease-(--ease-out) focus-visible:outline-2 focus-visible:outline-(--color-focus-ring) ${
+        className={`group -ml-1 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs transition-colors duration-(--motion-fast) ease-(--ease-out) focus-visible:outline-2 focus-visible:outline-(--focus-ring) ${
           hasDetails
             ? 'cursor-pointer hover:text-(--color-text-2)'
             : 'cursor-default'
@@ -144,7 +144,7 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
                     </span>
                     <button
                       onClick={handleCopyArgs}
-                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--color-focus-ring)"
+                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
                       aria-label="Copy arguments"
                       title="Copy"
                     >
@@ -155,7 +155,7 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
                       )}
                     </button>
                   </div>
-                  <div className="rounded-md border border-(--color-border) bg-(--color-surface-2) px-2.5 py-2">
+                  <div className="rounded-md border border-(--color-border) bg-(--bg-key) px-2.5 py-2">
                     {language === 'bash' ? (
                       <pre className="overflow-auto whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-(--color-accent)">
                         <span className="select-none text-(--color-text-muted)">$ </span>
@@ -179,7 +179,7 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
                     </span>
                     <button
                       onClick={handleCopyResult}
-                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--color-focus-ring)"
+                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
                       aria-label="Copy result"
                       title="Copy result"
                     >
@@ -190,7 +190,7 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
                       )}
                     </button>
                   </div>
-                  <div className="rounded-md border border-(--color-border) bg-(--color-surface-2) px-2.5 py-2 text-xs leading-relaxed text-(--color-text-2)">
+                  <div className="rounded-md border border-(--color-border) bg-(--bg-key) px-2.5 py-2 text-xs leading-relaxed text-(--color-text-2)">
                     <ToolResult toolName={name} result={shownResult} />
                   </div>
                 </section>

--- a/web/src/components/ToolCall/index.tsx
+++ b/web/src/components/ToolCall/index.tsx
@@ -1,16 +1,18 @@
 /**
- * ToolCall — quiet, aside-style record of a tool invocation.
+ * ToolCall — paper-card record of a tool invocation.
  *
- * Visual language mirrors `Thinking`: no card, no gray fill, no tool-type
- * icon. A single left rule (`border-l` in `--color-border`) with left
- * padding marks the block as a margin note. Identity is carried by a
- * colored status dot (matching the `AgentCapabilities` vocabulary) +
- * either a tool-specific one-line summary or the bare tool name.
+ * Visual language follows the pencil source (nodes ``dqwZw`` / ``LJOUY``)
+ * and the canonical spec at ``applications.md#tool-call-row``:
  *
- * Collapsed: dot + summary + optional done check.
- * Expanded: arguments (optionally as a bash code block) and/or result,
- * each with its own copy button; both sections share the left rule
- * indentation rather than living inside their own surfaces.
+ *   - Outer card: 1px ``--color-border`` outline, ``rounded-md``, on the
+ *     ambient surface (no fill of its own — sits on the chat surface).
+ *   - Header row: status dot + mono tool-name (or one-line summary) +
+ *     chevron, padded ``px-3 py-2``.
+ *   - Expanded body: divider, then the args/result panels on the warm
+ *     ``--bg-key`` surface so the actual content gets a calm reading wash.
+ *
+ * Identity is carried by a colored status dot (pending / running /
+ * done) matching the capability colour vocabulary.
  *
  * The per-tool header/args customisation lives in ``./display.tsx``;
  * this module owns only the chrome (collapse, copy, status dot, motion).
@@ -75,14 +77,14 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
   const displayName = name || 'tool'
 
   return (
-    <div className="tool-row-enter my-2 border-l border-(--color-border) pl-3">
-      {/* Header row — text-first, no card chrome */}
+    <div className="tool-row-enter my-2 overflow-hidden rounded-md border border-(--color-border)">
+      {/* Header row — card-padded, mono name, chevron at end */}
       <button
         type="button"
         onClick={() => hasDetails && setExpanded((v) => !v)}
-        className={`group -ml-1 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs transition-colors duration-(--motion-fast) ease-(--ease-out) focus-visible:outline-2 focus-visible:outline-(--focus-ring) ${
+        className={`group flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs transition-colors duration-(--motion-fast) ease-(--ease-out) focus-visible:outline-2 focus-visible:outline-(--focus-ring) ${
           hasDetails
-            ? 'cursor-pointer hover:text-(--color-text-2)'
+            ? 'cursor-pointer hover:bg-(--bg-key)'
             : 'cursor-default'
         }`}
         aria-expanded={expanded}
@@ -94,34 +96,38 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
             : `${displayName} (no details)`
         }
       >
-        {hasDetails && (
-          <ChevronRight
-            size={12}
-            className={`shrink-0 text-(--color-text-muted) transition-transform duration-(--motion-fast) ease-(--ease-out) ${expanded ? 'rotate-90' : ''}`}
-            aria-hidden
-          />
-        )}
         <StatusDot state={state} />
 
         {/* Header content: tool-specific summary or fallback to tool name.
             Only argument values inside the header are italicised (via <Arg>);
-            the verb/framing text stays upright. */}
+            the verb/framing text stays upright. Mono+600 per pencil dqwZw. */}
         {header ? (
-          <span className="flex-1 truncate text-(--color-text-2)" title={headerTitle ?? undefined}>
+          <span
+            className="flex-1 truncate font-mono font-semibold text-(--color-text)"
+            title={headerTitle ?? undefined}
+          >
             {header}
           </span>
         ) : (
-          <code className="flex-1 truncate font-mono font-medium text-(--color-text-2)">
+          <code className="flex-1 truncate font-mono font-semibold text-(--color-text)">
             {displayName}
           </code>
         )}
 
         {isPending && (
-          <span className="shrink-0 text-(--color-text-muted)">pending</span>
+          <span className="shrink-0 font-mono text-(--color-text-muted)">pending</span>
+        )}
+
+        {hasDetails && (
+          <ChevronRight
+            size={14}
+            className={`shrink-0 text-(--color-text-muted) transition-transform duration-(--motion-fast) ease-(--ease-out) ${expanded ? 'rotate-90' : ''}`}
+            aria-hidden
+          />
         )}
       </button>
 
-      {/* Expandable details — no card, flows under the same left rule */}
+      {/* Expandable details — divider then warm paper body per pencil LJOUY */}
       <AnimatePresence initial={false}>
         {expanded && hasDetails && (
           <motion.div
@@ -132,30 +138,28 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
             transition={{ duration: DURATIONS_S.base, ease: EASINGS.out }}
             className="overflow-hidden"
           >
-            <div className="mt-1.5 space-y-2 pl-1 pb-1">
-              {/* Args section — caption + copy sit above a subtle panel so
-                  the actual content (JSON / bash / text) gets a calm reading
-                  surface without the heavy overlay we used before. */}
-              {formattedArgs && (
-                <section className="relative">
-                  <div className="mb-1 flex items-center justify-between gap-2">
-                    <span className="text-[10px] uppercase tracking-wider text-(--color-text-subtle)">
-                      {language === 'bash' ? 'bash' : 'arguments'}
-                    </span>
-                    <button
-                      onClick={handleCopyArgs}
-                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
-                      aria-label="Copy arguments"
-                      title="Copy"
-                    >
-                      {copiedArgs ? (
-                        <Check size={12} className="text-(--color-success)" />
-                      ) : (
-                        <Copy size={12} />
-                      )}
-                    </button>
-                  </div>
-                  <div className="rounded-md border border-(--color-border) bg-(--bg-key) px-2.5 py-2">
+            <div className="border-t border-(--color-border) bg-(--bg-key)">
+              <div className="space-y-3 px-3 py-2.5">
+                {/* Args section — caption + copy sit above the content. */}
+                {formattedArgs && (
+                  <section className="relative">
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <span className="text-[10px] uppercase tracking-wider text-(--color-text-subtle)">
+                        {language === 'bash' ? 'bash' : 'arguments'}
+                      </span>
+                      <button
+                        onClick={handleCopyArgs}
+                        className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:text-(--color-text) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
+                        aria-label="Copy arguments"
+                        title="Copy"
+                      >
+                        {copiedArgs ? (
+                          <Check size={12} className="text-(--color-success)" />
+                        ) : (
+                          <Copy size={12} />
+                        )}
+                      </button>
+                    </div>
                     {language === 'bash' ? (
                       <pre className="overflow-auto whitespace-pre-wrap break-all font-mono text-xs leading-relaxed text-(--color-accent)">
                         <span className="select-none text-(--color-text-muted)">$ </span>
@@ -166,35 +170,35 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
                         {formattedArgs}
                       </pre>
                     )}
-                  </div>
-                </section>
-              )}
+                  </section>
+                )}
 
-              {/* Result section — same caption + panel treatment as args. */}
-              {shownResult && (
-                <section className="relative">
-                  <div className="mb-1 flex items-center justify-between gap-2">
-                    <span className="text-[10px] uppercase tracking-wider text-(--color-text-subtle)">
-                      result
-                    </span>
-                    <button
-                      onClick={handleCopyResult}
-                      className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
-                      aria-label="Copy result"
-                      title="Copy result"
-                    >
-                      {copiedResult ? (
-                        <Check size={12} className="text-(--color-success)" />
-                      ) : (
-                        <Copy size={12} />
-                      )}
-                    </button>
-                  </div>
-                  <div className="rounded-md border border-(--color-border) bg-(--bg-key) px-2.5 py-2 text-xs leading-relaxed text-(--color-text-2)">
-                    <ToolResult toolName={name} result={shownResult} />
-                  </div>
-                </section>
-              )}
+                {/* Result section — same caption treatment as args. */}
+                {shownResult && (
+                  <section className="relative">
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <span className="text-[10px] uppercase tracking-wider text-(--color-text-subtle)">
+                        result
+                      </span>
+                      <button
+                        onClick={handleCopyResult}
+                        className="rounded p-0.5 text-(--color-text-muted) transition-colors hover:text-(--color-text) focus-visible:outline-2 focus-visible:outline-(--focus-ring)"
+                        aria-label="Copy result"
+                        title="Copy result"
+                      >
+                        {copiedResult ? (
+                          <Check size={12} className="text-(--color-success)" />
+                        ) : (
+                          <Copy size={12} />
+                        )}
+                      </button>
+                    </div>
+                    <div className="text-xs leading-relaxed text-(--color-text-2)">
+                      <ToolResult toolName={name} result={shownResult} />
+                    </div>
+                  </section>
+                )}
+              </div>
             </div>
           </motion.div>
         )}

--- a/web/src/components/ToolCall/index.tsx
+++ b/web/src/components/ToolCall/index.tsx
@@ -11,8 +11,8 @@
  *   - Expanded body: divider, then the args/result panels on the warm
  *     ``--bg-key`` surface so the actual content gets a calm reading wash.
  *
- * Identity is carried by a colored status dot (pending / running /
- * done) matching the capability colour vocabulary.
+ * Identity is carried by a colored status dot for the lifecycle:
+ * start / running / success / failed.
  *
  * The per-tool header/args customisation lives in ``./display.tsx``;
  * this module owns only the chrome (collapse, copy, status dot, motion).
@@ -34,19 +34,37 @@ interface ToolCallProps {
   result?: string // tool response content
 }
 
+function isFailedResult(result: string | undefined): boolean {
+  if (!result) return false
+  const firstLine = result.trimStart().split('\n', 1)[0]?.toLowerCase() ?? ''
+  return (
+    firstLine.startsWith('[failed') ||
+    firstLine.startsWith('[error') ||
+    firstLine.includes('exit code 1') ||
+    firstLine.includes('exit 1')
+  )
+}
+
 export function ToolCall({ name, args, done, result }: ToolCallProps) {
   // Hooks must be called unconditionally — before any early returns
   const [expanded, setExpanded] = useState(false)
   const [copiedArgs, setCopiedArgs] = useState(false)
   const [copiedResult, setCopiedResult] = useState(false)
 
-  // Determine status: pending (no args yet) → running (args, not done) → done
+  // Determine status: start (name only) → running (args) → success/failed (result)
   const isPending = args === undefined || args === null
   const isRunning = !isPending && !done
-  const state: ToolCallState = done ? 'done' : isRunning ? 'running' : 'pending'
+  const state: ToolCallState = isPending
+    ? 'start'
+    : isRunning
+      ? 'running'
+      : isFailedResult(result)
+        ? 'failed'
+        : 'success'
 
   const { header, headerTitle, formattedArgs, language, suppressResult } =
     getToolDisplay(name, args)
+  const visibleHeader = isPending ? null : header
   const shownResult = suppressResult ? undefined : result
 
   const handleCopyArgs = async (e: React.MouseEvent) => {
@@ -101,21 +119,17 @@ export function ToolCall({ name, args, done, result }: ToolCallProps) {
         {/* Header content: tool-specific summary or fallback to tool name.
             Only argument values inside the header are italicised (via <Arg>);
             the verb/framing text stays upright. Mono+600 per pencil dqwZw. */}
-        {header ? (
+        {visibleHeader ? (
           <span
             className="flex-1 truncate font-mono font-semibold text-(--color-text)"
             title={headerTitle ?? undefined}
           >
-            {header}
+            {visibleHeader}
           </span>
         ) : (
           <code className="flex-1 truncate font-mono font-semibold text-(--color-text)">
             {displayName}
           </code>
-        )}
-
-        {isPending && (
-          <span className="shrink-0 font-mono text-(--color-text-muted)">pending</span>
         )}
 
         {hasDetails && (

--- a/web/src/components/ToolCall/types.ts
+++ b/web/src/components/ToolCall/types.ts
@@ -24,4 +24,4 @@ export interface ToolDisplay {
   suppressResult?: boolean
 }
 
-export type ToolCallState = 'pending' | 'running' | 'done'
+export type ToolCallState = 'start' | 'running' | 'success' | 'failed'

--- a/web/src/components/ToolResult.tsx
+++ b/web/src/components/ToolResult.tsx
@@ -8,7 +8,7 @@
  * Visual language matches the `ToolCall` aside: no opaque dark fills, no
  * boxed-in containers. Results flow under the same left-rule indentation
  * as the args. When a code-like block is needed (file contents, shell
- * output), we use a quiet `--color-surface-2` tint and a thin border
+ * output), we use a quiet `--bg-key` tint and a thin border
  * rather than an overlay. Theme-aware, no hard-coded rgba.
  */
 

--- a/web/src/components/VoiceMicButton.tsx
+++ b/web/src/components/VoiceMicButton.tsx
@@ -157,7 +157,7 @@ export function VoiceMicButton({
       className={`flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full transition-colors disabled:opacity-25 ${
         voiceState === 'recording'
           ? 'bg-(--color-error)/15 text-(--color-error) hover:bg-(--color-error)/25'
-          : 'text-(--color-text-muted) hover:bg-(--color-accent-subtle) hover:text-(--color-text)'
+          : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text)'
       }`}
     >
       {icon}

--- a/web/src/components/VoiceMicButton.tsx
+++ b/web/src/components/VoiceMicButton.tsx
@@ -154,10 +154,10 @@ export function VoiceMicButton({
       aria-label={label}
       title={title}
       data-recording={voiceState === 'recording' ? 'true' : undefined}
-      className={`flex h-8 w-8 shrink-0 self-end items-center justify-center rounded-full transition-colors disabled:opacity-25 ${
+      className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md border transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
         voiceState === 'recording'
-          ? 'bg-(--color-error)/15 text-(--color-error) hover:bg-(--color-error)/25'
-          : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text)'
+          ? 'border-(--color-error) bg-(--color-error)/15 text-(--color-error) hover:bg-(--color-error)/25'
+          : 'border-(--color-border) bg-(--color-surface) text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)'
       }`}
     >
       {icon}

--- a/web/src/components/Welcome.tsx
+++ b/web/src/components/Welcome.tsx
@@ -74,7 +74,7 @@ export function Welcome({ onReady }: WelcomeProps) {
 
         {/* Wordmark */}
         <div>
-          <h1 className="text-4xl font-bold tracking-tight text-(--color-text)">
+          <h1 className="font-hand text-6xl leading-none text-(--color-text)">
             OpenAgentd
           </h1>
           <p className="mt-2 text-sm text-(--color-text-muted)">

--- a/web/src/components/Welcome.tsx
+++ b/web/src/components/Welcome.tsx
@@ -49,7 +49,7 @@ export function Welcome({ onReady }: WelcomeProps) {
         : 'ready'
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center bg-(--color-bg)">
+    <div className="flex h-screen flex-col items-center justify-center bg-(--bg-page)">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -58,7 +58,7 @@ export function Welcome({ onReady }: WelcomeProps) {
       >
         {/* Logo with glow */}
         <div className="relative">
-          <div className="absolute inset-0 rounded-3xl bg-(--color-accent-subtle) blur-2xl" />
+          <div className="absolute inset-0 rounded-3xl bg-(--bg-key) blur-2xl" />
           <motion.div
             animate={
               step === 'ready'
@@ -66,7 +66,7 @@ export function Welcome({ onReady }: WelcomeProps) {
                 : { scale: 1 }
             }
             transition={{ duration: 0.5, ease: 'easeInOut' }}
-            className="relative flex h-20 w-20 items-center justify-center rounded-3xl bg-(--color-accent-subtle) ring-1 ring-(--color-border-strong)"
+            className="relative flex h-20 w-20 items-center justify-center rounded-3xl bg-(--bg-key) ring-1 ring-(--color-border-strong)"
           >
             <img src={OpenAgentdAppIcon} width={72} height={72} alt="OpenAgentd logo" className="rounded-2xl" />
           </motion.div>
@@ -85,7 +85,7 @@ export function Welcome({ onReady }: WelcomeProps) {
         {/* Progress */}
         <div className="flex w-56 flex-col items-center gap-3">
           {/* Progress bar */}
-          <div className="h-0.5 w-full overflow-hidden rounded-full bg-(--color-accent-subtle)">
+          <div className="h-0.5 w-full overflow-hidden rounded-full bg-(--bg-key)">
             <motion.div
               className={`h-full rounded-full ${
                 step === 'error'
@@ -107,7 +107,7 @@ export function Welcome({ onReady }: WelcomeProps) {
               error={step === 'error'}
               label="Backend"
             />
-            <div className="h-px w-4 bg-(--color-accent-subtle)" />
+            <div className="h-px w-4 bg-(--bg-key)" />
             <StepIcon
               icon={Users}
               done={teamStatus.isSuccess}
@@ -115,7 +115,7 @@ export function Welcome({ onReady }: WelcomeProps) {
               error={false}
               label="Team"
             />
-            <div className="h-px w-4 bg-(--color-accent-subtle)" />
+            <div className="h-px w-4 bg-(--bg-key)" />
             <StepIcon
               icon={CheckCircle2}
               done={step === 'ready'}
@@ -172,10 +172,10 @@ function StepIcon({
           error
             ? 'bg-(--color-error-subtle) text-(--color-error)'
             : done
-              ? 'bg-(--color-success-subtle) text-(--color-success)'
+              ? 'bg-(--accent-green-soft) text-(--color-success)'
               : active
-                ? 'bg-(--color-accent-subtle) text-(--color-accent)'
-                : 'bg-(--color-accent-dim) text-(--color-text-muted)'
+                ? 'bg-(--bg-key) text-(--color-accent)'
+                : 'bg-(--bg-key) text-(--color-text-muted)'
         }`}
       >
         {error ? (

--- a/web/src/components/WikiPanel.tsx
+++ b/web/src/components/WikiPanel.tsx
@@ -97,14 +97,14 @@ export function WikiPanel({ open, onClose }: WikiPanelProps) {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '-100%', opacity: 0 }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
-            className="fixed inset-y-0 left-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden bg-(--color-surface) shadow-2xl"
+            className="fixed inset-y-0 left-0 z-50 flex w-[min(960px,90vw)] flex-col overflow-hidden bg-(--bg-card) shadow-2xl"
           >
             <header className="flex items-center justify-between border-b border-(--color-border) px-4 py-3">
               <div className="flex items-center gap-2">
                 {isMobile && mobilePane === 'editor' && (
                   <button
                     onClick={handleBack}
-                    className="rounded p-1 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+                    className="rounded p-1 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
                     aria-label="Back to file list"
                   >
                     <ArrowLeft size={16} />
@@ -119,7 +119,7 @@ export function WikiPanel({ open, onClose }: WikiPanelProps) {
               </div>
               <button
                 onClick={onClose}
-                className="rounded p-1 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+                className="rounded p-1 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
                 aria-label="Close wiki panel"
               >
                 <X size={16} />
@@ -252,8 +252,8 @@ function WikiSection({
                   className={cn(
                     'group flex w-full items-start gap-1.5 rounded px-2 py-1.5 text-left text-xs transition-colors',
                     isActive
-                      ? 'bg-(--color-accent-subtle) text-(--color-accent)'
-                      : 'text-(--color-text-2) hover:bg-(--color-accent-subtle) hover:text-(--color-text)',
+                      ? 'bg-(--bg-key) text-(--color-accent)'
+                      : 'text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)',
                   )}
                   title={file.description || name}
                 >
@@ -356,7 +356,7 @@ function WikiEditor({
               className={cn(
                 'flex items-center gap-1 rounded px-2.5 py-1 text-xs font-medium transition-colors',
                 dirty
-                  ? 'text-(--color-success) hover:bg-(--color-success-subtle)'
+                  ? 'text-(--color-success) hover:bg-(--accent-green-soft)'
                   : 'cursor-not-allowed text-(--color-text-subtle)',
               )}
               title="Save (Ctrl+S)"
@@ -400,8 +400,8 @@ function WikiEditor({
         className={cn(
           'min-h-0 flex-1 resize-none p-4 font-mono text-sm text-(--color-text) focus:outline-none',
           isReadOnly
-            ? 'cursor-default bg-(--color-surface-2) text-(--color-text-muted)'
-            : 'bg-(--color-bg)',
+            ? 'cursor-default bg-(--bg-key) text-(--color-text-muted)'
+            : 'bg-(--bg-page)',
         )}
         placeholder={
           isReadOnly ? '' :

--- a/web/src/components/WorkspaceFilesPanel.tsx
+++ b/web/src/components/WorkspaceFilesPanel.tsx
@@ -136,8 +136,8 @@ function FileRow({
       className={cn(
         'group flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs transition-colors',
         selected
-          ? 'bg-(--color-accent-subtle) text-(--color-accent)'
-          : 'text-(--color-text-2) hover:bg-(--color-accent-subtle) hover:text-(--color-text)',
+          ? 'bg-(--bg-key) text-(--color-accent)'
+          : 'text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)',
       )}
       title={file.path}
     >
@@ -187,7 +187,7 @@ function ImagePreview({ sessionId, file }: { sessionId: string; file: WorkspaceF
   const url = workspaceMediaUrl(sessionId, file.path)
   return (
     <>
-      <div className="flex h-full items-center justify-center bg-(--color-bg) p-4">
+      <div className="flex h-full items-center justify-center bg-(--bg-page) p-4">
         <img
           src={url}
           alt={file.name}
@@ -288,7 +288,7 @@ function BinaryPreview({ sessionId, file }: { sessionId: string; file: Workspace
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-1.5 rounded-md bg-(--color-accent-subtle) px-3 py-1.5 text-xs text-(--color-accent) transition-colors hover:bg-(--color-accent-dim)"
+          className="flex items-center gap-1.5 rounded-md bg-(--bg-key) px-3 py-1.5 text-xs text-(--color-accent) transition-colors hover:bg-(--bg-key)"
         >
           <ExternalLink size={12} /> Open in new tab
         </a>
@@ -347,7 +347,7 @@ export function CopyContentsButton({
       disabled={busy || tooLarge}
       title={title}
       aria-label={title}
-      className="flex items-center gap-1 rounded px-2 py-1 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-(--color-text-muted)"
+      className="flex items-center gap-1 rounded px-2 py-1 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2) disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-(--color-text-muted)"
     >
       {copied ? (
         <Check size={12} className="text-(--color-success)" />
@@ -384,7 +384,7 @@ function PreviewArea({
           <a
             href={workspaceMediaUrl(sessionId, file.path)}
             download={file.name}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
             title="Download"
           >
             <Download size={12} />
@@ -509,7 +509,7 @@ export function WorkspaceFilesPanel({ open, sessionId, onClose }: WorkspaceFiles
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: '100%', opacity: 0 }}
             transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
-            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,95vw)] flex-col overflow-hidden border-l border-(--color-border) bg-(--color-surface) shadow-2xl"
+            className="fixed inset-y-0 right-0 z-50 flex w-[min(960px,95vw)] flex-col overflow-hidden border-l border-(--color-border) bg-(--bg-card) shadow-2xl"
             role="dialog"
             aria-modal="true"
             aria-label="Workspace files"
@@ -521,7 +521,7 @@ export function WorkspaceFilesPanel({ open, sessionId, onClose }: WorkspaceFiles
                 {isMobile && mobilePane === 'preview' && (
                   <button
                     onClick={handleBackToTree}
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
                     aria-label="Back to file list"
                   >
                     <ArrowLeft size={14} />
@@ -541,7 +541,7 @@ export function WorkspaceFilesPanel({ open, sessionId, onClose }: WorkspaceFiles
                 <button
                   onClick={() => refetch()}
                   disabled={!sessionId || isFetching}
-                  className="rounded p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text) disabled:opacity-50"
+                  className="rounded p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:opacity-50"
                   title="Refresh"
                   aria-label="Refresh"
                 >
@@ -549,7 +549,7 @@ export function WorkspaceFilesPanel({ open, sessionId, onClose }: WorkspaceFiles
                 </button>
                 <button
                   onClick={onClose}
-                  className="rounded p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+                  className="rounded p-1.5 text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
                   title="Close (Esc)"
                   aria-label="Close"
                 >

--- a/web/src/components/previews/AgentTopbarPreview.tsx
+++ b/web/src/components/previews/AgentTopbarPreview.tsx
@@ -1,0 +1,126 @@
+/**
+ * AgentTopbarPreview — composite preview matching the three pencil
+ * variants in the right-cluster section `BbrKe`:
+ *
+ *   1. Default   — agent view, no token meter, no dream
+ *   2. Working   — agent view, token meter pulsing + Dream running
+ *   3. Unified   — unified view, split-pane buttons + 3-mode ViewToggle
+ *
+ * The component is preview-only so it owns its own viewMode state and
+ * the actions are no-ops.
+ */
+
+import { useState } from 'react'
+import { FolderOpen, ListChecks, Users } from 'lucide-react'
+
+import { AgentTopbar } from '@/components/AgentTopbar'
+import type { ViewMode } from '@/components/ui/view-toggle'
+
+function PreviewFrame({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-[10px] border border-(--color-border) bg-(--bg-page)">
+      <div className="border-b border-(--color-border) px-4 py-2">
+        <h3 className="font-mono text-xs font-semibold uppercase tracking-wider text-(--color-text-2)">
+          {title}
+        </h3>
+        <p className="text-xs text-(--color-text-muted)">{description}</p>
+      </div>
+      {/* Mock left-cluster filler so the right cluster sits at the trailing edge,
+          mirroring the production header layout. */}
+      <header className="flex items-center gap-1.5 px-4">
+        <div className="min-w-0 flex-1 truncate text-xs text-(--color-text-muted)">
+          ← left cluster (agent tabs / split label / unified strip)
+        </div>
+        {children}
+      </header>
+    </div>
+  )
+}
+
+export function AgentTopbarPreview() {
+  const [defaultMode, setDefaultMode] = useState<ViewMode>('agent')
+  const [workingMode, setWorkingMode] = useState<ViewMode>('agent')
+  const [unifiedMode, setUnifiedMode] = useState<ViewMode>('unified')
+
+  const todos = {
+    Icon: ListChecks,
+    label: 'Todos',
+    onClick: () => undefined,
+  }
+  const files = {
+    Icon: FolderOpen,
+    label: 'Files',
+    onClick: () => undefined,
+  }
+  const agents = {
+    Icon: Users,
+    label: 'Agents',
+    onClick: () => undefined,
+  }
+
+  return (
+    <section className="grid gap-5 rounded-[14px] border border-(--color-border) bg-(--bg-card) p-5 text-(--color-text)">
+      <div>
+        <h2 className="font-hand text-3xl font-bold">AgentTopbar</h2>
+        <p className="text-sm text-(--color-text-2)">
+          Composite topbar right-cluster used across single-agent and team chats.
+        </p>
+      </div>
+
+      <div className="grid gap-3">
+        <PreviewFrame
+          title="1 · Default"
+          description="Idle agent view — no token meter, no dream indicator."
+        >
+          <AgentTopbar
+            viewMode={defaultMode}
+            onViewModeChange={setDefaultMode}
+            todosAction={todos}
+            filesAction={files}
+            agentsAction={agents}
+          />
+        </PreviewFrame>
+
+        <PreviewFrame
+          title="2 · Working"
+          description="Token meter pulses while output climbs; Dream indicator appears."
+        >
+          <AgentTopbar
+            tokens={{ input: 12_400, output: 3_200, cached: 8_100, pulsing: true }}
+            dreamRunning
+            viewMode={workingMode}
+            onViewModeChange={setWorkingMode}
+            todosAction={{ ...todos, indicator: true }}
+            filesAction={files}
+            agentsAction={agents}
+          />
+        </PreviewFrame>
+
+        <PreviewFrame
+          title="3 · Unified"
+          description="Unified mode adds split-pane buttons before the view toggle."
+        >
+          <AgentTopbar
+            tokens={{ input: 18_900, output: 5_400, cached: 11_200 }}
+            viewMode={unifiedMode}
+            onViewModeChange={setUnifiedMode}
+            showSplitButtons
+            onSplitDown={() => undefined}
+            onSplitRight={() => undefined}
+            todosAction={todos}
+            filesAction={files}
+            agentsAction={agents}
+          />
+        </PreviewFrame>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/previews/FormPrimitivesPreview.tsx
+++ b/web/src/components/previews/FormPrimitivesPreview.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { DateTimePicker } from '@/components/ui/date-time-picker'
+import { Input } from '@/components/ui/input'
+import {
+  NumberInput,
+  NumberInputField,
+  NumberInputGroup,
+  NumberInputStepper,
+} from '@/components/ui/number-input'
+import { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger } from '@/components/ui/popover'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+
+function PreviewField({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="grid gap-1.5 text-xs font-medium text-(--color-text-muted)">
+      {label}
+      {children}
+    </label>
+  )
+}
+
+export function LowLevelComponentsPreview() {
+  const [agent, setAgent] = useState('researcher')
+  const [interval, setInterval] = useState<number | null>(3600)
+  const [startsAt, setStartsAt] = useState('')
+  const [enabled, setEnabled] = useState(true)
+
+  return (
+    <section className="grid gap-5 rounded-[14px] border border-(--color-border) bg-(--bg-card) p-5 text-(--color-text)">
+      <div>
+        <h2 className="font-hand text-3xl font-bold">Low-Level UI Components</h2>
+        <p className="text-sm text-(--color-text-2)">Tokenized primitive controls from the OpenAgentd color panel.</p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <PreviewField label="Input">
+          <Input placeholder="Task name" />
+        </PreviewField>
+
+        <PreviewField label="Select">
+          <Select value={agent} onValueChange={(value) => value && setAgent(value)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="researcher">Researcher</SelectItem>
+              <SelectItem value="reviewer">Reviewer</SelectItem>
+              <SelectItem value="writer">Writer</SelectItem>
+            </SelectContent>
+          </Select>
+        </PreviewField>
+
+        <PreviewField label="Number input">
+          <NumberInput value={interval} min={60} step={60} onValueChange={setInterval}>
+            <NumberInputGroup>
+              <NumberInputField aria-label="Interval seconds" />
+              <NumberInputStepper />
+            </NumberInputGroup>
+          </NumberInput>
+        </PreviewField>
+
+        <PreviewField label="Date time picker">
+          <DateTimePicker value={startsAt} onChange={setStartsAt} />
+        </PreviewField>
+
+        <div className="grid gap-2">
+          <span className="text-xs font-medium text-(--color-text-muted)">Segmented</span>
+          <Tabs defaultValue="every">
+            <TabsList className="w-full">
+              <TabsTrigger value="every">Every</TabsTrigger>
+              <TabsTrigger value="cron">Cron</TabsTrigger>
+              <TabsTrigger value="at">At</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <div className="grid gap-2">
+          <span className="text-xs font-medium text-(--color-text-muted)">Toggles</span>
+          <div className="flex items-center gap-5 rounded-[10px] border border-(--color-border) bg-(--bg-page) px-3 py-2">
+            <label className="flex items-center gap-2 text-sm">
+              <Checkbox defaultChecked /> Check
+            </label>
+            <RadioGroup defaultValue="one" className="flex gap-3">
+              <label className="flex items-center gap-2 text-sm">
+                <RadioGroupItem value="one" /> One
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <RadioGroupItem value="two" /> Two
+              </label>
+            </RadioGroup>
+            <label className="ml-auto flex items-center gap-2 text-sm">
+              <Switch checked={enabled} onCheckedChange={setEnabled} /> Enabled
+            </label>
+          </div>
+        </div>
+
+        <PreviewField label="Textarea">
+          <Textarea placeholder="What should the agent do?" />
+        </PreviewField>
+
+        <div className="grid content-start gap-2">
+          <span className="text-xs font-medium text-(--color-text-muted)">Popover</span>
+          <Popover>
+            <PopoverTrigger render={<Button variant="outline">Open popover</Button>} />
+            <PopoverContent align="start">
+              <PopoverHeader>
+                <PopoverTitle>Schedule conflict</PopoverTitle>
+                <PopoverDescription>This task overlaps with Daily report. Adjust the time to continue.</PopoverDescription>
+              </PopoverHeader>
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="ghost" size="sm">Dismiss</Button>
+                <Button size="sm">Resolve</Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function CreateTaskFormPreview() {
+  const [scheduleType, setScheduleType] = useState('every')
+  const [enabled, setEnabled] = useState(true)
+
+  return (
+    <section className="max-w-lg rounded-[14px] border border-(--color-border) bg-(--bg-card) p-6 text-(--color-text) shadow-[0_8px_32px_rgba(26,23,20,0.12)]">
+      <div className="mb-5">
+        <h2 className="font-hand text-3xl font-bold">Create scheduled task</h2>
+        <p className="text-sm text-(--color-text-2)">Composite preview assembled from the low-level primitives.</p>
+      </div>
+
+      <div className="grid gap-4">
+        <PreviewField label="Name">
+          <Input placeholder="Daily status report" />
+        </PreviewField>
+
+        <PreviewField label="Agent">
+          <Select defaultValue="researcher">
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="researcher">Researcher</SelectItem>
+              <SelectItem value="reviewer">Reviewer</SelectItem>
+              <SelectItem value="writer">Writer</SelectItem>
+            </SelectContent>
+          </Select>
+        </PreviewField>
+
+        <div className="grid gap-1.5">
+          <span className="text-xs font-medium text-(--color-text-muted)">Schedule type</span>
+          <Tabs value={scheduleType} onValueChange={setScheduleType}>
+            <TabsList className="w-full">
+              <TabsTrigger value="every">Every</TabsTrigger>
+              <TabsTrigger value="cron">Cron</TabsTrigger>
+              <TabsTrigger value="at">At</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+
+        <PreviewField label="Interval seconds">
+          <NumberInput defaultValue={3600} min={60} step={60}>
+            <NumberInputGroup>
+              <NumberInputField aria-label="Interval seconds" />
+              <NumberInputStepper />
+            </NumberInputGroup>
+          </NumberInput>
+        </PreviewField>
+
+        <PreviewField label="Prompt">
+          <Textarea placeholder="Summarize yesterday's work and draft today's priorities." />
+        </PreviewField>
+
+        <label className="flex items-center justify-between rounded-[10px] border border-(--color-border) bg-(--bg-page) px-3 py-2 text-sm">
+          <span>
+            Enabled
+            <span className="block text-xs text-(--color-text-muted)">Run this schedule after saving.</span>
+          </span>
+          <Switch checked={enabled} onCheckedChange={setEnabled} />
+        </label>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline">Cancel</Button>
+          <Button>Save task</Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/previews/ToolCallPreview.tsx
+++ b/web/src/components/previews/ToolCallPreview.tsx
@@ -1,0 +1,93 @@
+/**
+ * ToolCallPreview — composite preview that mirrors the lifecycle
+ * matrix in `.diagrams/OpenAgentd-ui.pen` (`W0qCF`/`sLqLL`):
+ *
+ *   1. Start         — name only, muted dot
+ *   2. Running       — args visible, pulsing orange dot
+ *   3. End · Success — green dot, result body
+ *   4. End · Failed  — red dot, error result body
+ *
+ * Each variant maps to a real `ToolCall` invocation so the preview
+ * stays in sync with the component's failure-detection heuristics
+ * (`isFailedResult`).
+ */
+
+import { ToolCall } from '@/components/ToolCall'
+
+function PreviewFrame({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-[10px] border border-(--color-border) bg-(--bg-page) p-4">
+      <div className="mb-2">
+        <h3 className="font-mono text-xs font-semibold uppercase tracking-wider text-(--color-text-2)">
+          {title}
+        </h3>
+        <p className="text-xs text-(--color-text-muted)">{description}</p>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function ToolCallPreview() {
+  return (
+    <section className="grid gap-5 rounded-[14px] border border-(--color-border) bg-(--bg-card) p-5 text-(--color-text)">
+      <div>
+        <h2 className="font-hand text-3xl font-bold">ToolCall lifecycle</h2>
+        <p className="text-sm text-(--color-text-2)">
+          Four canonical states a tool invocation passes through.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <PreviewFrame
+          title="1 · Start"
+          description="Tool name announced before any arguments stream in."
+        >
+          <ToolCall name="shell" />
+        </PreviewFrame>
+
+        <PreviewFrame
+          title="2 · Running"
+          description="Arguments visible; pulsing orange dot signals work in flight."
+        >
+          <ToolCall
+            name="shell"
+            args={JSON.stringify({ command: 'pytest --no-cov -q tests/api/test_streams.py' })}
+          />
+        </PreviewFrame>
+
+        <PreviewFrame
+          title="3 · End · Success"
+          description="Done with a clean result — green status dot."
+        >
+          <ToolCall
+            name="shell"
+            args={JSON.stringify({ command: 'pytest --no-cov -q tests/api/test_streams.py' })}
+            done
+            result={'..........\n10 passed in 0.42s'}
+          />
+        </PreviewFrame>
+
+        <PreviewFrame
+          title="4 · End · Failed"
+          description="Result begins with a failure marker — red status dot."
+        >
+          <ToolCall
+            name="shell"
+            args={JSON.stringify({ command: 'pytest --no-cov -q tests/api/test_streams.py' })}
+            done
+            result={'[Failed] exit code 1\nFAILED tests/api/test_streams.py::test_sse_close — AssertionError'}
+          />
+        </PreviewFrame>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -227,7 +227,7 @@ function ParseErrorBanner({
   onSwitchToRaw: () => void
 }) {
   return (
-    <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+    <div className="flex items-start gap-2 rounded-lg border border-(--color-error)/30 bg-(--color-error-subtle) px-3 py-2 text-xs text-(--color-error)">
       <AlertCircle size={14} className="mt-0.5 shrink-0" />
       <div className="flex-1">
         <p className="font-medium">Parse error</p>
@@ -595,7 +595,7 @@ function ModelPicker({
         disabled={disabled}
       >
         <SelectTrigger
-          className={cn('flex-1', invalid && 'aria-invalid:border-destructive')}
+          className={cn('flex-1', invalid && 'aria-invalid:border-(--color-error)')}
           aria-invalid={invalid || undefined}
         >
           <SelectValue placeholder={allowEmpty ? '(none)' : 'Select a model…'} />
@@ -652,15 +652,15 @@ function Field({
   // silently delete a chip when the user clicks empty space in the field.
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
-      <span className="text-xs font-medium text-foreground">
+      <span className="text-xs font-medium text-(--color-text)">
         {label}
-        {required && <span className="ml-0.5 text-destructive">*</span>}
+        {required && <span className="ml-0.5 text-(--color-error)">*</span>}
       </span>
       {children}
       {error ? (
-        <p className="text-[11px] text-destructive">{error}</p>
+        <p className="text-[11px] text-(--color-error)">{error}</p>
       ) : hint ? (
-        <p className="text-[11px] text-muted-foreground">{hint}</p>
+        <p className="text-[11px] text-(--color-text-muted)">{hint}</p>
       ) : null}
     </div>
   )

--- a/web/src/components/settings/CategoryList.tsx
+++ b/web/src/components/settings/CategoryList.tsx
@@ -110,10 +110,10 @@ const META: Record<Kind, KindMeta> = {
 }
 
 const STATE_COLOR: Record<ServerStatus['state'], string> = {
-  ready: 'bg-green-500',
-  starting: 'bg-yellow-500',
-  error: 'bg-destructive',
-  stopped: 'bg-muted-foreground/40',
+  ready: 'bg-(--accent-green)',
+  starting: 'bg-(--accent-orange)',
+  error: 'bg-(--color-error)',
+  stopped: 'bg-(--color-text-muted)/40',
 }
 
 // ─── Public entry point ────────────────────────────────────────────────────
@@ -221,22 +221,22 @@ function ListShell({ meta, rows, isLoading, isError }: ListShellProps) {
       aria-label={meta.title}
       className={
         isMobile
-          ? 'flex h-full min-h-0 flex-1 flex-col border-r-0 bg-background'
-          : 'flex h-full w-72 shrink-0 flex-col border-r border-border bg-background'
+          ? 'flex h-full min-h-0 flex-1 flex-col border-r-0 bg-(--bg-page)'
+          : 'flex h-full w-72 shrink-0 flex-col border-r border-(--color-border) bg-(--bg-page)'
       }
     >
-      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-border px-3">
+      <header className="flex h-14 shrink-0 items-center gap-2 border-b border-(--color-border) px-3">
         {/* Mobile: back arrow to return to settings hub */}
         {isMobile && (
           <Link
             to="/settings"
             aria-label="Back to settings"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
           >
             <ArrowLeft size={16} aria-hidden="true" />
           </Link>
         )}
-        <h2 className="flex-1 truncate text-sm font-semibold">{meta.title}</h2>
+        <h2 className="flex-1 truncate text-sm font-semibold text-(--color-text)">{meta.title}</h2>
         <Tooltip>
           <TooltipTrigger
             render={
@@ -256,11 +256,11 @@ function ListShell({ meta, rows, isLoading, isError }: ListShellProps) {
 
       {/* Search */}
       {rows.length > 0 && (
-        <div className="border-b border-border p-2">
+        <div className="border-b border-(--color-border) p-2">
           <div className="relative">
             <Search
               size={12}
-              className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-(--color-text-muted)"
               aria-hidden="true"
             />
             <Input
@@ -277,19 +277,19 @@ function ListShell({ meta, rows, isLoading, isError }: ListShellProps) {
       {/* Body */}
       <div className="min-h-0 flex-1 overflow-y-auto">
         {isLoading && (
-          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+          <p className="px-3 py-6 text-center text-xs text-(--color-text-muted)">
             Loading…
           </p>
         )}
         {isError && (
-          <p className="px-3 py-6 text-center text-xs text-destructive">
+          <p className="px-3 py-6 text-center text-xs text-(--color-error)">
             Failed to load.
           </p>
         )}
         {!isLoading && !isError && rows.length === 0 && (
           <div className="flex flex-col items-center gap-3 px-4 py-10 text-center">
-            <p className="text-sm font-medium">{meta.emptyTitle}</p>
-            <p className="text-xs leading-relaxed text-muted-foreground">
+            <p className="text-sm font-medium text-(--color-text)">{meta.emptyTitle}</p>
+            <p className="text-xs leading-relaxed text-(--color-text-muted)">
               {meta.emptyBody}
             </p>
             <Button size="sm" render={<Link to={meta.newRoute} />}>
@@ -299,7 +299,7 @@ function ListShell({ meta, rows, isLoading, isError }: ListShellProps) {
           </div>
         )}
         {!isLoading && !isError && rows.length > 0 && filtered.length === 0 && (
-          <p className="px-3 py-6 text-center text-xs text-muted-foreground">
+          <p className="px-3 py-6 text-center text-xs text-(--color-text-muted)">
             No matches for &ldquo;{query}&rdquo;.
           </p>
         )}
@@ -340,17 +340,17 @@ function ListRowLink({
       aria-current={active ? 'page' : undefined}
       className={cn(
         'flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors',
-        'hover:bg-muted',
-        'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40',
-        active && 'bg-muted',
+        'hover:bg-(--bg-key) text-(--color-text-2)',
+        'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-(--focus-ring)/40',
+        active && 'bg-(--bg-key) text-(--color-text)',
       )}
     >
       <span
         className={cn(
           'flex h-7 w-7 shrink-0 items-center justify-center rounded-md ring-1',
           row.iconTone === 'accent'
-            ? 'bg-foreground/5 text-foreground ring-border'
-            : 'bg-muted text-muted-foreground ring-border',
+            ? 'bg-(--bg-key) text-(--color-text) ring-(--color-border)'
+            : 'bg-(--bg-key) text-(--color-text-muted) ring-(--color-border)',
         )}
         aria-hidden="true"
       >
@@ -361,7 +361,7 @@ function ListRowLink({
           <span
             className={cn(
               'truncate text-sm',
-              active ? 'font-semibold text-foreground' : 'font-medium',
+              active ? 'font-semibold text-(--color-text)' : 'font-medium',
             )}
           >
             {row.name}
@@ -370,7 +370,7 @@ function ListRowLink({
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <span className="text-destructive">
+                  <span className="text-(--color-error)">
                     <AlertCircle size={11} aria-label="Invalid configuration" />
                   </span>
                 }
@@ -382,7 +382,7 @@ function ListRowLink({
           )}
         </div>
         {row.subtitle && (
-          <p className="truncate text-[11px] text-muted-foreground">
+          <p className="truncate text-[11px] text-(--color-text-muted)">
             {row.subtitle}
           </p>
         )}
@@ -396,7 +396,7 @@ function McpStatusDot({ server }: { server: ServerStatus }) {
   if (server.state === 'error') {
     return (
       <span
-        className="flex shrink-0 items-center text-destructive"
+        className="flex shrink-0 items-center text-(--color-error)"
         title={server.error ?? 'Server failed to start'}
         aria-label={`Error: ${server.error ?? 'unknown'}`}
       >

--- a/web/src/components/settings/CategoryRail.tsx
+++ b/web/src/components/settings/CategoryRail.tsx
@@ -74,7 +74,7 @@ export function CategoryRail() {
   return (
     <nav
       aria-label="Settings categories"
-      className="flex h-full w-14 shrink-0 flex-col items-center gap-1 border-r border-border bg-muted/30 py-3"
+      className="flex h-full w-14 shrink-0 flex-col items-center gap-1 border-r border-(--color-border) bg-(--bg-sidebar) py-3"
     >
       {/* Exit settings → app home */}
       <Tooltip>
@@ -85,8 +85,8 @@ export function CategoryRail() {
               aria-label="Exit settings"
               className={cn(
                 'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
-                'text-muted-foreground hover:bg-muted hover:text-foreground',
-                'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40',
+                'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text)',
+                'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-(--focus-ring)/40',
               )}
             >
               <ArrowLeft size={16} aria-hidden="true" />
@@ -97,7 +97,7 @@ export function CategoryRail() {
       </Tooltip>
 
       <div
-        className="my-1.5 h-px w-6 shrink-0 bg-border"
+        className="my-1.5 h-px w-6 shrink-0 bg-(--color-border)"
         role="separator"
         aria-hidden="true"
       />
@@ -115,10 +115,10 @@ export function CategoryRail() {
                   aria-current={active ? 'page' : undefined}
                   className={cn(
                     'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
-                    'text-muted-foreground hover:bg-muted hover:text-foreground',
-                    'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40',
+                    'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text)',
+                    'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-(--focus-ring)/40',
                     active &&
-                      'bg-foreground/10 text-foreground ring-1 ring-border hover:bg-foreground/10',
+                      'bg-(--bg-key) text-(--color-text) ring-1 ring-(--color-border) hover:bg-(--bg-key)',
                   )}
                 >
                   <Icon size={16} aria-hidden="true" />

--- a/web/src/components/settings/DetailEmptyState.tsx
+++ b/web/src/components/settings/DetailEmptyState.tsx
@@ -28,19 +28,19 @@ export function DetailEmptyState({
   return (
     <div className="flex h-full items-center justify-center p-10">
       <div className="flex max-w-md flex-col items-center gap-4 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted ring-1 ring-border">
-          <Icon size={22} className="text-muted-foreground" aria-hidden="true" />
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-(--bg-key) ring-1 ring-(--color-border)">
+          <Icon size={22} className="text-(--color-text-muted)" aria-hidden="true" />
         </div>
         <div className="space-y-1.5">
-          <h2 className="text-base font-semibold">{title}</h2>
-          <p className="text-sm leading-relaxed text-muted-foreground">{body}</p>
+          <h2 className="text-base font-semibold text-(--color-text)">{title}</h2>
+          <p className="text-sm leading-relaxed text-(--color-text-muted)">{body}</p>
         </div>
         <Button size="sm" render={<Link to={ctaTo} />}>
           <Plus size={12} aria-hidden="true" />
           {ctaLabel}
         </Button>
         {tips && tips.length > 0 && (
-          <ul className="mt-2 w-full space-y-1.5 rounded-lg border border-border bg-card/40 p-3 text-left text-xs text-muted-foreground">
+          <ul className="mt-2 w-full space-y-1.5 rounded-lg border border-(--color-border) bg-(--bg-card) p-3 text-left text-xs text-(--color-text-muted)">
             {tips.map((tip, i) => (
               <li key={i} className="flex gap-2">
                 <span aria-hidden="true">•</span>

--- a/web/src/components/settings/EditorSubHeader.tsx
+++ b/web/src/components/settings/EditorSubHeader.tsx
@@ -82,7 +82,7 @@ export function EditorSubHeader({
       : null
 
   return (
-    <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-border bg-background px-4">
+    <header className="sticky top-0 z-10 flex h-14 items-center gap-3 border-b border-(--color-border) bg-(--bg-page) px-4">
       {/* Title block ─────────────────────────────────────────────── */}
       <Tooltip>
         <TooltipTrigger
@@ -100,16 +100,16 @@ export function EditorSubHeader({
       </Tooltip>
 
       <span
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground ring-1 ring-border"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-(--bg-key) text-(--color-text-muted) ring-1 ring-(--color-border)"
         aria-hidden="true"
       >
         <KindIcon size={13} />
       </span>
 
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-semibold leading-tight">{name}</p>
+        <p className="truncate text-sm font-semibold leading-tight text-(--color-text)">{name}</p>
         {path && (
-          <p className="truncate font-mono text-[10px] text-muted-foreground">
+          <p className="truncate font-mono text-[10px] text-(--color-text-muted)">
             {path}
           </p>
         )}
@@ -137,7 +137,7 @@ export function EditorSubHeader({
           <Tooltip>
             <TooltipTrigger
               render={
-                <span className="flex items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                <span className="flex items-center gap-1 rounded-md bg-(--color-error-subtle) px-2 py-1 text-xs text-(--color-error)">
                   <AlertCircle size={11} />
                   Error
                 </span>
@@ -150,7 +150,7 @@ export function EditorSubHeader({
           <Tooltip>
             <TooltipTrigger
               render={
-                <span className="flex items-center gap-1 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                <span className="flex items-center gap-1 rounded-md bg-(--color-error-subtle) px-2 py-1 text-xs text-(--color-error)">
                   <AlertCircle size={11} />
                   Invalid
                 </span>
@@ -160,10 +160,10 @@ export function EditorSubHeader({
           </Tooltip>
         )}
         {!error && !invalid && dirty && (
-          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5 text-xs text-(--color-text-muted)">
             <span
               className={cn(
-                'h-1.5 w-1.5 rounded-full bg-foreground',
+                'h-1.5 w-1.5 rounded-full bg-(--color-text)',
                 saving ? 'animate-pulse' : '',
               )}
               aria-hidden="true"

--- a/web/src/components/settings/McpServerForm.tsx
+++ b/web/src/components/settings/McpServerForm.tsx
@@ -217,15 +217,15 @@ function Field({
 }) {
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
-      <span className="text-xs font-medium text-foreground">
+      <span className="text-xs font-medium text-(--color-text)">
         {label}
-        {required && <span className="ml-0.5 text-destructive">*</span>}
+        {required && <span className="ml-0.5 text-(--color-error)">*</span>}
       </span>
       {children}
       {error ? (
-        <p className="text-[11px] text-destructive">{error}</p>
+        <p className="text-[11px] text-(--color-error)">{error}</p>
       ) : hint ? (
-        <p className="text-[11px] text-muted-foreground">{hint}</p>
+        <p className="text-[11px] text-(--color-text-muted)">{hint}</p>
       ) : null}
     </div>
   )
@@ -251,7 +251,7 @@ function EnabledToggle({
     <div
       role="radiogroup"
       aria-label="Server enabled state"
-      className="inline-flex h-9 rounded-md bg-muted p-0.5 ring-1 ring-border"
+      className="inline-flex h-9 rounded-md bg-(--bg-key) p-0.5 ring-1 ring-(--color-border)"
     >
       <ToggleOption
         active={value}
@@ -290,8 +290,8 @@ function ToggleOption({
       className={cn(
         'flex-1 rounded-sm px-3 text-xs font-medium transition-colors',
         active
-          ? 'bg-background text-foreground shadow-sm'
-          : 'text-muted-foreground hover:text-foreground',
+          ? 'bg-(--bg-card) text-(--color-text) shadow-sm'
+          : 'text-(--color-text-muted) hover:text-(--color-text)',
         disabled && 'cursor-not-allowed opacity-50',
       )}
     >
@@ -327,7 +327,7 @@ function PairListField({
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-foreground">{label}</span>
+        <span className="text-xs font-medium text-(--color-text)">{label}</span>
         <Button
           size="xs"
           variant="ghost"
@@ -341,7 +341,7 @@ function PairListField({
       </div>
 
       {pairs.length === 0 ? (
-        <p className="text-[11px] text-muted-foreground">None.</p>
+        <p className="text-[11px] text-(--color-text-muted)">None.</p>
       ) : (
         <div className="flex flex-col gap-1.5">
           {pairs.map((pair, idx) => (
@@ -374,7 +374,7 @@ function PairListField({
         </div>
       )}
 
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      {error && <p className="text-[11px] text-(--color-error)">{error}</p>}
     </div>
   )
 }

--- a/web/src/components/settings/MultiSelect.tsx
+++ b/web/src/components/settings/MultiSelect.tsx
@@ -121,19 +121,18 @@ export function MultiSelect({
             aria-haspopup="listbox"
             tabIndex={0}
             className={cn(
-              'flex min-h-8 w-full cursor-text flex-wrap items-center gap-1 rounded-lg border border-input bg-transparent px-1.5 py-1 text-sm transition-colors outline-none',
-              'focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50',
-              'aria-expanded:border-ring',
-              'dark:bg-input/30',
+              'flex min-h-8 w-full cursor-text flex-wrap items-center gap-1 rounded-lg border border-(--color-border) bg-(--bg-input) px-1.5 py-1 text-sm text-(--color-text) transition-colors outline-none',
+              'focus-visible:border-(--focus-ring) focus-visible:ring-3 focus-visible:ring-(--focus-ring)/50',
+              'aria-expanded:border-(--focus-ring)',
             )}
           >
             {value.length === 0 && (
-              <span className="px-1.5 text-muted-foreground">{placeholder}</span>
+              <span className="px-1.5 text-(--color-text-muted)">{placeholder}</span>
             )}
             {value.map((v) => (
               <span
                 key={v}
-                className="flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground"
+                className="flex items-center gap-1 rounded-sm bg-(--bg-key) px-1.5 py-0.5 font-mono text-xs text-(--color-text)"
               >
                 {v}
                 <button
@@ -147,7 +146,7 @@ export function MultiSelect({
                     remove(v)
                   }}
                   aria-label={`Remove ${v}`}
-                  className="text-muted-foreground transition-colors hover:text-foreground"
+                  className="text-(--color-text-muted) transition-colors hover:text-(--color-text)"
                 >
                   <X size={11} />
                 </button>
@@ -155,7 +154,7 @@ export function MultiSelect({
             ))}
             <ChevronDown
               size={14}
-              className="ml-auto shrink-0 self-center text-muted-foreground"
+              className="ml-auto shrink-0 self-center text-(--color-text-muted)"
               aria-hidden="true"
             />
           </div>
@@ -166,8 +165,8 @@ export function MultiSelect({
         sideOffset={4}
         className="w-[--anchor-width] min-w-72 max-w-[28rem] p-0"
       >
-        <div className="flex items-center gap-2 border-b border-border px-2.5 py-2">
-          <Search size={13} className="shrink-0 text-muted-foreground" aria-hidden="true" />
+        <div className="flex items-center gap-2 border-b border-(--color-border) px-2.5 py-2">
+          <Search size={13} className="shrink-0 text-(--color-text-muted)" aria-hidden="true" />
           <input
             id={searchId}
             ref={searchRef}
@@ -176,10 +175,10 @@ export function MultiSelect({
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKey}
             placeholder="Search…"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            className="flex-1 bg-transparent text-sm text-(--color-text) outline-none placeholder:text-(--color-text-muted)"
             aria-label="Search options"
           />
-          <span className="shrink-0 text-[11px] text-muted-foreground">
+          <span className="shrink-0 text-[11px] text-(--color-text-muted)">
             {filtered.length}/{options.length}
           </span>
         </div>
@@ -189,7 +188,7 @@ export function MultiSelect({
           className="max-h-64 overflow-y-auto py-1"
         >
           {filtered.length === 0 ? (
-            <li className="px-3 py-4 text-center text-sm text-muted-foreground">
+            <li className="px-3 py-4 text-center text-sm text-(--color-text-muted)">
               {emptyLabel}
             </li>
           ) : (
@@ -211,26 +210,26 @@ export function MultiSelect({
                     onMouseEnter={() => setHighlight(i)}
                     className={cn(
                       'flex w-full items-start gap-2 px-2.5 py-1.5 text-left transition-colors',
-                      isHi && 'bg-muted',
+                      isHi && 'bg-(--bg-key)',
                     )}
                   >
                     <span
                       className={cn(
-                        'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border text-foreground transition-colors',
+                        'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-colors',
                         isSel
-                          ? 'border-foreground bg-foreground text-background'
-                          : 'border-input',
+                          ? 'border-(--color-text) bg-(--color-text) text-(--bg-page)'
+                          : 'border-(--color-border) text-(--color-text)',
                       )}
                       aria-hidden="true"
                     >
                       {isSel && <Check size={10} strokeWidth={3} />}
                     </span>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate font-mono text-xs text-foreground">
+                      <p className="truncate font-mono text-xs text-(--color-text)">
                         {o.label}
                       </p>
                       {o.description && (
-                        <p className="truncate text-[11px] text-muted-foreground">
+                        <p className="truncate text-[11px] text-(--color-text-muted)">
                           {o.description}
                         </p>
                       )}

--- a/web/src/components/ui/agent-chip.tsx
+++ b/web/src/components/ui/agent-chip.tsx
@@ -8,7 +8,7 @@
  *
  * - 8×8 colored dot drawn in the role's marker color
  * - mono label
- * - rounded-full pill, padding 6×12, gap 8
+ * - rounded-md badge, padding 6×12, gap 8
  * - active variant: 1.2px border in role's marker color + bold (600) label in `--color-text`
  * - inactive variant: no border, 500-weight label in `--color-text-2`
  *
@@ -28,7 +28,7 @@ import { cn } from '@/lib/utils'
 import type { AgentRole } from '@/lib/agent-roles'
 
 const chipVariants = cva(
-  'inline-flex items-center gap-2 rounded-full px-3 py-1.5 font-mono text-xs leading-none transition-all',
+  'inline-flex items-center gap-2 rounded-md px-3 py-1.5 font-mono text-xs leading-none transition-all',
   {
     variants: {
       role: {

--- a/web/src/components/ui/agent-chip.tsx
+++ b/web/src/components/ui/agent-chip.tsx
@@ -1,0 +1,109 @@
+/**
+ * AgentChip — pill that identifies a canonical agent role.
+ *
+ * Visual structure (per `.diagrams/OpenAgentd-ui.pen`, components
+ * OpenagentdChip / ExecutorChip / ConsultantChip / ExplorerChip):
+ *
+ *   [● role]
+ *
+ * - 8×8 colored dot drawn in the role's marker color
+ * - mono label
+ * - rounded-full pill, padding 6×12, gap 8
+ * - active variant: 1.2px border in role's marker color + bold (600) label in `--color-text`
+ * - inactive variant: no border, 500-weight label in `--color-text-2`
+ *
+ * Roles map to marker tokens (NOT chip-soft tokens — the pencil deliberately
+ * uses the more saturated marker palette here):
+ *   openagentd  → mint    (--color-marker-mint)
+ *   executor    → orange  (--color-marker-orange)
+ *   consultant  → blue    (--color-marker-blue)
+ *   explorer    → muted   (--color-text-muted)
+ *
+ * The chip is identity-only. For interactive variants pass an `onClick`
+ * (the wrapper renders as a `<button>`); read-only variants render a `<span>`.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+import type { AgentRole } from '@/lib/agent-roles'
+
+const chipVariants = cva(
+  'inline-flex items-center gap-2 rounded-full px-3 py-1.5 font-mono text-xs leading-none transition-all',
+  {
+    variants: {
+      role: {
+        openagentd: '',
+        executor: '',
+        consultant: '',
+        explorer: '',
+      },
+      active: {
+        true: 'border font-semibold text-(--color-text)',
+        false: 'border-transparent font-medium text-(--color-text-2)',
+      },
+    },
+    compoundVariants: [
+      { role: 'openagentd', active: true, className: 'border-(--color-marker-mint)' },
+      { role: 'executor', active: true, className: 'border-(--color-marker-orange)' },
+      { role: 'consultant', active: true, className: 'border-(--color-marker-blue)' },
+      { role: 'explorer', active: true, className: 'border-(--color-text-muted)' },
+    ],
+    defaultVariants: {
+      role: 'openagentd',
+      active: false,
+    },
+  },
+)
+
+const dotColorByRole: Record<AgentRole, string> = {
+  openagentd: 'bg-(--color-marker-mint)',
+  executor: 'bg-(--color-marker-orange)',
+  consultant: 'bg-(--color-marker-blue)',
+  explorer: 'bg-(--color-text-muted)',
+}
+
+export interface AgentChipProps
+  extends Omit<React.ComponentPropsWithoutRef<'button'>, 'role'>,
+    VariantProps<typeof chipVariants> {
+  role: AgentRole
+  /** Optional override for the visible label (defaults to the role name). */
+  label?: string
+  /** Optional override of the dot color when an agent's status diverges from idle. */
+  dotClassName?: string
+}
+
+export function AgentChip({
+  role,
+  active = false,
+  label,
+  dotClassName,
+  className,
+  onClick,
+  ...rest
+}: AgentChipProps) {
+  const dotClasses = cn('h-2 w-2 shrink-0 rounded-full', dotColorByRole[role], dotClassName)
+  const content = (
+    <>
+      <span className={dotClasses} aria-hidden="true" />
+      <span className="truncate">{label ?? role}</span>
+    </>
+  )
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={Boolean(active)}
+        className={cn(chipVariants({ role, active }), className)}
+        {...rest}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <span className={cn(chipVariants({ role, active }), className)}>{content}</span>
+  )
+}

--- a/web/src/components/ui/brand-header.tsx
+++ b/web/src/components/ui/brand-header.tsx
@@ -1,0 +1,74 @@
+/**
+ * BrandHeader — sidebar brand row with mascot, Caveat title, and dock toggle.
+ *
+ * Pencil component `dtEOn` (BrandHeader):
+ *   [mascot 44]  OpenAgentd                 [⫶]
+ *                on-machine ai
+ *
+ * - Mascot 44×44 (image fill from /openagentd-app-icon.png)
+ * - Title: font-hand (Caveat), 28px, weight 700, --color-text
+ * - Subtitle: font-mono, 11px, --color-text-muted
+ * - Dock toggle: 32×32 outlined button on the right
+ * - Container: 64h, gap 12, padding 8×4
+ *
+ * Caveat is decorative chrome; the brand name is also conveyed by the
+ * adjacent app icon and any document/page title, so screen readers will
+ * still encounter "OpenAgentd" elsewhere.
+ */
+
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface BrandHeaderProps {
+  /** Whether the sidebar is currently expanded; flips the dock-toggle icon. */
+  expanded?: boolean
+  onToggle?: () => void
+  className?: string
+  /** Skip the dock toggle (mobile sheet, etc.). */
+  hideToggle?: boolean
+}
+
+export function BrandHeader({
+  expanded = true,
+  onToggle,
+  hideToggle = false,
+  className,
+}: BrandHeaderProps) {
+  const ToggleIcon = expanded ? PanelLeftClose : PanelLeftOpen
+
+  return (
+    <div
+      className={cn(
+        'flex h-16 items-center gap-3 px-1 py-2',
+        className,
+      )}
+    >
+      <img
+        src="/brand/openagentd-app-icon.png"
+        alt=""
+        aria-hidden="true"
+        className="h-11 w-11 shrink-0 select-none"
+        draggable={false}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="font-hand text-[28px] font-bold leading-none text-(--color-text)">
+          OpenAgentd
+        </span>
+        <span className="font-mono text-[11px] text-(--color-text-muted)">
+          on-machine ai
+        </span>
+      </div>
+      {!hideToggle && onToggle && (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          title={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-(--color-border-subtle) text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
+        >
+          <ToggleIcon size={16} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/ui/brand-header.tsx
+++ b/web/src/components/ui/brand-header.tsx
@@ -17,12 +17,15 @@
  */
 
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import OpenAgentdAppIcon from '@/assets/brand/openagentd-app-icon.png'
 import { cn } from '@/lib/utils'
 
 export interface BrandHeaderProps {
   /** Whether the sidebar is currently expanded; flips the dock-toggle icon. */
   expanded?: boolean
   onToggle?: () => void
+  /** Optional click handler for the brand block (mascot + title). */
+  onBrandClick?: () => void
   className?: string
   /** Skip the dock toggle (mobile sheet, etc.). */
   hideToggle?: boolean
@@ -31,20 +34,16 @@ export interface BrandHeaderProps {
 export function BrandHeader({
   expanded = true,
   onToggle,
+  onBrandClick,
   hideToggle = false,
   className,
 }: BrandHeaderProps) {
   const ToggleIcon = expanded ? PanelLeftClose : PanelLeftOpen
 
-  return (
-    <div
-      className={cn(
-        'flex h-16 items-center gap-3 px-1 py-2',
-        className,
-      )}
-    >
+  const brandContent = (
+    <>
       <img
-        src="/brand/openagentd-app-icon.png"
+        src={OpenAgentdAppIcon}
         alt=""
         aria-hidden="true"
         className="h-11 w-11 shrink-0 select-none"
@@ -58,6 +57,25 @@ export function BrandHeader({
           on-machine ai
         </span>
       </div>
+    </>
+  )
+
+  return (
+    <div className={cn('flex h-16 items-center gap-3 px-1 py-2', className)}>
+      {onBrandClick ? (
+        <button
+          type="button"
+          onClick={onBrandClick}
+          title="Home"
+          className="flex min-w-0 flex-1 items-center gap-3 rounded-md p-1 -ml-1 text-left transition-colors hover:bg-(--bg-key)"
+        >
+          {brandContent}
+        </button>
+      ) : (
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          {brandContent}
+        </div>
+      )}
       {!hideToggle && onToggle && (
         <button
           type="button"

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -4,33 +4,33 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-[10px] border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap text-(--color-text) transition-all outline-none select-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)/40 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "border-(--color-accent) bg-(--color-accent) text-(--color-text-on-accent) hover:opacity-90",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-(--color-border) bg-(--bg-page) hover:border-(--color-border-strong) hover:bg-(--bg-key) aria-expanded:border-(--color-border-strong) aria-expanded:bg-(--bg-key)",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "border-(--color-border) bg-(--bg-key) text-(--color-text) hover:bg-(--color-surface-2) aria-expanded:bg-(--color-surface-2)",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "bg-transparent hover:bg-(--bg-key) hover:text-(--color-text) aria-expanded:bg-(--bg-key)",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border-(--color-error)/25 bg-(--color-error-subtle) text-(--color-error) hover:bg-(--color-error)/15 focus-visible:ring-(--color-error)/20",
+        link: "bg-transparent text-(--accent-blue-text) underline-offset-4 hover:underline",
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-8",
+          "h-9 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
+        xs: "h-6 gap-1 rounded-[8px] px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1 rounded-[8px] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        icon: "size-9",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-6 rounded-[8px] [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+          "size-8 rounded-[8px]",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl border border-(--color-border) bg-(--bg-card) py-4 text-sm text-(--color-text) has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className
       )}
       {...props}
@@ -50,7 +50,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm text-(--color-text-muted)", className)}
       {...props}
     />
   )
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        "flex items-center rounded-b-xl border-t border-(--color-border) bg-(--bg-key)/50 p-4 group-data-[size=sm]/card:p-3",
         className
       )}
       {...props}

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,24 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { CheckIcon, MinusIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer flex size-[18px] shrink-0 items-center justify-center rounded-[4px] border border-(--color-border-strong) bg-(--bg-page) text-white transition-colors outline-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-(--accent-blue) data-checked:bg-(--accent-blue) data-indeterminate:border-(--accent-blue) data-indeterminate:bg-(--accent-blue) aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator keepMounted>
+        <CheckIcon className="hidden size-3 data-checked:block" aria-hidden="true" />
+        <MinusIcon className="hidden size-3 data-indeterminate:block" aria-hidden="true" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/web/src/components/ui/date-time-picker.tsx
+++ b/web/src/components/ui/date-time-picker.tsx
@@ -26,6 +26,9 @@ interface DateTimePickerProps {
   onChange: (value: string) => void
   placeholder?: string
   className?: string
+  /** Override classes on the trigger button — useful when embedding in a
+   *  drawer where the default `bg-(--bg-key)` clashes with sibling inputs. */
+  triggerClassName?: string
   disabled?: boolean
 }
 
@@ -65,7 +68,7 @@ function TimeUnit({
       onChange={handleChange}
       onKeyDown={handleKey}
       aria-label={label}
-      className="h-9 w-12 rounded-md border border-(--color-border) bg-(--bg-key) text-center text-sm tabular-nums text-(--color-text) focus:outline-none focus:ring-1 focus:ring-(--color-accent)"
+      className="h-9 w-12 rounded-[8px] border border-(--color-border) bg-(--bg-page) text-center text-sm tabular-nums text-(--color-text) focus:outline-none focus:ring-2 focus:ring-(--focus-ring)/25"
     />
   )
 }
@@ -77,6 +80,7 @@ export function DateTimePicker({
   onChange,
   placeholder = 'Pick date & time',
   className,
+  triggerClassName,
   disabled,
 }: DateTimePickerProps) {
   const [open, setOpen] = React.useState(false)
@@ -116,15 +120,16 @@ export function DateTimePicker({
           disabled={disabled}
           className={cn(
             buttonVariants({ variant: 'outline' }),
-            'h-9 w-full justify-start gap-2 rounded-lg border border-(--color-border) bg-(--bg-key) px-3 text-sm font-normal text-(--color-text) hover:bg-(--bg-key)',
+            'h-9 w-full justify-start gap-2 rounded-[10px] border border-(--color-border) bg-(--bg-page) px-3 text-sm font-normal text-(--color-text) hover:border-(--color-border-strong) hover:bg-(--bg-key)',
             !parsed && 'text-(--color-text-muted)',
+            triggerClassName,
           )}
         >
           <CalendarIcon className="size-4 shrink-0 opacity-60" />
           <span>{displayLabel}</span>
         </PopoverTrigger>
 
-        <PopoverContent className="w-auto p-0" align="start">
+          <PopoverContent className="w-auto overflow-hidden p-0" align="start">
           <Calendar
             mode="single"
             selected={parsed}
@@ -145,7 +150,7 @@ export function DateTimePicker({
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded-md bg-(--color-accent) px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+              className="rounded-[8px] bg-(--color-accent) px-3 py-1.5 text-xs font-medium text-(--color-text-on-accent) transition-opacity hover:opacity-90"
             >
               Done
             </button>

--- a/web/src/components/ui/date-time-picker.tsx
+++ b/web/src/components/ui/date-time-picker.tsx
@@ -65,7 +65,7 @@ function TimeUnit({
       onChange={handleChange}
       onKeyDown={handleKey}
       aria-label={label}
-      className="h-9 w-12 rounded-md border border-(--color-border) bg-(--color-surface-2) text-center text-sm tabular-nums text-(--color-text) focus:outline-none focus:ring-1 focus:ring-(--color-accent)"
+      className="h-9 w-12 rounded-md border border-(--color-border) bg-(--bg-key) text-center text-sm tabular-nums text-(--color-text) focus:outline-none focus:ring-1 focus:ring-(--color-accent)"
     />
   )
 }
@@ -116,7 +116,7 @@ export function DateTimePicker({
           disabled={disabled}
           className={cn(
             buttonVariants({ variant: 'outline' }),
-            'h-9 w-full justify-start gap-2 rounded-lg border border-(--color-border) bg-(--color-surface-2) px-3 text-sm font-normal text-(--color-text) hover:bg-(--color-surface-3)',
+            'h-9 w-full justify-start gap-2 rounded-lg border border-(--color-border) bg-(--bg-key) px-3 text-sm font-normal text-(--color-text) hover:bg-(--bg-key)',
             !parsed && 'text-(--color-text-muted)',
           )}
         >

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-(--color-border) bg-(--bg-card) p-4 text-sm text-(--color-text) duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-(--color-border) bg-(--bg-card) p-1 text-(--color-text) shadow-lg duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>
@@ -133,7 +133,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("w-auto min-w-[96px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn("w-auto min-w-[96px] rounded-md border border-(--color-border) bg-(--bg-card) p-1 text-(--color-text) shadow-lg duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
       align={align}
       alignOffset={alignOffset}
       side={side}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>
@@ -133,7 +133,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn("w-auto min-w-[96px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
       align={align}
       alignOffset={alignOffset}
       side={side}

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-9 w-full min-w-0 rounded-[10px] border border-(--color-border) bg-(--bg-page) px-3 py-1 text-sm text-(--color-text) transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-(--color-text) placeholder:text-(--color-text-subtle) hover:border-(--color-border-strong) focus-visible:border-(--focus-ring) focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-(--bg-key) disabled:text-(--color-text-muted) disabled:opacity-60 aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20",
         className
       )}
       {...props}

--- a/web/src/components/ui/native-select.tsx
+++ b/web/src/components/ui/native-select.tsx
@@ -24,7 +24,7 @@ function NativeSelect({
       <select
         data-slot="native-select"
         data-size={size}
-        className="h-8 w-full min-w-0 appearance-none rounded-lg border border-input bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
+        className="h-8 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent py-1 pr-8 pl-2.5 text-sm transition-colors outline-none select-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:cursor-not-allowed aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-[size=sm]:py-0.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40"
         {...props}
       />
       <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-2.5 size-4 -translate-y-1/2 text-muted-foreground select-none" aria-hidden="true" data-slot="native-select-icon" />

--- a/web/src/components/ui/number-input.tsx
+++ b/web/src/components/ui/number-input.tsx
@@ -1,0 +1,59 @@
+import { NumberField as NumberFieldPrimitive } from "@base-ui/react/number-field"
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function NumberInput({ className, ...props }: NumberFieldPrimitive.Root.Props) {
+  return (
+    <NumberFieldPrimitive.Root
+      data-slot="number-input"
+      className={cn("w-full", className)}
+      {...props}
+    />
+  )
+}
+
+function NumberInputGroup({ className, ...props }: NumberFieldPrimitive.Group.Props) {
+  return (
+    <NumberFieldPrimitive.Group
+      data-slot="number-input-group"
+      className={cn(
+        "flex h-9 w-full overflow-hidden rounded-[10px] border border-(--color-border) bg-(--bg-page) text-sm text-(--color-text) transition-colors focus-within:border-(--focus-ring) focus-within:ring-2 focus-within:ring-(--focus-ring)/25",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function NumberInputField({ className, ...props }: NumberFieldPrimitive.Input.Props) {
+  return (
+    <NumberFieldPrimitive.Input
+      data-slot="number-input-field"
+      className={cn(
+        "min-w-0 flex-1 bg-transparent px-3 font-mono text-sm tabular-nums outline-none placeholder:text-(--color-text-subtle) disabled:cursor-not-allowed disabled:opacity-60",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function NumberInputStepper({ className }: { className?: string }) {
+  return (
+    <div
+      data-slot="number-input-stepper"
+      className={cn("flex w-8 shrink-0 flex-col border-l border-(--color-border)", className)}
+    >
+      <NumberFieldPrimitive.Increment className="flex flex-1 items-center justify-center text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:opacity-40">
+        <ChevronUpIcon className="size-3" aria-hidden="true" />
+      </NumberFieldPrimitive.Increment>
+      <div className="h-px bg-(--color-border)" />
+      <NumberFieldPrimitive.Decrement className="flex flex-1 items-center justify-center text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:opacity-40">
+        <ChevronDownIcon className="size-3" aria-hidden="true" />
+      </NumberFieldPrimitive.Decrement>
+    </div>
+  )
+}
+
+export { NumberInput, NumberInputField, NumberInputGroup, NumberInputStepper }

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -35,7 +35,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-[12px] border border-(--color-border-strong) bg-(--bg-page) p-3.5 text-sm text-(--color-text) shadow-[0_8px_24px_rgba(26,23,20,0.16)] outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}
@@ -59,7 +59,7 @@ function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
   return (
     <PopoverPrimitive.Title
       data-slot="popover-title"
-      className={cn("font-medium", className)}
+      className={cn("font-semibold text-(--color-text)", className)}
       {...props}
     />
   )
@@ -72,7 +72,7 @@ function PopoverDescription({
   return (
     <PopoverPrimitive.Description
       data-slot="popover-description"
-      className={cn("text-muted-foreground", className)}
+      className={cn("text-(--color-text-2)", className)}
       {...props}
     />
   )

--- a/web/src/components/ui/queue-banner.tsx
+++ b/web/src/components/ui/queue-banner.tsx
@@ -1,0 +1,88 @@
+/**
+ * QueueBanner — aggregate "messages waiting" header for the pending queue.
+ *
+ * Pencil component `agDAu` (QueueBanner):
+ *   [● QUEUE · 2 messages awaiting                ⌄]
+ *
+ * - Mono, 11px, weight 600, letter-spacing 0.6
+ * - Orange marker dot (--color-marker-orange)
+ * - --color-surface fill, --color-border outline, soft drop shadow
+ * - Optional expand chevron rotates when expanded
+ * - radius-md
+ *
+ * Used as a header above the per-message PendingMessageQueue list. The
+ * banner summarises *count*; the list summarises *content*.
+ */
+
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface QueueBannerProps {
+  count: number
+  expanded?: boolean
+  onToggle?: () => void
+  className?: string
+  /** Override the noun ("messages") if needed. */
+  noun?: string
+}
+
+export function QueueBanner({
+  count,
+  expanded = true,
+  onToggle,
+  className,
+  noun = 'messages',
+}: QueueBannerProps) {
+  if (count <= 0) return null
+
+  const Icon = expanded ? ChevronUp : ChevronDown
+  const labelNoun = count === 1 ? noun.replace(/s$/, '') : noun
+  const interactive = Boolean(onToggle)
+
+  const content = (
+    <>
+      <span
+        className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--color-marker-orange)"
+        aria-hidden="true"
+      />
+      <span className="font-mono text-[11px] font-semibold tracking-wider text-(--color-text)">
+        QUEUE · {count} {labelNoun} awaiting
+      </span>
+      <span className="ml-auto" aria-hidden="true">
+        {interactive && (
+          <Icon
+            size={14}
+            className="text-(--color-text-2) transition-transform"
+          />
+        )}
+      </span>
+    </>
+  )
+
+  const baseClasses =
+    'flex w-full items-center gap-2 rounded-md border border-(--color-border) bg-(--color-surface) px-4 py-2.5 shadow-(--shadow-depth)'
+
+  if (interactive) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-label={`${count} ${labelNoun} awaiting (click to ${expanded ? 'collapse' : 'expand'})`}
+        className={cn(
+          baseClasses,
+          'transition-colors hover:bg-(--bg-key)',
+          className,
+        )}
+      >
+        {content}
+      </button>
+    )
+  }
+
+  return (
+    <div className={cn(baseClasses, className)} role="status" aria-live="polite">
+      {content}
+    </div>
+  )
+}

--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,34 @@
+import { Radio as RadioPrimitive } from "@base-ui/react/radio"
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "flex size-[18px] shrink-0 items-center justify-center rounded-full border border-(--color-border-strong) bg-(--bg-page) transition-colors outline-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-(--accent-blue) aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20",
+        className
+      )}
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        keepMounted
+        className="size-2 rounded-full bg-(--accent-blue) opacity-0 transition-opacity data-checked:opacity-100"
+      />
+    </RadioPrimitive.Root>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
 const Select = SelectPrimitive.Root
 
@@ -39,7 +39,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex w-fit items-center justify-between gap-2 rounded-[10px] border border-(--color-border) bg-(--bg-page) py-2 pr-2.5 pl-3 text-sm text-(--color-text) whitespace-nowrap transition-colors outline-none select-none hover:border-(--color-border-strong) focus-visible:border-(--focus-ring) focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:cursor-not-allowed disabled:bg-(--bg-key) disabled:opacity-60 aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20 data-placeholder:text-(--color-text-subtle) data-[size=default]:h-9 data-[size=sm]:h-8 data-[size=sm]:rounded-[8px] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -47,7 +47,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+          <ChevronDownIcon className="pointer-events-none size-4 text-(--color-text-muted)" />
         }
       />
     </SelectPrimitive.Trigger>
@@ -59,9 +59,9 @@ function SelectContent({
   children,
   side = "bottom",
   sideOffset = 4,
-  align = "center",
+  align = "start",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
@@ -81,7 +81,10 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-[12px] border border-(--color-border-strong) bg-(--bg-page) p-1.5 text-(--color-text) shadow-[0_8px_24px_rgba(26,23,20,0.16)] duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
           {...props}
         >
           <SelectScrollUpButton />
@@ -100,7 +103,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.GroupLabel
       data-slot="select-label"
-      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      className={cn("px-2 py-1 text-xs font-medium text-(--color-text-muted)", className)}
       {...props}
     />
   )
@@ -115,7 +118,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex h-8 w-full cursor-default items-center gap-2 rounded-[8px] py-1 pr-8 pl-2.5 text-sm text-(--color-text) outline-hidden select-none focus:bg-(--bg-key) data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}
@@ -128,7 +131,7 @@ function SelectItem({
           <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
         }
       >
-        <CheckIcon className="pointer-events-none" />
+        <CheckIcon className="pointer-events-none text-(--accent-blue)" />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   )
@@ -141,7 +144,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-(--color-border-subtle)", className)}
       {...props}
     />
   )
@@ -155,13 +158,12 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
       className={cn(
-        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-(--bg-page) py-1 text-(--color-text-muted) [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpArrow>
   )
 }
@@ -174,13 +176,12 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"
       className={cn(
-        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-(--bg-page) py-1 text-(--color-text-muted) [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownArrow>
   )
 }

--- a/web/src/components/ui/sidebar-item.tsx
+++ b/web/src/components/ui/sidebar-item.tsx
@@ -1,0 +1,84 @@
+/**
+ * SidebarItem — sidebar nav row with icon, label, and optional keyboard hint.
+ *
+ * Pencil component `F3DZn` (SidebarItem) covers the nav rows in
+ * `Urcca` (Sidebar/Expanded). 40h, padding [10,12], gap 10, radius-md.
+ *
+ * Two render modes:
+ *   - expanded: [icon] [label .....] [kbd?]
+ *   - collapsed: [icon] (centered, 40×40 square, no label, no kbd)
+ *
+ * Active / hover styling matches paper-token nav: hover bumps weight from
+ * 500→600 via `interactive-weight`, active uses `--bg-key` fill.
+ */
+import { motion, AnimatePresence } from 'framer-motion'
+import { cn } from '@/lib/utils'
+import type { ComponentType, MouseEventHandler, ReactNode } from 'react'
+
+export interface SidebarItemProps {
+  /** Lucide icon component (or any component accepting `size` prop). */
+  Icon: ComponentType<{ size?: number; className?: string }>
+  label: string
+  /** Keyboard hint text shown on the right of the row when expanded. */
+  kbd?: string
+  active?: boolean
+  collapsed?: boolean
+  onClick?: MouseEventHandler<HTMLButtonElement>
+  title?: string
+  /** Optional override for the right-side slot when expanded. */
+  rightSlot?: ReactNode
+  className?: string
+}
+
+export function SidebarItem({
+  Icon,
+  label,
+  kbd,
+  active = false,
+  collapsed = false,
+  onClick,
+  title,
+  rightSlot,
+  className,
+}: SidebarItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title ?? (kbd ? `${label} (${kbd.replace('^', 'Ctrl+')})` : label)}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        'interactive-weight flex w-full items-center gap-2.5 rounded-lg text-sm transition-colors',
+        collapsed ? 'h-10 w-10 justify-center px-0 py-0' : 'px-3 py-2',
+        active
+          ? 'bg-(--bg-key) text-(--color-text) font-medium'
+          : 'text-(--color-text-2) hover:bg-(--bg-key) hover:text-(--color-text)',
+        className,
+      )}
+    >
+      <Icon size={16} className="shrink-0" />
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.span
+            key="label"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.12 }}
+            className="flex-1 truncate text-left whitespace-nowrap"
+          >
+            {label}
+          </motion.span>
+        )}
+      </AnimatePresence>
+      {!collapsed &&
+        (rightSlot !== undefined ? (
+          rightSlot
+        ) : kbd ? (
+          <kbd className="shrink-0 rounded border border-(--color-border) bg-(--bg-page) px-1 py-0.5 font-mono text-xs text-(--color-text-subtle)">
+            {kbd}
+          </kbd>
+        ) : null)}
+    </button>
+  )
+}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,20 @@
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-(--color-border-strong) bg-(--bg-key) p-0.5 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-(--accent-blue) data-checked:bg-(--accent-blue)",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb className="size-3.5 rounded-full border border-(--color-border) bg-(--bg-card) transition-transform data-checked:translate-x-4 data-checked:border-white data-checked:bg-white" />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -14,22 +14,19 @@ function Tabs({
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
-        className
-      )}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />
   )
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-[10px] border border-(--color-border) bg-(--bg-page) p-1 text-(--color-text-muted) group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:border-transparent data-[variant=line]:bg-transparent data-[variant=line]:p-0",
   {
     variants: {
       variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
+        default: "",
+        line: "gap-1",
       },
     },
     defaultVariants: {
@@ -58,10 +55,8 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "relative inline-flex h-full flex-1 items-center justify-center gap-1.5 rounded-[8px] border border-transparent px-3 py-1 text-sm font-medium whitespace-nowrap text-(--color-text-muted) transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-(--color-text) focus-visible:border-(--focus-ring) focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:border-(--color-border-strong) data-active:bg-(--bg-card) data-active:text-(--color-text) group-data-[variant=line]/tabs-list:data-active:border-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "after:absolute after:bg-(--accent-blue) after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-2 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-1 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className
       )}
       {...props}
@@ -73,7 +68,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
     <TabsPrimitive.Panel
       data-slot="tabs-content"
-      className={cn("flex-1 text-sm outline-none", className)}
+      className={cn("flex-1 text-sm text-(--color-text) outline-none", className)}
       {...props}
     />
   )

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-24 w-full rounded-[10px] border border-(--color-border) bg-(--bg-page) px-3 py-2.5 text-sm leading-relaxed text-(--color-text) transition-colors outline-none placeholder:text-(--color-text-subtle) hover:border-(--color-border-strong) focus-visible:border-(--focus-ring) focus-visible:ring-2 focus-visible:ring-(--focus-ring)/25 disabled:cursor-not-allowed disabled:bg-(--bg-key) disabled:text-(--color-text-muted) disabled:opacity-60 aria-invalid:border-(--color-error) aria-invalid:ring-2 aria-invalid:ring-(--color-error)/20",
         className
       )}
       {...props}

--- a/web/src/components/ui/token-meter.tsx
+++ b/web/src/components/ui/token-meter.tsx
@@ -1,0 +1,70 @@
+/**
+ * TokenMeter — compact display of input · output · cached token totals.
+ *
+ * Pencil component `h9NN3Z` (TokenMeter):
+ *   [ 12.4k · 3.2k · 8.1k ]   ← all mono, separators muted
+ *
+ * - Mono font, 11px
+ * - Numbers in `--color-text`
+ * - "·" separators in `--color-text-muted`
+ * - Padding 4×10, gap 6, radius-sm
+ *
+ * Cached is rendered only when > 0 to keep the pill quiet during the
+ * first turn of a new session.
+ */
+
+import { cn } from '@/lib/utils'
+import { formatTokens } from '@/utils/format'
+
+export interface TokenMeterProps {
+  input: number
+  output: number
+  cached?: number
+  /** Show a pulsing dot to signal that values are still climbing. */
+  pulsing?: boolean
+  className?: string
+  /** Title attribute override (defaults to a verbose tooltip). */
+  title?: string
+}
+
+export function TokenMeter({
+  input,
+  output,
+  cached = 0,
+  pulsing = false,
+  className,
+  title,
+}: TokenMeterProps) {
+  const tooltip =
+    title ??
+    `Prompt: ${input.toLocaleString()} · Output: ${output.toLocaleString()}${
+      cached > 0 ? ` · Cached: ${cached.toLocaleString()}` : ''
+    }`
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1 font-mono text-[11px] leading-none',
+        className,
+      )}
+      title={tooltip}
+      aria-label={tooltip}
+    >
+      <span className="text-(--color-text)">{formatTokens(input)}</span>
+      <span aria-hidden="true" className="text-(--color-text-muted)">·</span>
+      <span className="text-(--color-text)">{formatTokens(output)}</span>
+      {cached > 0 && (
+        <>
+          <span aria-hidden="true" className="text-(--color-text-muted)">·</span>
+          <span className="text-(--color-text)">{formatTokens(cached)}</span>
+        </>
+      )}
+      {pulsing && (
+        <span
+          aria-hidden="true"
+          className="ml-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-(--color-accent)"
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/ui/topbar-action.tsx
+++ b/web/src/components/ui/topbar-action.tsx
@@ -1,0 +1,66 @@
+/**
+ * TopbarAction — small icon+label button used in the agent topbar.
+ *
+ * Pencil component `rFG6A` (TopbarAction): padding 6×10, gap 6,
+ * radius-sm, transparent fill, lucide icon at 13px, label at 12px
+ * weight-500, both in `--color-text-2`. Hover lifts the surface to
+ * `--bg-key`.
+ *
+ * Used for "Todos", "Files", "Agents" in the topbar.
+ */
+
+import { forwardRef } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface TopbarActionProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  Icon: LucideIcon
+  label?: string
+  /** Show a colored dot to signal an active/in-progress state. */
+  indicator?: boolean
+  indicatorClassName?: string
+  /** Hide the label on small viewports while keeping it for screen readers. */
+  hideLabelOnMobile?: boolean
+}
+
+export const TopbarAction = forwardRef<HTMLButtonElement, TopbarActionProps>(
+  function TopbarAction(
+    {
+      Icon,
+      label,
+      indicator,
+      indicatorClassName,
+      hideLabelOnMobile = true,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-sm px-2.5 py-1.5 text-xs font-medium leading-none text-(--color-text-2) transition-colors hover:bg-(--bg-key) hover:text-(--color-text) disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent',
+          className,
+        )}
+        {...rest}
+      >
+        <Icon size={13} aria-hidden="true" />
+        {label && (
+          <span className={cn(hideLabelOnMobile && 'hidden md:inline')}>{label}</span>
+        )}
+        {indicator && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              'h-1.5 w-1.5 shrink-0 rounded-full bg-(--color-accent)',
+              indicatorClassName,
+            )}
+          />
+        )}
+      </button>
+    )
+  },
+)

--- a/web/src/components/ui/view-toggle.tsx
+++ b/web/src/components/ui/view-toggle.tsx
@@ -1,16 +1,21 @@
 /**
- * ViewToggle — three-state segmented control for chat view modes.
+ * ViewToggle — three-state icon-only segmented control for chat view modes.
  *
- * Pencil component `T9nydm` (ViewToggle): single rounded pill, 1px subtle
- * border, three equally-sized icon buttons. The active button has a
- * `--color-surface-2` fill; others are transparent. The pencil uses
- * Material Symbols `person` / `view_column` / `view_quilt`; we map to
- * the lucide equivalents already used elsewhere in the codebase.
+ * Pencil component `T9nydm` (ViewToggle): three equally-sized 28×28
+ * icon-only buttons inside a rounded-md pill bordered with
+ * `--color-border-subtle`. The active button has a `--color-surface-2`
+ * fill; others are transparent. Pencil uses Material Symbols `person` /
+ * `view_column` / `view_quilt`; we map to lucide equivalents already
+ * used elsewhere.
  *
  * Modes:
  *   - "agent"   → focus a single agent (Maximize2)
  *   - "split"   → side-by-side panes  (LayoutGrid)
  *   - "unified" → tabbed unified view (Layers)
+ *
+ * Labels live on `aria-label` and `title` only — the control is too
+ * dense to fit all three labels on the topbar. Tooltips surface them on
+ * hover for sighted users.
  */
 
 import { Maximize2, LayoutGrid, Layers, type LucideIcon } from 'lucide-react'
@@ -33,15 +38,12 @@ const MODES: readonly ModeDef[] = [
 export interface ViewToggleProps {
   value: ViewMode
   onValueChange: (mode: ViewMode) => void
-  /** Show text labels next to icons. Default true on desktop usage. */
-  showLabels?: boolean
   className?: string
 }
 
 export function ViewToggle({
   value,
   onValueChange,
-  showLabels = true,
   className,
 }: ViewToggleProps) {
   return (
@@ -65,14 +67,13 @@ export function ViewToggle({
             title={label}
             onClick={() => onValueChange(mode)}
             className={cn(
-              'inline-flex items-center justify-center gap-1.5 rounded-sm px-2.5 py-1 text-xs leading-none transition-all',
+              'inline-flex h-7 w-7 items-center justify-center rounded-sm transition-colors',
               selected
                 ? 'bg-(--color-surface-2) text-(--color-text)'
-                : 'text-(--color-text-muted) hover:text-(--color-text-2)',
+                : 'text-(--color-text-muted) hover:bg-(--bg-key) hover:text-(--color-text-2)',
             )}
           >
-            <Icon size={12} aria-hidden="true" />
-            {showLabels && <span className="capitalize">{mode}</span>}
+            <Icon size={14} aria-hidden="true" />
           </button>
         )
       })}

--- a/web/src/components/ui/view-toggle.tsx
+++ b/web/src/components/ui/view-toggle.tsx
@@ -5,20 +5,20 @@
  * icon-only buttons inside a rounded-md pill bordered with
  * `--color-border-subtle`. The active button has a `--color-surface-2`
  * fill; others are transparent. Pencil uses Material Symbols `person` /
- * `view_column` / `view_quilt`; we map to lucide equivalents already
- * used elsewhere.
+ * `view_column` / `view_quilt`; we map to the closest lucide
+ * equivalents to preserve semantics.
  *
  * Modes:
- *   - "agent"   → focus a single agent (Maximize2)
- *   - "split"   → side-by-side panes  (LayoutGrid)
- *   - "unified" → tabbed unified view (Layers)
+ *   - "agent"   → focus a single agent (User      ↔ person)
+ *   - "split"   → side-by-side panes  (Columns2   ↔ view_column)
+ *   - "unified" → tiled unified view  (LayoutGrid ↔ view_quilt)
  *
  * Labels live on `aria-label` and `title` only — the control is too
  * dense to fit all three labels on the topbar. Tooltips surface them on
  * hover for sighted users.
  */
 
-import { Maximize2, LayoutGrid, Layers, type LucideIcon } from 'lucide-react'
+import { User, Columns2, LayoutGrid, type LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 export type ViewMode = 'agent' | 'split' | 'unified'
@@ -30,9 +30,9 @@ interface ModeDef {
 }
 
 const MODES: readonly ModeDef[] = [
-  { mode: 'agent', label: 'Agent view', Icon: Maximize2 },
-  { mode: 'split', label: 'Split view', Icon: LayoutGrid },
-  { mode: 'unified', label: 'Unified view', Icon: Layers },
+  { mode: 'agent', label: 'Agent view', Icon: User },
+  { mode: 'split', label: 'Split view', Icon: Columns2 },
+  { mode: 'unified', label: 'Unified view', Icon: LayoutGrid },
 ] as const
 
 export interface ViewToggleProps {

--- a/web/src/components/ui/view-toggle.tsx
+++ b/web/src/components/ui/view-toggle.tsx
@@ -1,0 +1,81 @@
+/**
+ * ViewToggle — three-state segmented control for chat view modes.
+ *
+ * Pencil component `T9nydm` (ViewToggle): single rounded pill, 1px subtle
+ * border, three equally-sized icon buttons. The active button has a
+ * `--color-surface-2` fill; others are transparent. The pencil uses
+ * Material Symbols `person` / `view_column` / `view_quilt`; we map to
+ * the lucide equivalents already used elsewhere in the codebase.
+ *
+ * Modes:
+ *   - "agent"   → focus a single agent (Maximize2)
+ *   - "split"   → side-by-side panes  (LayoutGrid)
+ *   - "unified" → tabbed unified view (Layers)
+ */
+
+import { Maximize2, LayoutGrid, Layers, type LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export type ViewMode = 'agent' | 'split' | 'unified'
+
+interface ModeDef {
+  mode: ViewMode
+  label: string
+  Icon: LucideIcon
+}
+
+const MODES: readonly ModeDef[] = [
+  { mode: 'agent', label: 'Agent view', Icon: Maximize2 },
+  { mode: 'split', label: 'Split view', Icon: LayoutGrid },
+  { mode: 'unified', label: 'Unified view', Icon: Layers },
+] as const
+
+export interface ViewToggleProps {
+  value: ViewMode
+  onValueChange: (mode: ViewMode) => void
+  /** Show text labels next to icons. Default true on desktop usage. */
+  showLabels?: boolean
+  className?: string
+}
+
+export function ViewToggle({
+  value,
+  onValueChange,
+  showLabels = true,
+  className,
+}: ViewToggleProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="View mode"
+      className={cn(
+        'inline-flex items-center overflow-hidden rounded-md border border-(--color-border-subtle) p-0.5',
+        className,
+      )}
+    >
+      {MODES.map(({ mode, label, Icon }) => {
+        const selected = value === mode
+        return (
+          <button
+            key={mode}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={label}
+            title={label}
+            onClick={() => onValueChange(mode)}
+            className={cn(
+              'inline-flex items-center justify-center gap-1.5 rounded-sm px-2.5 py-1 text-xs leading-none transition-all',
+              selected
+                ? 'bg-(--color-surface-2) text-(--color-text)'
+                : 'text-(--color-text-muted) hover:text-(--color-text-2)',
+            )}
+          >
+            <Icon size={12} aria-hidden="true" />
+            {showLabels && <span className="capitalize">{mode}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/hooks/useProximity.ts
+++ b/web/src/hooks/useProximity.ts
@@ -12,7 +12,7 @@
  *   // ...per row:
  *   const { ref, intensity } = useProximityIntensity(mouseY, 120)
  *   <div ref={ref} style={{
- *     backgroundColor: `color-mix(in srgb, var(--color-accent-subtle) ${intensity * 100}%, transparent)`,
+ *     backgroundColor: `color-mix(in srgb, var(--bg-key) ${intensity * 100}%, transparent)`,
  *   }} />
  *
  * Respects `prefers-reduced-motion` — returns 0 for all rows when set.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -101,11 +101,10 @@
 }
 
 /* ─────────────────────────────────────────────────────────────
- * OpenAgentd paper tokens — DARK default
- * Light mode overrides via :root.light.
+ * OpenAgentd paper tokens — DARK override
+ * Light mode is canonical (defined on :root below).
  * Theme class is set on <html> before paint (see index.html).
  * ───────────────────────────────────────────────────────────── */
-:root,
 :root.dark {
     color-scheme: dark;
 
@@ -247,8 +246,10 @@
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Light mode — warm paper, shared shadow+border for elevation
+ * Light mode — warm paper, canonical default. Applies to bare :root
+ * and to :root.light (explicit user pick).
  * ───────────────────────────────────────────────────────────── */
+:root,
 :root.light {
     color-scheme: light;
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,11 +1,16 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/geist";
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/jetbrains-mono";
+@import "@fontsource/caveat/400.css";
+@import "@fontsource/caveat/500.css";
+@import "@fontsource/caveat/600.css";
+@import "@fontsource/caveat/700.css";
 @import "highlight.js/styles/atom-one-dark.css";
 
 /* ─────────────────────────────────────────────────────────────
- * Silver Instrument — syntax highlighting (highlight.js)
+ * OpenAgentd — syntax highlighting (highlight.js)
  * Tokens are theme-aware via var() references.
  * ───────────────────────────────────────────────────────────── */
 .hljs {
@@ -49,9 +54,11 @@
  * ───────────────────────────────────────────────────────────── */
 @theme inline {
     --font-heading: var(--font-sans);
-    --font-sans: 'Geist Variable', sans-serif;
+    --font-sans: 'Inter Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-mono: 'JetBrains Mono Variable', ui-monospace, 'SF Mono', 'Courier New', monospace;
+    --font-hand: 'Caveat', 'Bradley Hand', cursive;
 
-    /* shadcn semantic tokens (mapped onto Silver Instrument) */
+    /* shadcn semantic tokens (mapped onto OpenAgentd paper tokens) */
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -83,70 +90,114 @@
     --color-card: var(--card);
     --color-foreground: var(--foreground);
     --color-background: var(--background);
-    --radius-sm: calc(var(--radius) * 0.6);
-    --radius-md: calc(var(--radius) * 0.8);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) * 1.4);
-    --radius-2xl: calc(var(--radius) * 1.8);
-    --radius-3xl: calc(var(--radius) * 2.2);
-    --radius-4xl: calc(var(--radius) * 2.6);
+    --radius-xs: 6px;
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-xl: 18px;
+    --radius-2xl: 24px;
+    --radius-3xl: 32px;
+    --radius-4xl: 40px;
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Silver Instrument — design tokens
- * Dark mode is default. Light mode overrides via :root.light.
+ * OpenAgentd paper tokens — DARK default
+ * Light mode overrides via :root.light.
  * Theme class is set on <html> before paint (see index.html).
  * ───────────────────────────────────────────────────────────── */
 :root,
 :root.dark {
     color-scheme: dark;
 
-    /* Foundation — surfaces */
-    --color-bg:            #0A0A0B;
-    --color-surface:       #111113;
-    --color-surface-2:     #18181B;
-    --color-surface-3:     #1F1F23;
-    --color-border:        #27272A;
-    --color-border-strong: #3F3F46;
+    /* Surfaces */
+    --bg-page:           #15110D;
+    --bg-sidebar:        #1C1813;
+    --bg-card:           #1C1813;
+    --bg-input:          #1C1813;
+    --bg-key:            #2A2219;
+    --bg-send:           #F5EBD8;
+    --color-surface:     #221C16;
+    --color-surface-2:   #2A2219;
+    --color-bg-elevated: #1C1813;
+
+    /* Borders */
+    --border-soft:         #2C231A;
+    --border-card:         #3A2F23;
+    --color-border-subtle: #2C231A;
+    --color-border:        #3A2F23;
+    --color-border-strong: #5C4B36;
 
     /* Text */
-    --color-text:          #FAFAFA;
-    --color-text-2:        #A1A1AA;
-    --color-text-muted:    #71717A;
-    --color-text-subtle:   #52525B;
+    --color-text:           #F5EBD8;
+    --color-text-2:         #C5B59A;
+    --color-text-muted:     #9C8A72;
+    --color-text-subtle:    #7A6B58;
+    --color-text-on-accent: #15110D;
+    --fg-primary:           #F5EBD8;
+    --fg-secondary:         #C5B59A;
+    --fg-muted:             #9C8A72;
 
-    /* Accent — max-contrast neutral (silver on dark) */
-    --color-accent:        #E4E4E7;
-    --color-accent-hover:  #F4F4F5;
-    --color-accent-subtle: rgba(228, 228, 231, 0.10);
-    --color-accent-dim:    rgba(228, 228, 231, 0.05);
-    --gradient-accent:     linear-gradient(180deg, #FAFAFA 0%, #D4D4D8 100%);
+    /* Accent (UI) */
+    --color-accent:  #F5EBD8;
+    --color-overlay: #00000099;
 
-    /* Semantic state (muted set for dark) */
-    --color-success:         #4ADE80;
-    --color-success-subtle:  rgba(74, 222, 128, 0.12);
-    --color-warning:         #FBBF24;
-    --color-warning-subtle:  rgba(251, 191, 36, 0.12);
-    --color-error:           #F87171;
-    --color-error-subtle:    rgba(248, 113, 113, 0.12);
-    --color-info:            #93C5FD;
-    --color-info-subtle:     rgba(147, 197, 253, 0.12);
+    /* Agent chips */
+    --accent-blue:        #7CC2F0;
+    --accent-blue-soft:   #1E3A52;
+    --accent-blue-text:   #9DD0F5;
+
+    --accent-green:       #5DC487;
+    --accent-green-soft:  #1F3A2A;
+    --accent-green-text:  #92E0B0;
+
+    --accent-orange:      #FDB75D;
+    --accent-orange-soft: #3D2D14;
+    --accent-orange-text: #FCC780;
+
+    --accent-pink:        #F472B6;
+    --accent-pink-soft:   #3D1F2D;
+
+    --accent-purple:      #A78BFA;
+    --accent-purple-soft: #2D2440;
+
+    --accent-red:         #F87171;
+
+    /* Markers (charts) */
+    --color-marker-blue:   #38BDF8;
+    --color-marker-mint:   #4ADE80;
+    --color-marker-orange: #FCC352;
+    --color-marker-pink:   #F472B6;
+    --color-marker-yellow: #FBBF24;
+    --color-violet:        #A78BFA;
+    --color-tint-mint:     rgba(74, 222, 128, 0.15);
+    --color-tint-orange:   rgba(252, 195, 82, 0.15);
+    --color-tint-violet:   rgba(167, 139, 250, 0.15);
+
+    /* Semantic state (re-use chip palette so the system stays small) */
+    --color-success:        var(--accent-green);
+    --color-success-subtle: var(--accent-green-soft);
+    --color-warning:        var(--accent-orange);
+    --color-warning-subtle: var(--accent-orange-soft);
+    --color-error:          #F87171;
+    --color-error-subtle:   rgba(248, 113, 113, 0.12);
+    --color-info:           var(--accent-blue);
+    --color-info-subtle:    var(--accent-blue-soft);
 
     /* Syntax highlighting */
-    --color-syn-comment:   #71717A;
-    --color-syn-keyword:   #C4B5FD;
-    --color-syn-function:  #93C5FD;
-    --color-syn-variable:  #F87171;
-    --color-syn-string:    #86EFAC;
-    --color-syn-number:    #FBBF24;
-    --color-syn-type:      #FCD34D;
-    --color-syn-operator:  #A1A1AA;
+    --color-syn-comment:  #9C8A72;
+    --color-syn-keyword:  #A78BFA;
+    --color-syn-function: #38BDF8;
+    --color-syn-variable: #F87171;
+    --color-syn-string:   #4ADE80;
+    --color-syn-number:   #FBBF24;
+    --color-syn-type:     #FCC780;
+    --color-syn-operator: #C5B59A;
 
     /* Depth & focus */
-    --focus-ring:          #E4E4E7;
-    --shadow-depth:        none;
+    --focus-ring:   var(--color-accent);
+    --shadow-depth: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.25);
 
-    /* Motion — durations (theme-invariant, defined once on dark root) */
+    /* Motion — durations */
     --motion-instant: 80ms;
     --motion-fast:    150ms;
     --motion-base:    240ms;
@@ -160,92 +211,134 @@
     --ease-spring-snappy: cubic-bezier(0.22, 1.4, 0.36, 1);
     --ease-linear:        linear;
 
-    /* shadcn base tokens (map to Silver Instrument) */
-    --background:              var(--color-bg);
-    --foreground:              var(--color-text);
-    --card:                    var(--color-surface-2);
-    --card-foreground:         var(--color-text);
-    --popover:                 var(--color-surface);
-    --popover-foreground:      var(--color-text);
-    --primary:                 var(--color-accent);
-    --primary-foreground:      var(--color-bg);
-    --secondary:               var(--color-surface-2);
-    --secondary-foreground:    var(--color-text);
-    --muted:                   var(--color-surface-2);
-    --muted-foreground:        var(--color-text-muted);
-    --accent:                  var(--color-accent-subtle);
-    --accent-foreground:       var(--color-text);
-    --destructive:             var(--color-error);
-    --border:                  var(--color-border);
-    --input:                   var(--color-border);
-    --ring:                    var(--focus-ring);
-    --radius:                  0.5rem;
-    --sidebar:                 var(--color-surface);
-    --sidebar-foreground:      var(--color-text);
-    --sidebar-primary:         var(--color-accent);
-    --sidebar-primary-foreground: var(--color-bg);
-    --sidebar-accent:          var(--color-surface-2);
-    --sidebar-accent-foreground: var(--color-text);
-    --sidebar-border:          var(--color-border);
-    --sidebar-ring:            var(--focus-ring);
-    --chart-1:                 #93C5FD;
-    --chart-2:                 #86EFAC;
-    --chart-3:                 #FCD34D;
-    --chart-4:                 #C4B5FD;
-    --chart-5:                 #F9A8D4;
+    /* shadcn base tokens (map to OpenAgentd paper tokens) */
+    --background:                 var(--bg-page);
+    --foreground:                 var(--color-text);
+    --card:                       var(--bg-card);
+    --card-foreground:            var(--color-text);
+    --popover:                    var(--bg-card);
+    --popover-foreground:         var(--color-text);
+    --primary:                    var(--color-accent);
+    --primary-foreground:         var(--bg-page);
+    --secondary:                  var(--bg-key);
+    --secondary-foreground:       var(--color-text);
+    --muted:                      var(--bg-key);
+    --muted-foreground:           var(--color-text-muted);
+    --accent:                     var(--bg-key);
+    --accent-foreground:          var(--color-text);
+    --destructive:                var(--color-error);
+    --border:                     var(--color-border);
+    --input:                      var(--color-border);
+    --ring:                       var(--focus-ring);
+    --radius:                     0.5rem;
+    --sidebar:                    var(--bg-sidebar);
+    --sidebar-foreground:         var(--color-text);
+    --sidebar-primary:            var(--color-accent);
+    --sidebar-primary-foreground: var(--bg-page);
+    --sidebar-accent:             var(--bg-key);
+    --sidebar-accent-foreground:  var(--color-text);
+    --sidebar-border:             var(--border-soft);
+    --sidebar-ring:               var(--focus-ring);
+    --chart-1:                    var(--color-marker-blue);
+    --chart-2:                    var(--color-marker-mint);
+    --chart-3:                    var(--color-marker-orange);
+    --chart-4:                    var(--color-violet);
+    --chart-5:                    var(--color-marker-pink);
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Light mode — graphite accent, shadows provide depth
+ * Light mode — warm paper, shared shadow+border for elevation
  * ───────────────────────────────────────────────────────────── */
 :root.light {
     color-scheme: light;
 
-    --color-bg:            #FAFAFA;
-    --color-surface:       #FFFFFF;
-    --color-surface-2:     #F4F4F5;
-    --color-surface-3:     #E4E4E7;
-    --color-border:        #E4E4E7;
-    --color-border-strong: #D4D4D8;
+    /* Surfaces */
+    --bg-page:           #FAF6EC;
+    --bg-sidebar:        #F5EFDD;
+    --bg-card:           #FFFBF1;
+    --bg-input:          #FAF6EC;
+    --bg-key:            #F0E9D4;
+    --bg-send:           #2D241B;
+    --color-surface:     #FFFDF7;
+    --color-surface-2:   #F5EBD8;
+    --color-bg-elevated: #FFFDF7;
 
-    --color-text:          #09090B;
-    --color-text-2:        #52525B;
-    --color-text-muted:    #71717A;
-    --color-text-subtle:   #A1A1AA;
+    /* Borders */
+    --border-soft:         #E8DFC6;
+    --border-card:         #E0D5B7;
+    --color-border-subtle: #E8DCC2;
+    --color-border:        #D7C7AA;
+    --color-border-strong: #A89880;
 
-    --color-accent:        #27272A;
-    --color-accent-hover:  #18181B;
-    --color-accent-subtle: rgba(39, 39, 42, 0.06);
-    --color-accent-dim:    rgba(39, 39, 42, 0.03);
-    --gradient-accent:     linear-gradient(180deg, #3F3F46 0%, #18181B 100%);
+    /* Text */
+    --color-text:           #1A1714;
+    --color-text-2:         #5F5143;
+    --color-text-muted:     #7A6B58;
+    --color-text-subtle:    #A89880;
+    --color-text-on-accent: #FFFDF7;
+    --fg-primary:           #1F1A14;
+    --fg-secondary:         #6B6253;
+    --fg-muted:             #9A9080;
 
-    --color-success:         #16A34A;
-    --color-success-subtle:  rgba(22, 163, 74, 0.10);
-    --color-warning:         #D97706;
-    --color-warning-subtle:  rgba(217, 119, 6, 0.10);
-    --color-error:           #DC2626;
-    --color-error-subtle:    rgba(220, 38, 38, 0.08);
-    --color-info:            #2563EB;
-    --color-info-subtle:     rgba(37, 99, 235, 0.08);
+    /* Accent (UI) */
+    --color-accent:  #3F3429;
+    --color-overlay: rgba(26, 23, 20, 0.40);
 
-    --color-syn-comment:   #71717A;
-    --color-syn-keyword:   #7C3AED;
-    --color-syn-function:  #2563EB;
-    --color-syn-variable:  #DC2626;
-    --color-syn-string:    #16A34A;
-    --color-syn-number:    #D97706;
-    --color-syn-type:      #B45309;
-    --color-syn-operator:  #52525B;
+    /* Agent chips */
+    --accent-blue:        #5AA8E2;
+    --accent-blue-soft:   #DCEEFB;
+    --accent-blue-text:   #2D6FA8;
 
-    --focus-ring:          #18181B;
-    --shadow-depth:        0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.04);
+    --accent-green:       #3DA66A;
+    --accent-green-soft:  #E2F2E5;
+    --accent-green-text:  #2D7A4F;
 
-    /* Light-mode chart spectrum (bumped -600 shades for AA on white) */
-    --chart-1: #2563EB;
-    --chart-2: #16A34A;
-    --chart-3: #D97706;
-    --chart-4: #7C3AED;
-    --chart-5: #DB2777;
+    --accent-orange:      #F59E3B;
+    --accent-orange-soft: #FFF1D8;
+    --accent-orange-text: #C26A1E;
+
+    --accent-pink:        #E63D7A;
+    --accent-pink-soft:   #FBE0EB;
+
+    --accent-purple:      #7C5BCF;
+    --accent-purple-soft: #E8DEF8;
+
+    --accent-red:         #C8333E;
+
+    /* Markers (charts) */
+    --color-marker-blue:   #0284C7;
+    --color-marker-mint:   #16A34A;
+    --color-marker-orange: #FA8030;
+    --color-marker-pink:   #DB2777;
+    --color-marker-yellow: #B77900;
+    --color-violet:        #7C3AED;
+    --color-tint-mint:     rgba(22, 163, 74, 0.10);
+    --color-tint-orange:   rgba(250, 128, 48, 0.10);
+    --color-tint-violet:   rgba(124, 58, 237, 0.10);
+
+    /* Semantic */
+    --color-success:        var(--accent-green);
+    --color-success-subtle: var(--accent-green-soft);
+    --color-warning:        var(--accent-orange);
+    --color-warning-subtle: var(--accent-orange-soft);
+    --color-error:          #B91C1C;
+    --color-error-subtle:   rgba(185, 28, 28, 0.08);
+    --color-info:           var(--accent-blue);
+    --color-info-subtle:    var(--accent-blue-soft);
+
+    /* Syntax */
+    --color-syn-comment:  #7A6B58;
+    --color-syn-keyword:  #7C3AED;
+    --color-syn-function: #0284C7;
+    --color-syn-variable: #B91C1C;
+    --color-syn-string:   #16A34A;
+    --color-syn-number:   #B77900;
+    --color-syn-type:     #C26A1E;
+    --color-syn-operator: #5F5143;
+
+    /* Focus + depth */
+    --focus-ring:   var(--color-accent);
+    --shadow-depth: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 @layer base {
@@ -322,8 +415,8 @@
   top: -40px;
   left: 0;
   padding: 8px 16px;
-  background: var(--color-accent);
-  color: var(--color-bg);
+  background: var(--bg-send);
+  color: var(--color-text-on-accent);
   z-index: 100;
   transition: top var(--motion-fast) var(--ease-out);
 }
@@ -379,9 +472,9 @@
 
 /* ─────────────────────────────────────────────────────────────
  * Raised surface — cards, panels, grouped containers.
- * Dark: `--shadow-depth` is `none`; brightness carries elevation.
- * Light: real shadow (surfaces are all near-white, brightness can't).
- * Apply to elements that sit one layer above `bg`.
+ * Both modes use the same shadow+border treatment because the
+ * warm dark palette is too compressed for brightness-only depth.
+ * Apply to elements that sit one layer above `bg-page`.
  * ───────────────────────────────────────────────────────────── */
 .surface-raised {
   box-shadow: var(--shadow-depth);
@@ -389,7 +482,7 @@
 
 /* ─────────────────────────────────────────────────────────────
  * Font-weight transition — signature interaction.
- * Apply to buttons, nav items, tabs, menu items. Not prose.
+ * Apply to buttons, nav items, tabs, menu items. Not prose. Not Caveat.
  * ───────────────────────────────────────────────────────────── */
 .interactive-weight {
   font-weight: 400;
@@ -456,12 +549,12 @@
 }
 .oa-prose li { margin-bottom: 0.25em; }
 .oa-prose code {
-  background: var(--color-surface-2);
+  background: var(--bg-key);
   border: 1px solid var(--color-border);
   border-radius: 4px;
   padding: 0.15em 0.4em;
   font-size: 0.85em;
-  font-family: monospace;
+  font-family: var(--font-mono);
   color: var(--color-syn-string);
 }
 .oa-prose pre {
@@ -490,7 +583,7 @@
   transition: text-decoration-color 120ms ease, color 120ms ease;
 }
 .oa-prose a:hover {
-  color: var(--color-accent-hover, var(--color-accent));
+  color: var(--color-accent);
   text-decoration-color: currentColor;
 }
 .oa-prose a:focus-visible {
@@ -521,7 +614,7 @@
 }
 .oa-prose th {
   color: var(--color-text-2);
-  background: var(--color-surface-2);
+  background: var(--bg-key);
 }
 .oa-prose strong { color: var(--color-text); font-weight: 600; }
-.oa-prose em     { color: var(--color-syn-keyword); }
+.oa-prose em     { color: var(--color-text-2); font-style: italic; }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -192,8 +192,12 @@
     --color-syn-type:     #FCC780;
     --color-syn-operator: #C5B59A;
 
-    /* Depth & focus */
-    --focus-ring:   var(--color-accent);
+    /* Depth & focus
+     * Focus ring uses --accent-blue rather than --color-accent because the
+     * paper accent is near-black (light) / near-white (dark), so a ring
+     * derived from it reads as a hard rectangle. Blue gives the standard
+     * focus affordance while staying inside the brand palette. */
+    --focus-ring:   var(--accent-blue);
     --shadow-depth: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.25);
 
     /* Motion — durations */
@@ -337,8 +341,8 @@
     --color-syn-type:     #C26A1E;
     --color-syn-operator: #5F5143;
 
-    /* Focus + depth */
-    --focus-ring:   var(--color-accent);
+    /* Focus + depth (see dark-mode comment) */
+    --focus-ring:   var(--accent-blue);
     --shadow-depth: 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 

--- a/web/src/lib/agent-roles.ts
+++ b/web/src/lib/agent-roles.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical agent roles in OpenAgentd.
+ *
+ * These names are special-cased in the UI: they get an `AgentChip` with a
+ * role-specific dot color (mint / orange / blue / muted). Any other agent
+ * name falls back to a generic chip.
+ */
+
+export type AgentRole = 'openagentd' | 'executor' | 'consultant' | 'explorer'
+
+export const AGENT_ROLES: readonly AgentRole[] = [
+  'openagentd',
+  'executor',
+  'consultant',
+  'explorer',
+] as const
+
+/** True when a free-form agent name matches a canonical role. */
+export function isAgentRole(name: string): name is AgentRole {
+  return (AGENT_ROLES as readonly string[]).includes(name)
+}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -23,14 +23,14 @@ export function Root() {
 
 export function NotFound() {
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-6 bg-(--color-bg)">
+    <div className="flex h-screen flex-col items-center justify-center gap-6 bg-(--bg-page)">
       <div className="text-center">
         <p className="font-mono text-6xl font-bold text-(--color-text-muted)">404</p>
         <p className="mt-3 text-sm text-(--color-text-muted)">Page not found</p>
       </div>
       <Link
         to="/"
-        className="interactive-weight flex items-center gap-2 rounded-lg bg-(--color-accent-subtle) px-4 py-2 text-sm text-(--color-accent) ring-1 ring-(--color-border-strong) transition-colors hover:bg-(--color-accent-subtle)"
+        className="interactive-weight flex items-center gap-2 rounded-lg bg-(--bg-key) px-4 py-2 text-sm text-(--color-accent) ring-1 ring-(--color-border-strong) transition-colors hover:bg-(--bg-key)"
       >
         <Home size={14} />
         Go home

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -17,7 +17,7 @@ export function HomePage() {
   const error = health.isError
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center bg-(--color-bg) px-4">
+    <div className="flex h-screen flex-col items-center justify-center bg-(--bg-page) px-4">
       <motion.div
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
@@ -27,8 +27,8 @@ export function HomePage() {
         {/* Logo */}
         <div className="flex flex-col items-center gap-4">
           <div className="relative">
-            <div className="absolute inset-0 rounded-3xl bg-(--color-accent-subtle) blur-2xl" />
-            <div className="relative flex h-20 w-20 items-center justify-center rounded-3xl bg-(--color-accent-subtle) ring-1 ring-(--color-accent-subtle)">
+            <div className="absolute inset-0 rounded-3xl bg-(--bg-key) blur-2xl" />
+            <div className="relative flex h-20 w-20 items-center justify-center rounded-3xl bg-(--bg-key) ring-1 ring-(--bg-key)">
               <img src={OpenAgentdAppIcon} width={72} height={72} alt="OpenAgentd logo" className="rounded-2xl" />
             </div>
           </div>
@@ -120,15 +120,15 @@ function ModeCard({
       disabled={disabled}
       className={`flex w-full items-center gap-4 rounded-2xl border px-5 py-4 text-left transition-all ${
         disabled
-          ? 'cursor-not-allowed border-(--color-accent-dim) bg-(--color-accent-dim) opacity-40'
-          : 'border-(--color-accent-subtle) bg-(--color-surface-2) hover:border-(--color-border-strong) hover:bg-(--color-accent-dim)'
+          ? 'cursor-not-allowed border-(--bg-key) bg-(--bg-key) opacity-40'
+          : 'border-(--bg-key) bg-(--bg-key) hover:border-(--color-border-strong) hover:bg-(--bg-key)'
       }`}
     >
       <div
         className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${
           disabled
-            ? 'bg-(--color-accent-dim)'
-            : 'bg-(--color-accent-subtle) ring-1 ring-(--color-border-strong)'
+            ? 'bg-(--bg-key)'
+            : 'bg-(--bg-key) ring-1 ring-(--color-border-strong)'
         }`}
       >
         <Icon

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -33,7 +33,7 @@ export function HomePage() {
             </div>
           </div>
           <div className="text-center">
-            <h1 className="text-3xl font-bold tracking-tight text-(--color-text)">
+            <h1 className="font-hand text-5xl leading-none text-(--color-text)">
               OpenAgentd
             </h1>
             <p className="mt-1 text-sm text-(--color-text-muted)">

--- a/web/src/routes/settings.agents.$name.tsx
+++ b/web/src/routes/settings.agents.$name.tsx
@@ -88,10 +88,10 @@ export function AgentEditorPage() {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl p-6">
           {isLoading && (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <p className="text-sm text-(--color-text-muted)">Loading…</p>
           )}
           {isError && (
-            <p className="text-sm text-destructive">Failed to load: {String(error)}</p>
+            <p className="text-sm text-(--color-error)">Failed to load: {String(error)}</p>
           )}
           {data && (
             <AgentForm
@@ -104,7 +104,7 @@ export function AgentEditorPage() {
             />
           )}
           {dirty && (
-            <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+            <div className="mt-4 flex items-center gap-2 text-xs text-(--color-text-muted)">
               <Button
                 variant="ghost"
                 size="xs"

--- a/web/src/routes/settings.dream.tsx
+++ b/web/src/routes/settings.dream.tsx
@@ -25,6 +25,8 @@ import { useToastStore } from '@/stores/useToastStore'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
 import { splitFrontmatter } from '@/components/settings/frontmatter'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -215,20 +217,20 @@ export function DreamSettingsPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-4">
+      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-(--color-border) bg-(--bg-page) px-4">
         {isMobile && (
           <Link
             to="/settings"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             aria-label="Back to settings"
           >
             <ArrowLeft size={14} />
           </Link>
         )}
-        <Moon size={15} className="shrink-0 text-muted-foreground" aria-hidden="true" />
-        <h1 className="flex-1 truncate text-sm font-semibold">Dream</h1>
+        <Moon size={15} className="shrink-0 text-(--color-text-muted)" aria-hidden="true" />
+        <h1 className="flex-1 truncate text-sm font-semibold text-(--color-text)">Dream</h1>
         {dirty && (
-          <span className="text-xs text-muted-foreground" aria-live="polite">
+          <span className="text-xs text-(--color-text-muted)" aria-live="polite">
             Unsaved
           </span>
         )}
@@ -253,15 +255,15 @@ export function DreamSettingsPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl space-y-6 p-6">
-          <p className="text-sm leading-relaxed text-muted-foreground">
+          <p className="text-sm leading-relaxed text-(--color-text-muted)">
             The dream agent runs on a cron schedule and synthesises unprocessed conversation
             sessions and notes into wiki topics. Configure its schedule, model, and system prompt
             below, or click <strong>Run now</strong> to trigger it immediately.
           </p>
 
-          {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {isLoading && <p className="text-sm text-(--color-text-muted)">Loading…</p>}
           {error && (
-            <p className="text-sm text-destructive">
+            <p className="text-sm text-(--color-error)">
               {error instanceof Error ? error.message : String(error)}
             </p>
           )}
@@ -269,28 +271,26 @@ export function DreamSettingsPage() {
           {!isLoading && !error && (
             <div className="space-y-5">
               {/* ── Schedule ────────────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   Schedule
                 </h2>
 
                 <div className="flex items-center gap-3">
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
+                  <label className="flex cursor-pointer items-center gap-2 text-sm text-(--color-text)">
+                    <Switch
                       checked={form.enabled}
-                      onChange={(e) => setField('enabled', e.target.checked)}
-                      className="h-4 w-4 rounded border-border accent-foreground"
+                      onCheckedChange={(checked) => setField('enabled', checked)}
                     />
                     Enabled
                   </label>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="text-xs text-(--color-text-muted)">
                     When disabled, dream runs only via <em>Run now</em> or <code className="font-mono">/dream</code>.
                   </span>
                 </div>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="dream-schedule" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="dream-schedule" className="text-xs font-medium text-(--color-text-muted)">
                     Cron expression
                   </label>
                   <Input
@@ -300,20 +300,20 @@ export function DreamSettingsPage() {
                     placeholder="0 2 * * *"
                     className="h-9 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     Standard 5-field cron (UTC). Example: <code className="font-mono">0 2 * * *</code> = daily at 2 AM.
                   </p>
                 </div>
               </section>
 
               {/* ── Model ───────────────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   Model
                 </h2>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="dream-model" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="dream-model" className="text-xs font-medium text-(--color-text-muted)">
                     Model ID
                   </label>
                   <Input
@@ -323,13 +323,13 @@ export function DreamSettingsPage() {
                     placeholder="googlegenai:gemini-2.0-flash"
                     className="h-9 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     Format: <code className="font-mono">provider:model-name</code>. Leave empty to skip LLM synthesis (infrastructure-only mode).
                   </p>
                 </div>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="dream-tools" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="dream-tools" className="text-xs font-medium text-(--color-text-muted)">
                     Extra tools (comma-separated)
                   </label>
                   <Input
@@ -339,27 +339,27 @@ export function DreamSettingsPage() {
                     placeholder="ls, read, wiki_search, write"
                     className="h-9 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     <code className="font-mono">read, write, ls, wiki_search</code> are always injected by the backend regardless of this list.
                   </p>
                 </div>
               </section>
 
               {/* ── Prompt ──────────────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   System prompt
                 </h2>
 
-                <textarea
+                <Textarea
                   value={body}
                   onChange={(e) => setBody(e.target.value)}
                   rows={20}
                   spellCheck={false}
-                  className="w-full resize-y rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring/40"
+                  className="resize-y font-mono text-sm leading-normal"
                   placeholder={DEFAULT_BODY}
                 />
-                <p className="text-[11px] text-muted-foreground">
+                <p className="text-[11px] text-(--color-text-muted)">
                   The dream agent receives each unprocessed session transcript and note as user messages. This prompt sets its behaviour and quality gates.
                 </p>
               </section>

--- a/web/src/routes/settings.index.tsx
+++ b/web/src/routes/settings.index.tsx
@@ -63,7 +63,7 @@ function SettingsNavCard({ to, icon: Icon, title, description, count, countLabel
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-semibold">{title}</span>
-          <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">
+          <span className="rounded-md bg-muted px-2 py-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">
             {count === null ? '–' : count} {countLabel}
           </span>
         </div>

--- a/web/src/routes/settings.index.tsx
+++ b/web/src/routes/settings.index.tsx
@@ -49,12 +49,13 @@ function SettingsNavCard({ to, icon: Icon, title, description, count, countLabel
     <Link
       to={to}
       className={cn(
-        'group flex items-center gap-4 rounded-xl border border-border bg-card/40 p-4 transition-all',
-        'hover:border-border/80 hover:bg-card focus-visible:border-ring focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40',
+        'group flex items-center gap-4 rounded-xl border border-(--color-border) bg-(--bg-card) p-4 text-(--color-text) transition-colors',
+        'hover:border-(--color-border-strong) hover:bg-(--color-surface)',
+        'focus-visible:border-(--focus-ring) focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-(--focus-ring)/40',
       )}
     >
       <span
-        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground ring-1 ring-border transition-colors group-hover:text-foreground"
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-(--bg-key) text-(--color-text-muted) ring-1 ring-(--color-border) transition-colors group-hover:text-(--color-text)"
         aria-hidden="true"
       >
         <Icon size={18} />
@@ -62,17 +63,17 @@ function SettingsNavCard({ to, icon: Icon, title, description, count, countLabel
 
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-semibold">{title}</span>
-          <span className="rounded-md bg-muted px-2 py-0.5 font-mono text-[10px] tabular-nums text-muted-foreground">
+          <span className="truncate text-sm font-semibold text-(--color-text)">{title}</span>
+          <span className="rounded-md bg-(--bg-key) px-2 py-0.5 font-mono text-[10px] tabular-nums text-(--color-text-muted)">
             {count === null ? '–' : count} {countLabel}
           </span>
         </div>
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">{description}</p>
+        <p className="mt-0.5 truncate text-xs text-(--color-text-muted)">{description}</p>
       </div>
 
       <ChevronRight
         size={16}
-        className="shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+        className="shrink-0 text-(--color-text-muted) transition-transform group-hover:translate-x-0.5 group-hover:text-(--color-text)"
         aria-hidden="true"
       />
     </Link>
@@ -125,7 +126,7 @@ export function SystemUpdateCard() {
   }
 
   return (
-    <Card size="sm" className="border-border bg-card/40">
+    <Card size="sm" className="border-(--color-border) bg-(--bg-card)">
       <CardHeader className="gap-2 sm:grid-cols-[1fr_auto]">
         <div>
           <CardTitle>Application update</CardTitle>
@@ -145,21 +146,21 @@ export function SystemUpdateCard() {
         </Button>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="rounded-lg bg-muted/50 p-3 text-xs text-muted-foreground ring-1 ring-border/70">
+        <div className="rounded-lg bg-(--bg-key) p-3 text-xs text-(--color-text-muted) ring-1 ring-(--color-border)">
           <div className="flex flex-wrap items-center gap-2">
             <span>Current version:</span>
-            <span className="font-mono text-foreground">
+            <span className="font-mono text-(--color-text)">
               {currentVersion ? `v${currentVersion}` : 'Not checked'}
             </span>
             {status?.latest_version && (
               <>
                 <span>Latest:</span>
-                <span className="font-mono text-foreground">v{status.latest_version}</span>
+                <span className="font-mono text-(--color-text)">v{status.latest_version}</span>
               </>
             )}
           </div>
           {updateQ.error && (
-            <p className="mt-2 text-destructive">
+            <p className="mt-2 text-(--color-error)">
               {updateQ.error instanceof Error ? updateQ.error.message : String(updateQ.error)}
             </p>
           )}
@@ -169,8 +170,8 @@ export function SystemUpdateCard() {
         </div>
 
         {status?.update_available && (
-          <div className="flex flex-col gap-2 rounded-lg border border-primary/20 bg-primary/5 p-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm font-medium text-foreground">
+          <div className="flex flex-col gap-2 rounded-lg border border-(--accent-blue)/30 bg-(--accent-blue-soft) p-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm font-medium text-(--color-text)">
               New update v{status.latest_version} is available.
             </p>
             <Button
@@ -190,7 +191,7 @@ export function SystemUpdateCard() {
 
 function SectionHeader({ children }: { children: string }) {
   return (
-    <h2 className="mb-2 px-1 text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+    <h2 className="mb-2 px-1 text-[11px] font-medium tracking-wider text-(--color-text-muted) uppercase">
       {children}
     </h2>
   )
@@ -219,20 +220,20 @@ export function SettingsHubPage() {
             <Link
               to="/cockpit"
               aria-label="Back to chat"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             >
               <ArrowLeft size={16} aria-hidden="true" />
             </Link>
           )}
           <span
-            className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted text-muted-foreground ring-1 ring-border"
+            className="flex h-10 w-10 items-center justify-center rounded-xl bg-(--bg-key) text-(--color-text-muted) ring-1 ring-(--color-border)"
             aria-hidden="true"
           >
             <SettingsIcon size={18} />
           </span>
           <div>
-            <h1 className="text-lg font-semibold">Settings</h1>
-            <p className="text-xs text-muted-foreground">
+            <h1 className="text-lg font-semibold text-(--color-text)">Settings</h1>
+            <p className="text-xs text-(--color-text-muted)">
               Configure your workspace and the agents that run in it.
             </p>
           </div>

--- a/web/src/routes/settings.mcp.$name.tsx
+++ b/web/src/routes/settings.mcp.$name.tsx
@@ -117,10 +117,10 @@ export function McpServerDetailPage() {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto flex max-w-3xl flex-col gap-4 p-6">
           {serverQ.isLoading && (
-            <p className="text-sm text-muted-foreground">Loading server…</p>
+            <p className="text-sm text-(--color-text-muted)">Loading server…</p>
           )}
           {serverQ.isError && (
-            <p className="text-sm text-destructive">
+            <p className="text-sm text-(--color-error)">
               Failed to load: {String(serverQ.error)}
             </p>
           )}
@@ -130,15 +130,15 @@ export function McpServerDetailPage() {
               <StatusCard server={server} />
 
               {server.state === 'error' && server.error && (
-                <Card size="sm" className="border-destructive/40 bg-destructive/5">
+                <Card size="sm" className="border-(--color-error)/40 bg-(--color-error-subtle)">
                   <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <AlertCircle size={14} className="text-destructive" />
+                    <CardTitle className="flex items-center gap-2 text-(--color-error)">
+                      <AlertCircle size={14} className="text-(--color-error)" />
                       Runtime error
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className="font-mono text-xs text-destructive">{server.error}</p>
+                    <p className="font-mono text-xs text-(--color-error)">{server.error}</p>
                   </CardContent>
                 </Card>
               )}
@@ -154,7 +154,7 @@ export function McpServerDetailPage() {
               ) : (
                 <Card size="sm">
                   <CardContent className="pt-4">
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs text-(--color-text-muted)">
                       No saved configuration found. The server may have been removed
                       from <span className="font-mono">mcp.json</span>.
                     </p>
@@ -163,7 +163,7 @@ export function McpServerDetailPage() {
               )}
 
               {dirty && (
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <div className="flex items-center gap-2 text-xs text-(--color-text-muted)">
                   <Button
                     variant="ghost"
                     size="xs"
@@ -212,12 +212,12 @@ function StatusCard({
           <span
             className={
               server.state === 'ready'
-                ? 'text-green-600 dark:text-green-500'
+                ? 'text-(--accent-green)'
                 : server.state === 'starting'
-                  ? 'text-yellow-600 dark:text-yellow-500'
+                  ? 'text-(--accent-orange)'
                   : server.state === 'error'
-                    ? 'text-destructive'
-                    : 'text-muted-foreground'
+                    ? 'text-(--color-error)'
+                    : 'text-(--color-text-muted)'
             }
           >
             {server.state}
@@ -233,14 +233,14 @@ function StatusCard({
 
         {server.tool_names.length > 0 && (
           <div className="sm:col-span-2">
-            <p className="mb-1.5 text-xs font-medium text-foreground">
+            <p className="mb-1.5 text-xs font-medium text-(--color-text)">
               Tools ({server.tool_names.length})
             </p>
             <div className="flex flex-wrap gap-1">
               {server.tool_names.map((tool) => (
                 <span
                   key={tool}
-                  className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                  className="rounded-md bg-(--bg-key) px-1.5 py-0.5 font-mono text-[11px] text-(--color-text-muted)"
                 >
                   {tool}
                 </span>
@@ -256,8 +256,8 @@ function StatusCard({
 function Stat({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[11px] text-muted-foreground">{label}</span>
-      <span className="font-medium text-foreground">{children}</span>
+      <span className="text-[11px] text-(--color-text-muted)">{label}</span>
+      <span className="font-medium text-(--color-text)">{children}</span>
     </div>
   )
 }
@@ -293,7 +293,7 @@ function RestartCard({
           {pending ? 'Restarting…' : 'Restart'}
         </Button>
         {!enabled && (
-          <p className="mt-2 text-[11px] text-muted-foreground">
+          <p className="mt-2 text-[11px] text-(--color-text-muted)">
             Server is disabled — enable and save first to restart.
           </p>
         )}

--- a/web/src/routes/settings.sandbox.tsx
+++ b/web/src/routes/settings.sandbox.tsx
@@ -81,19 +81,19 @@ export function SandboxSettingsPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-4">
+      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-(--color-border) bg-(--bg-page) px-4">
         {isMobile && (
           <Link
             to="/settings"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             aria-label="Back to settings"
           >
             <ArrowLeft size={14} />
           </Link>
         )}
-        <h1 className="flex-1 truncate text-sm font-semibold">Sandbox</h1>
+        <h1 className="flex-1 truncate text-sm font-semibold text-(--color-text)">Sandbox</h1>
         {dirty && (
-          <span className="text-xs text-muted-foreground" aria-live="polite">
+          <span className="text-xs text-(--color-text-muted)" aria-live="polite">
             Unsaved
           </span>
         )}
@@ -109,23 +109,23 @@ export function SandboxSettingsPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl space-y-5 p-6">
-          <p className="text-sm leading-relaxed text-muted-foreground">
+          <p className="text-sm leading-relaxed text-(--color-text-muted)">
             Glob patterns matched against the resolved absolute path. Use{' '}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">**</code>{' '}
+            <code className="rounded bg-(--bg-key) px-1 py-0.5 font-mono text-xs">**</code>{' '}
             for any depth and{' '}
-            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">*</code>{' '}
+            <code className="rounded bg-(--bg-key) px-1 py-0.5 font-mono text-xs">*</code>{' '}
             for one path segment. The agent&rsquo;s workspace and shared memory
             are always reachable, even when a pattern would otherwise match.{' '}
             <SandboxHelpPopover />
           </p>
 
           {isLoading && (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <p className="text-sm text-(--color-text-muted)">Loading…</p>
           )}
 
           {error && (
             <div
-              className="flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-xs text-destructive"
+              className="flex items-start gap-2 rounded-lg bg-(--color-error-subtle) p-3 text-xs text-(--color-error)"
               role="alert"
             >
               <AlertCircle size={13} aria-hidden="true" className="mt-0.5" />
@@ -136,9 +136,9 @@ export function SandboxSettingsPage() {
           {!isLoading && !error && (
             <>
               {patterns.length === 0 ? (
-                <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border p-10 text-center">
-                  <p className="text-sm font-medium">No patterns</p>
-                  <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
+                <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-(--color-border) p-10 text-center">
+                  <p className="text-sm font-medium text-(--color-text)">No patterns</p>
+                  <p className="max-w-sm text-xs leading-relaxed text-(--color-text-muted)">
                     Agents have unrestricted filesystem access (apart from the
                     built-in DB / state / cache denial). Add a pattern below to
                     block files like <code className="font-mono">.env</code> or
@@ -223,7 +223,7 @@ function SandboxHelpPopover() {
         render={
           <button
             type="button"
-            className="inline-flex items-center gap-0.5 rounded text-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            className="inline-flex items-center gap-0.5 rounded text-(--color-text) underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-(--focus-ring)/40"
           >
             See examples
             <ChevronDown
@@ -241,17 +241,17 @@ function SandboxHelpPopover() {
         <ul className="flex flex-col gap-1.5">
           {EXAMPLES.map((ex) => (
             <li key={ex.pattern} className="flex flex-col gap-0.5">
-              <code className="self-start rounded bg-muted px-1.5 py-0.5 font-mono text-[11px]">
+              <code className="self-start rounded bg-(--bg-key) px-1.5 py-0.5 font-mono text-[11px] text-(--color-text)">
                 {ex.pattern}
               </code>
-              <span className="text-[11px] leading-snug text-muted-foreground">
+              <span className="text-[11px] leading-snug text-(--color-text-muted)">
                 {ex.description}
               </span>
             </li>
           ))}
         </ul>
 
-        <p className="border-t border-border pt-2 text-[11px] leading-snug text-muted-foreground">
+        <p className="border-t border-(--color-border) pt-2 text-[11px] leading-snug text-(--color-text-muted)">
           Built-in DB / state / cache paths are always denied; matching is
           logical-OR across patterns &mdash; one match blocks access.
         </p>

--- a/web/src/routes/settings.skills.$name.tsx
+++ b/web/src/routes/settings.skills.$name.tsx
@@ -73,9 +73,9 @@ export function SkillEditorPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-3xl p-6">
-          {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {isLoading && <p className="text-sm text-(--color-text-muted)">Loading…</p>}
           {isError && (
-            <p className="text-sm text-destructive">Failed to load: {String(error)}</p>
+            <p className="text-sm text-(--color-error)">Failed to load: {String(error)}</p>
           )}
           {data && (
             <Card size="sm">
@@ -101,7 +101,7 @@ export function SkillEditorPage() {
             </Card>
           )}
           {dirty && (
-            <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+            <div className="mt-4 flex items-center gap-2 text-xs text-(--color-text-muted)">
               <Button
                 variant="ghost"
                 size="xs"

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -54,7 +54,7 @@ export function SettingsLayout() {
   // Router navigates to the detail route and we render only the Outlet.
   if (isMobile) {
     return (
-      <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
+      <div className="flex h-dvh flex-col overflow-hidden bg-(--bg-page) text-(--color-text)">
         {/* On a list route show the list; on a detail route show the outlet */}
         {onDetail ? (
           <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -75,7 +75,7 @@ export function SettingsLayout() {
 
   // Desktop layout: three-column
   return (
-    <div className="flex h-dvh overflow-hidden bg-background text-foreground">
+    <div className="flex h-dvh overflow-hidden bg-(--bg-page) text-(--color-text)">
       <CategoryRail />
       {listKind && <CategoryList kind={listKind} />}
       <main className="flex min-w-0 flex-1 flex-col">

--- a/web/src/routes/settings.voice.tsx
+++ b/web/src/routes/settings.voice.tsx
@@ -17,6 +17,7 @@ import { useToastStore } from '@/stores/useToastStore'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
 import type { SpeechConfig } from '@/api/client'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -100,20 +101,20 @@ export function VoiceSettingsPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-4">
+      <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-3 border-b border-(--color-border) bg-(--bg-page) px-4">
         {isMobile && (
           <Link
             to="/settings"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             aria-label="Back to settings"
           >
             <ArrowLeft size={14} />
           </Link>
         )}
-        <Mic size={15} className="shrink-0 text-muted-foreground" aria-hidden="true" />
-        <h1 className="flex-1 truncate text-sm font-semibold">Voice input</h1>
+        <Mic size={15} className="shrink-0 text-(--color-text-muted)" aria-hidden="true" />
+        <h1 className="flex-1 truncate text-sm font-semibold text-(--color-text)">Voice input</h1>
         {dirty && (
-          <span className="text-xs text-muted-foreground" aria-live="polite">
+          <span className="text-xs text-(--color-text-muted)" aria-live="polite">
             Unsaved
           </span>
         )}
@@ -129,19 +130,19 @@ export function VoiceSettingsPage() {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-2xl space-y-5 p-6">
-          <p className="text-sm leading-relaxed text-muted-foreground">
+          <p className="text-sm leading-relaxed text-(--color-text-muted)">
             Voice input lets you record from the microphone and insert the
             transcript into the chat input for review before sending.
             Transcription runs locally — no audio leaves your machine.
           </p>
 
           {isLoading && (
-            <p className="text-sm text-muted-foreground">Loading…</p>
+            <p className="text-sm text-(--color-text-muted)">Loading…</p>
           )}
 
           {error && (
             <div
-              className="flex items-start gap-2 rounded-lg bg-destructive/10 p-3 text-xs text-destructive"
+              className="flex items-start gap-2 rounded-lg bg-(--color-error-subtle) p-3 text-xs text-(--color-error)"
               role="alert"
             >
               <span>{error instanceof Error ? error.message : String(error)}</span>
@@ -152,35 +153,33 @@ export function VoiceSettingsPage() {
             <div className="space-y-5">
 
               {/* ── Enable / disable ───────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   Status
                 </h2>
 
                 <label className="flex cursor-pointer items-center gap-3 text-sm">
-                  <input
-                    type="checkbox"
+                  <Switch
                     checked={form.enabled}
-                    onChange={(e) => setField('enabled', e.target.checked)}
-                    className="h-4 w-4 rounded border-border accent-foreground"
+                    onCheckedChange={(checked) => setField('enabled', checked)}
                   />
-                  <span className="text-foreground">Enabled</span>
+                  <span className="text-(--color-text)">Enabled</span>
                 </label>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-(--color-text-muted)">
                   When disabled the mic button in the chat input is shown but inactive.
-                  Requires the <code className="rounded bg-muted px-1 font-mono">voice-local</code> extra:{' '}
-                  <code className="rounded bg-muted px-1 font-mono">uv sync --extra voice-local</code>
+                  Requires the <code className="rounded bg-(--bg-key) px-1 font-mono">voice-local</code> extra:{' '}
+                  <code className="rounded bg-(--bg-key) px-1 font-mono">uv sync --extra voice-local</code>
                 </p>
               </section>
 
               {/* ── Model ─────────────────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   Model
                 </h2>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="voice-model" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="voice-model" className="text-xs font-medium text-(--color-text-muted)">
                     Model ID
                   </label>
                   <Input
@@ -190,7 +189,7 @@ export function VoiceSettingsPage() {
                     placeholder="local:base"
                     className="h-9 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     Format: <code className="font-mono">provider:name</code>.
                     V1 supports <code className="font-mono">local:base</code>,{' '}
                     <code className="font-mono">local:small</code>, and{' '}
@@ -200,13 +199,13 @@ export function VoiceSettingsPage() {
               </section>
 
               {/* ── Language & limits ─────────────────────────────── */}
-              <section className="space-y-3 rounded-xl border border-border p-4">
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <section className="space-y-3 rounded-xl border border-(--color-border) bg-(--bg-card) p-4">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-(--color-text-muted)">
                   Transcription
                 </h2>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="voice-language" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="voice-language" className="text-xs font-medium text-(--color-text-muted)">
                     Language
                   </label>
                   <Input
@@ -216,7 +215,7 @@ export function VoiceSettingsPage() {
                     placeholder="auto"
                     className="h-9 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     <code className="font-mono">auto</code> lets Whisper detect the language.
                     Use a BCP-47 code to force a specific language —{' '}
                     e.g. <code className="font-mono">en</code>, <code className="font-mono">fr</code>,{' '}
@@ -225,7 +224,7 @@ export function VoiceSettingsPage() {
                 </div>
 
                 <div className="grid gap-1.5">
-                  <label htmlFor="voice-max-mb" className="text-xs font-medium text-muted-foreground">
+                  <label htmlFor="voice-max-mb" className="text-xs font-medium text-(--color-text-muted)">
                     Max upload (MB)
                   </label>
                   <Input
@@ -240,7 +239,7 @@ export function VoiceSettingsPage() {
                     }}
                     className="h-9 w-28 font-mono text-sm"
                   />
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-[11px] text-(--color-text-muted)">
                     Recordings larger than this are rejected before transcription.
                     A few minutes of compressed WebM audio is typically under 5 MB.
                   </p>

--- a/web/src/routes/telemetry/chrome.tsx
+++ b/web/src/routes/telemetry/chrome.tsx
@@ -19,14 +19,14 @@ export function PageHeader({
   right: React.ReactNode
 }) {
   return (
-    <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-(--color-border) bg-(--color-surface-2) px-4">
+    <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-(--color-border) bg-(--bg-key) px-4">
       <div className="flex min-w-0 items-center gap-3">
         <Link
           to="/"
-          className="flex items-center gap-2.5 overflow-hidden rounded-md p-1 -ml-1 transition-colors hover:bg-(--color-accent-subtle)"
+          className="flex items-center gap-2.5 overflow-hidden rounded-md p-1 -ml-1 transition-colors hover:bg-(--bg-key)"
           title="Home"
         >
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-(--color-accent-subtle) ring-1 ring-(--color-border-strong)">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-(--bg-key) ring-1 ring-(--color-border-strong)">
             <img src={OpenAgentdAppIcon} width={28} height={28} alt="OpenAgentd logo" className="rounded-md" />
           </div>
           <span className="text-sm font-semibold text-(--color-text)">Telemetry</span>
@@ -66,9 +66,9 @@ export function ErrorState({
   onRetry: () => void
 }) {
   return (
-    <div className="rounded-xl border border-(--color-danger-subtle) bg-(--color-danger-subtle)/30 p-5">
+    <div className="rounded-xl border border-(--color-error-subtle) bg-(--color-error-subtle)/30 p-5">
       <div className="flex items-start gap-3">
-        <AlertTriangle size={18} className="mt-0.5 shrink-0 text-(--color-danger)" />
+        <AlertTriangle size={18} className="mt-0.5 shrink-0 text-(--color-error)" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-(--color-text)">
             Could not load observability data
@@ -76,7 +76,7 @@ export function ErrorState({
           <p className="mt-1 text-xs text-(--color-text-muted)">{message}</p>
           <button
             onClick={onRetry}
-            className="mt-3 rounded-md border border-(--color-border) bg-(--color-surface) px-3 py-1.5 text-xs font-medium text-(--color-text) transition-colors hover:bg-(--color-accent-subtle)"
+            className="mt-3 rounded-md border border-(--color-border) bg-(--bg-card) px-3 py-1.5 text-xs font-medium text-(--color-text) transition-colors hover:bg-(--bg-key)"
           >
             Retry
           </button>

--- a/web/src/routes/telemetry/index.tsx
+++ b/web/src/routes/telemetry/index.tsx
@@ -40,7 +40,7 @@ export function TelemetryPage() {
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null)
 
   return (
-    <div className="flex h-dvh flex-col overflow-hidden bg-(--color-bg) text-(--color-text)">
+    <div className="flex h-dvh flex-col overflow-hidden bg-(--bg-page) text-(--color-text)">
       {selectedTraceId ? (
         <TraceDetailRoute
           traceId={selectedTraceId}
@@ -78,14 +78,14 @@ function SummaryRoute({
         isFetching={isFetching}
         right={
           <>
-            <div className="flex items-center gap-1 rounded-lg border border-(--color-border) bg-(--color-surface) p-0.5">
+            <div className="flex items-center gap-1 rounded-lg border border-(--color-border) bg-(--bg-card) p-0.5">
               {RANGES.map((r) => (
                 <button
                   key={r.value}
                   onClick={() => onChangeDays(r.value)}
                   className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
                     days === r.value
-                      ? 'bg-(--color-accent-subtle) text-(--color-accent)'
+                      ? 'bg-(--bg-key) text-(--color-accent)'
                       : 'text-(--color-text-muted) hover:text-(--color-text)'
                   }`}
                 >
@@ -95,7 +95,7 @@ function SummaryRoute({
             </div>
             <Link
               to="/"
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
               aria-label="Back to home"
               title="Back to home"
             >
@@ -151,7 +151,7 @@ function TraceDetailRoute({
         left={
           <button
             onClick={onBack}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
             aria-label="Back to list"
           >
             <ArrowLeft size={14} />
@@ -161,7 +161,7 @@ function TraceDetailRoute({
         right={
           <Link
             to="/"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text-2)"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text-2)"
             aria-label="Back to home"
             title="Back to home"
           >
@@ -182,7 +182,7 @@ function TraceDetailRoute({
               onRetry={() => refetch()}
             />
           ) : !data ? (
-            <div className="rounded-xl border border-(--color-border) bg-(--color-surface-2) p-6 text-center">
+            <div className="rounded-xl border border-(--color-border) bg-(--bg-key) p-6 text-center">
               <p className="text-sm font-medium text-(--color-text)">
                 Trace not found
               </p>
@@ -201,7 +201,7 @@ function TraceDetailRoute({
         {selectedSpan && (
           isMobile ? (
             // Full-width overlay on mobile
-            <div className="absolute inset-0 z-10 overflow-y-auto bg-(--color-surface)">
+            <div className="absolute inset-0 z-10 overflow-y-auto bg-(--bg-card)">
               <SpanDetailPanel
                 span={selectedSpan}
                 onClose={() => setSelectedSpanId(null)}

--- a/web/src/routes/telemetry/primitives.tsx
+++ b/web/src/routes/telemetry/primitives.tsx
@@ -23,13 +23,13 @@ export function Stat({
   tone?: 'danger'
 }) {
   return (
-    <div className="rounded-lg border border-(--color-border) bg-(--color-surface) p-3">
+    <div className="rounded-lg border border-(--color-border) bg-(--bg-card) p-3">
       <p className="text-[10px] uppercase tracking-wide text-(--color-text-muted)">
         {label}
       </p>
       <p
         className={`mt-1 text-lg font-semibold tabular-nums ${
-          tone === 'danger' ? 'text-(--color-danger)' : 'text-(--color-text)'
+          tone === 'danger' ? 'text-(--color-error)' : 'text-(--color-text)'
         }`}
       >
         {value}
@@ -50,10 +50,10 @@ export function Table({
   align: ('left' | 'right')[]
 }) {
   return (
-    <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--color-surface)">
+    <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--bg-card)">
       <table className="min-w-[360px] w-full text-xs">
         <thead>
-          <tr className="border-b border-(--color-border) bg-(--color-surface-2)">
+          <tr className="border-b border-(--color-border) bg-(--bg-key)">
             {headers.map((h, i) => (
               <th
                 key={h}
@@ -92,7 +92,7 @@ export function Table({
 
 export function EmptyTable({ label }: { label: string }) {
   return (
-    <div className="rounded-lg border border-dashed border-(--color-border) bg-(--color-surface-2) p-6 text-center">
+    <div className="rounded-lg border border-dashed border-(--color-border) bg-(--bg-key) p-6 text-center">
       <p className="text-xs text-(--color-text-muted)">{label}</p>
     </div>
   )

--- a/web/src/routes/telemetry/summary/DailyBars.tsx
+++ b/web/src/routes/telemetry/summary/DailyBars.tsx
@@ -15,7 +15,7 @@ export function DailyBars({
   }
   const max = Math.max(...rows.map((r) => r.turns), 1)
   return (
-    <div className="rounded-lg border border-(--color-border) bg-(--color-surface) p-4">
+    <div className="rounded-lg border border-(--color-border) bg-(--bg-card) p-4">
       <div className="flex h-28 items-end gap-2">
         {rows.map((r) => {
           const pct = (r.turns / max) * 100
@@ -28,7 +28,7 @@ export function DailyBars({
               >
                 {r.errors > 0 && (
                   <div
-                    className="w-full rounded-t-sm bg-(--color-danger)"
+                    className="w-full rounded-t-sm bg-(--color-error)"
                     style={{
                       height: `${(r.errors / Math.max(r.turns, 1)) * 100}%`,
                     }}

--- a/web/src/routes/telemetry/summary/SummaryView.tsx
+++ b/web/src/routes/telemetry/summary/SummaryView.tsx
@@ -20,12 +20,12 @@ export function SummaryView({ data }: { data: ObservabilitySummary }) {
   return (
     <div className="flex flex-col gap-5">
       {sampled && (
-        <div className="flex items-start gap-2 rounded-lg border border-(--color-border) bg-(--color-accent-subtle)/40 p-3">
+        <div className="flex items-start gap-2 rounded-lg border border-(--color-border) bg-(--bg-key)/40 p-3">
           <Info size={14} className="mt-0.5 shrink-0 text-(--color-accent)" />
           <p className="text-xs text-(--color-text-2)">
             Spans are sampled at <strong>{Math.round(data.sample_ratio * 100)}%</strong>.
             Figures for non-error, non-slow spans are approximate. Set{' '}
-            <code className="rounded bg-(--color-surface) px-1 py-0.5 text-[10px]">
+            <code className="rounded bg-(--bg-card) px-1 py-0.5 text-[10px]">
               OTEL_SPAN_SAMPLE_RATIO=1.0
             </code>{' '}
             to disable sampling.
@@ -94,7 +94,7 @@ export function SummaryView({ data }: { data: ObservabilitySummary }) {
               t.tool,
               formatInt(t.calls),
               t.errors > 0 ? (
-                <span className="text-(--color-danger)">{formatInt(t.errors)}</span>
+                <span className="text-(--color-error)">{formatInt(t.errors)}</span>
               ) : (
                 '0'
               ),

--- a/web/src/routes/telemetry/traces/TracesTable.tsx
+++ b/web/src/routes/telemetry/traces/TracesTable.tsx
@@ -27,10 +27,10 @@ export function TracesTable({
   // giving fresh labels whenever the table unmounts/remounts on refetch.
   const [now] = useState(() => Date.now())
   return (
-    <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--color-surface)">
+    <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--bg-card)">
       <table className="min-w-[640px] w-full text-xs">
         <thead>
-          <tr className="border-b border-(--color-border) bg-(--color-surface-2)">
+          <tr className="border-b border-(--color-border) bg-(--bg-key)">
             <Th>When</Th>
             <Th>Session</Th>
             <Th>Agent</Th>
@@ -48,7 +48,7 @@ export function TracesTable({
             <tr
               key={t.trace_id}
               onClick={() => onSelect(t.trace_id)}
-              className="cursor-pointer border-b border-(--color-border) transition-colors last:border-b-0 hover:bg-(--color-accent-subtle)/40"
+              className="cursor-pointer border-b border-(--color-border) transition-colors last:border-b-0 hover:bg-(--bg-key)/40"
             >
               <Td>
                 <span title={new Date(t.start_ms).toLocaleString()}>
@@ -68,7 +68,7 @@ export function TracesTable({
               </Td>
               <Td align="right">
                 {t.error ? (
-                  <span className="rounded bg-(--color-danger-subtle) px-1.5 py-0.5 text-[10px] font-medium text-(--color-danger)">
+                  <span className="rounded bg-(--color-error-subtle) px-1.5 py-0.5 text-[10px] font-medium text-(--color-error)">
                     error
                   </span>
                 ) : (

--- a/web/src/routes/telemetry/waterfall/SpanDetailPanel.tsx
+++ b/web/src/routes/telemetry/waterfall/SpanDetailPanel.tsx
@@ -30,14 +30,14 @@ export function SpanDetailPanel({
   const tokens = useMemo(() => extractTokens(span.attributes), [span.attributes])
 
   return (
-    <aside className={`flex shrink-0 flex-col overflow-hidden border-l border-(--color-border) bg-(--color-surface-2) ${fullWidth ? 'w-full' : 'w-96'}`}>
+    <aside className={`flex shrink-0 flex-col overflow-hidden border-l border-(--color-border) bg-(--bg-key) ${fullWidth ? 'w-full' : 'w-96'}`}>
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-(--color-border) px-4">
         <h3 className="truncate text-sm font-semibold text-(--color-text)" title={span.name}>
           {span.name}
         </h3>
         <button
           onClick={onClose}
-          className="flex h-6 w-6 items-center justify-center rounded text-(--color-text-muted) transition-colors hover:bg-(--color-accent-subtle) hover:text-(--color-text)"
+          className="flex h-6 w-6 items-center justify-center rounded text-(--color-text-muted) transition-colors hover:bg-(--bg-key) hover:text-(--color-text)"
           aria-label="Close span detail"
         >
           <X size={14} />
@@ -50,7 +50,7 @@ export function SpanDetailPanel({
             label="Status"
             value={
               span.status === 'ERROR' ? (
-                <span className="text-(--color-danger)">{span.status}</span>
+                <span className="text-(--color-error)">{span.status}</span>
               ) : (
                 span.status || 'OK'
               )
@@ -75,7 +75,7 @@ export function SpanDetailPanel({
               {tokens.map((t) => (
                 <div
                   key={t.label}
-                  className="rounded-md border border-(--color-border) bg-(--color-surface) p-2"
+                  className="rounded-md border border-(--color-border) bg-(--bg-card) p-2"
                 >
                   <p className="text-[9px] uppercase tracking-wide text-(--color-text-muted)">
                     {t.label}
@@ -95,7 +95,7 @@ export function SpanDetailPanel({
         {attrs.length === 0 ? (
           <p className="text-xs text-(--color-text-muted)">No attributes.</p>
         ) : (
-          <dl className="flex flex-col divide-y divide-(--color-border) rounded-md border border-(--color-border) bg-(--color-surface) text-[11px]">
+          <dl className="flex flex-col divide-y divide-(--color-border) rounded-md border border-(--color-border) bg-(--bg-card) text-[11px]">
             {attrs.map(([key, value]) => (
               <div key={key} className="flex flex-col gap-0.5 px-3 py-2">
                 <dt className="font-medium text-(--color-text-muted)">{key}</dt>

--- a/web/src/routes/telemetry/waterfall/Waterfall.tsx
+++ b/web/src/routes/telemetry/waterfall/Waterfall.tsx
@@ -45,9 +45,9 @@ export function Waterfall({
         </span>
         <span>Total {formatMs(bounds.duration_ms)}</span>
       </div>
-      <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--color-surface)">
+      <div className="overflow-x-auto rounded-lg border border-(--color-border) bg-(--bg-card)">
         <div className="min-w-[480px]">
-          <div className="flex border-b border-(--color-border) bg-(--color-surface-2) px-3 py-2 text-[10px] font-medium uppercase tracking-wide text-(--color-text-muted)">
+          <div className="flex border-b border-(--color-border) bg-(--bg-key) px-3 py-2 text-[10px] font-medium uppercase tracking-wide text-(--color-text-muted)">
             <div className="w-48 shrink-0 sm:w-64">Span</div>
             <div className="flex-1">Timeline</div>
             <div className="w-20 shrink-0 text-right">Duration</div>
@@ -88,8 +88,8 @@ function WaterfallRow({
     <button
       type="button"
       onClick={onSelect}
-      className={`flex w-full items-center px-3 py-2 text-left text-xs transition-colors hover:bg-(--color-accent-subtle)/30 ${
-        selected ? 'bg-(--color-accent-subtle)/60' : ''
+      className={`flex w-full items-center px-3 py-2 text-left text-xs transition-colors hover:bg-(--bg-key)/30 ${
+        selected ? 'bg-(--bg-key)/60' : ''
       }`}
     >
       <div
@@ -102,7 +102,7 @@ function WaterfallRow({
         />
         <span
           className={`truncate font-medium ${
-            isError ? 'text-(--color-danger)' : 'text-(--color-text)'
+            isError ? 'text-(--color-error)' : 'text-(--color-text)'
           }`}
           title={node.span.name}
         >

--- a/web/src/routes/telemetry/waterfall/categories.ts
+++ b/web/src/routes/telemetry/waterfall/categories.ts
@@ -24,7 +24,7 @@ export function categoryDotClass(cat: SpanCategory): string {
 }
 
 export function categoryBarClass(cat: SpanCategory, isError: boolean): string {
-  if (isError) return 'bg-(--color-danger)'
+  if (isError) return 'bg-(--color-error)'
   switch (cat) {
     case 'agent_run':
       return 'bg-(--color-accent)'

--- a/web/src/utils/markdown.tsx
+++ b/web/src/utils/markdown.tsx
@@ -141,10 +141,10 @@ export function CodeBlock({ children, rawText }: { children: React.ReactNode; ra
   }
 
   return (
-    <div className="surface-raised group relative my-2 overflow-hidden rounded-xl border border-(--color-border) bg-(--color-surface)">
+    <div className="surface-raised group relative my-2 overflow-hidden rounded-xl border border-(--color-border) bg-(--bg-card)">
       <button
         onClick={handleCopy}
-        className="absolute right-2 top-2 z-10 rounded-md p-1.5 text-(--color-text-muted) transition-all opacity-100 hover:bg-(--color-accent-subtle) hover:text-(--color-text-2) md:opacity-0 md:group-hover:opacity-100"
+        className="absolute right-2 top-2 z-10 rounded-md p-1.5 text-(--color-text-muted) transition-all opacity-100 hover:bg-(--bg-key) hover:text-(--color-text-2) md:opacity-0 md:group-hover:opacity-100"
         aria-label="Copy code"
         title="Copy"
       >
@@ -241,7 +241,7 @@ const MarkdownVideo = memo(function MarkdownVideo({
   if (errored) {
     return (
       <span
-        className="my-2 inline-flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--color-surface) px-3 py-2 text-xs text-(--color-text-muted)"
+        className="my-2 inline-flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--bg-card) px-3 py-2 text-xs text-(--color-text-muted)"
         title={alt || 'Video unavailable'}
       >
         <FileVideo size={14} />
@@ -302,7 +302,7 @@ function MarkdownImage({
   if (!src || errored) {
     return (
       <span
-        className="my-2 inline-flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--color-surface) px-3 py-2 text-xs text-(--color-text-muted)"
+        className="my-2 inline-flex items-center gap-2 rounded-lg border border-(--color-border) bg-(--bg-card) px-3 py-2 text-xs text-(--color-text-muted)"
         title={alt || 'Image unavailable'}
       >
         <ImageOff size={14} />

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Aligns the OpenAgentd web UI with the warm paper notebook aesthetic, restyles the core chat surfaces to match the pencil design, and rewrites `documents/styling-specs/` as prescriptive guidelines a frontend dev (or LLM) can build to without reading the codebase.

### Theme & tokens
- Warm paper palette across the app (`--bg-page`, `--bg-card`, `--bg-key`, `--bg-sidebar`, `--color-border`, agent-chip palette, marker palette).
- Light-first canonical theme; dark mode equally supported.
- Caveat wordmark on the home and welcome screens.
- `rounded-full` reserved for genuine circles; chips and badges use `rounded-md`.

### Component restyle (pencil parity)
- `ToolCall` rebuilt as a paper card driven by a `StatusDot` lifecycle (start / running / success / failed); per-tool customization moved into `ToolCall/display.tsx`.
- `Thinking` rebuilt as a paper card with chevron + 13/500 label + mono 11px sub-hint; streaming dots replace the sub-hint while reasoning is live.
- `UserBubble` aligned across `AgentView` and `AgentPane` to the paper-card recipe.
- `ViewToggle` icons aligned to pencil semantics (User / Columns2 / LayoutGrid).
- `TodosPopover` restyled to paper-card chrome with hand-drawn Caveat empty state.
- `FloatingInputBar` gains minimize-on-blur, `Ctrl+I` summon, and a slim icon strip resting state on desktop; mobile keeps the static dock.
- `ThemeToggle` expanded variant is icon-only for sidebar consistency.
- New primitives extracted: `BrandHeader`, `SidebarItem`, `AgentTopbar`, `TopbarAction`, `TokenMeter`, `QueueBanner`, `AgentChip`, `FilePreviewStrip`.
- Hand-drawn Caveat empty-state pattern adopted in AgentView, TileArea, TodosPopover.

### Form primitives & settings migration
- Refreshed `Input`, `Textarea`, `Select`, `DateTimePicker`, `Switch`, `Checkbox`, `RadioGroup`, `NumberInput` with the paper-card token recipe.
- `Card`, `Dialog`, `DropdownMenu` primitives drop the `ring-1 ring-foreground/10` antipattern; the warm border alone carries elevation.
- Settings routes (12 files) migrated from shadcn semantic utilities to canonical CSS-variable tokens; native `<input type=\"checkbox\">` flags replaced with `Switch`; raw `<textarea>` replaced with `Textarea` primitive.

### Styling-specs rewrite
- All 9 spec files converted to a prescriptive guideline voice: state the rules, anti-patterns, and state choreographies in prose; no code recipes, no file paths, no emoji.
- `applications.md` fully rewritten with new sections for AgentTopbar, ViewToggle, TopbarAction, TodosPopover, FilePreviewStrip, TokenMeter, QueueBanner, plus the hand-drawn Caveat empty-state pattern.
- `interaction.md` adds canonical anti-patterns: `ring-foreground/N` on flat surfaces, drop-shadow on flat cards, native checkbox for feature flags.
- Net spec diff: +555 / −1064 lines (less duplication, more invariants).

## Validation

- `bun run lint` — clean
- `bun run typecheck` — clean
- `bun test src/__tests__` — 1520 tests pass
- Pre-commit hooks (ruff, ty, tsc) — clean on every commit

## Changed

- 110 files, +4653 / −2464
- 22 commits, all on `feat/styling` since `58dee30`