### PR TITLE
Fix desktop release build on Windows and Linux

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -906,6 +906,7 @@ fn main() {
                     }
                 }
             }
+            #[cfg(target_os = "macos")]
             RunEvent::Reopen { has_visible_windows: _, .. } => {
                 show_main_window(app);
             }


### PR DESCRIPTION
Fixes the v1.13.0 desktop release build by compiling the macOS-only RunEvent::Reopen arm only on macOS.