### PR TITLE
ci: bump artifact and cache actions to Node 24 majors

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -177,7 +177,7 @@ jobs:
       # hop; bump it deliberately when Tauri ships a new patch.
       - name: Restore cached tauri-cli
         id: cache-tauri-cli
-        uses: actions/cache@v4
+        uses: actions/cache@v7
         with:
           path: |
             ~/.cargo/bin/cargo-tauri
@@ -341,7 +341,7 @@ jobs:
             -o -name 'OpenAgentd_*.deb' \
           \) -print -exec cp {} "$GITHUB_WORKSPACE/_release/" \;
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: openagentd-desktop-${{ matrix.platform }}-${{ matrix.arch }}
           path: _release/*
@@ -355,7 +355,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: _artifacts
 


### PR DESCRIPTION
Eliminates the Node 20 deprecation warnings surfaced on the v1.17.3 desktop release run:

- `actions/cache@v4` → `@v7`
- `actions/upload-artifact@v4` → `@v5`
- `actions/download-artifact@v4` → `@v5`

All three current majors target Node 24 natively, so the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 shim no longer has to wrap them.