### PR TITLE
Fix flaky spawn counter DB lock test

### DIFF
--- a/tests/agent/mode/team/test_team_spawn.py
+++ b/tests/agent/mode/team/test_team_spawn.py
@@ -738,6 +738,8 @@ async def test_counter_reconciliation_reads_db(tmp_path):
     try:
         sid = str(uuid.uuid7())
         await team.handle_user_message("hi", session_id=sid)
+        if team.lead._active_task is not None:
+            await team.lead._active_task
         lead_uuid = uuid.UUID(sid)
 
         # Pre-create executor#7 under this lead.


### PR DESCRIPTION
Fixes the post-merge Core test flake from v1.20.0.\n\n- Wait for the lead activation task to finish before manually inserting child session rows in the spawn counter reconciliation test.\n- Prevents the test fixture cleanup from racing an active lead DB write and hitting SQLite `database is locked`.\n\nVerification:\n- `uv run pytest --no-cov -q tests/agent/mode/team/test_team_spawn.py::test_counter_reconciliation_reads_db`\n- `uv run pytest --no-cov -q tests/agent/mode/team/test_team_spawn.py`