### PR TITLE
Fix Windows desktop release smoke blockers

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -29,6 +29,11 @@ on:
         type: choice
         options: [stable, beta, nightly]
         default: stable
+      platform:
+        description: "Platform matrix to build"
+        type: choice
+        options: [all, windows, macos, linux]
+        default: all
 
 permissions:
   contents: write
@@ -45,6 +50,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
       - id: version
@@ -58,6 +64,27 @@ jobs:
           VERSION=$(cat app/version.txt | tr -d '[:space:]')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+      - id: matrix
+        run: |
+          case "${{ github.event.inputs.platform }}" in
+            all)
+              MATRIX='{"include":[{"platform":"macos","arch":"aarch64","runner":"macos-26","rust_target":"aarch64-apple-darwin","tauri_args":"--target aarch64-apple-darwin --verbose"},{"platform":"windows","arch":"x86_64","runner":"windows-latest","rust_target":"x86_64-pc-windows-msvc","tauri_args":"--verbose"},{"platform":"linux","arch":"x86_64","runner":"ubuntu-22.04","rust_target":"x86_64-unknown-linux-gnu","tauri_args":"--bundles deb --verbose"}]}'
+              ;;
+            macos)
+              MATRIX='{"include":[{"platform":"macos","arch":"aarch64","runner":"macos-26","rust_target":"aarch64-apple-darwin","tauri_args":"--target aarch64-apple-darwin --verbose"}]}'
+              ;;
+            windows)
+              MATRIX='{"include":[{"platform":"windows","arch":"x86_64","runner":"windows-latest","rust_target":"x86_64-pc-windows-msvc","tauri_args":"--verbose"}]}'
+              ;;
+            linux)
+              MATRIX='{"include":[{"platform":"linux","arch":"x86_64","runner":"ubuntu-22.04","rust_target":"x86_64-unknown-linux-gnu","tauri_args":"--bundles deb --verbose"}]}'
+              ;;
+            *)
+              echo "Unknown platform: ${{ github.event.inputs.platform }}" >&2
+              exit 1
+              ;;
+          esac
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   build:
     needs: prepare
@@ -65,45 +92,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: macos
-            arch: aarch64
-            # macos-26 (Tahoe, Apple Silicon, GA) — the title-bar
-            # control geometry that Tao computes from
-            # ``traffic_light_position`` is sensitive to the build-host
-            # SDK on Tahoe. Binaries built on macos-15 render the
-            # traffic lights ~6 pt off-centre when run on macOS 26.
-            # Building on macos-26 itself makes the offset render
-            # correctly on Tahoe (verified locally; see
-            # documents/docs/desktop.md → "Window chrome"). Older
-            # macOS versions (Sonoma 14, Sequoia 15) continue to
-            # render correctly with a Tahoe-built binary because the
-            # SDK's title-bar metrics are forward-compatible.
-            #
-            # Label note: the standard arm64 Tahoe runner is ``macos-26``
-            # (and the larger paid tier is ``macos-26-xlarge``). The
-            # plain ``macos-26-arm64`` label that appears in
-            # actions/runner-images docs is the *image readme name*, not
-            # a runner label — using it queues forever.
-            runner: macos-26
-            rust_target: aarch64-apple-darwin
-            tauri_args: "--target aarch64-apple-darwin --verbose"
-          - platform: windows
-            arch: x86_64
-            runner: windows-latest
-            rust_target: x86_64-pc-windows-msvc
-            tauri_args: "--verbose"
-          - platform: linux
-            arch: x86_64
-            runner: ubuntu-22.04
-            rust_target: x86_64-unknown-linux-gnu
-            # Skip the AppImage bundle on CI for now: linuxdeploy reliably
-            # fails on GitHub-hosted Ubuntu 22.04 runners and Tauri swallows
-            # the underlying error so we can't actually diagnose it from CI
-            # output. The .deb covers Debian/Ubuntu users; tracking AppImage
-            # restoration in documents/techdebts/distribution-coverage.md.
-            tauri_args: "--bundles deb --verbose"
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -340,6 +329,7 @@ jobs:
     needs: [prepare, build]
     name: Publish release
     runs-on: ubuntu-latest
+    if: github.event.inputs.platform == 'all'
     steps:
       - uses: actions/checkout@v6
 

--- a/app/cli/commands/serve.py
+++ b/app/cli/commands/serve.py
@@ -56,7 +56,6 @@ import json
 import os
 import secrets
 import signal
-import socket
 import sys
 import threading
 from typing import Any
@@ -158,22 +157,14 @@ def _start_parent_watch(
     t.start()
 
 
-def _bind_socket(host: str, port: int) -> socket.socket:
-    """Pre-bind a socket so we know the chosen port before uvicorn starts.
-
-    Uvicorn accepts a pre-bound socket via the ``fd`` parameter on its
-    ``Config``. By binding ourselves first we can read ``getsockname()``
-    before the server even starts serving — which is exactly what the
-    handshake needs.
-
-    No ``SO_REUSEADDR`` — that's a restart-in-place flag and here it
-    would just create a small window in which another process could
-    sneak onto the same port between bind and listen.
-    """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind((host, port))
-    s.set_inheritable(True)
-    return s
+def _server_port(server: Any, fallback: int) -> int:
+    """Return the actual TCP port bound by uvicorn after startup."""
+    for srv in getattr(server, "servers", []) or []:
+        for sock in getattr(srv, "sockets", []) or []:
+            addr = sock.getsockname()
+            if isinstance(addr, tuple) and len(addr) >= 2:
+                return int(addr[1])
+    return fallback
 
 
 def _emit_handshake(*, port: int, token: str | None, version: str) -> None:
@@ -215,15 +206,10 @@ def cmd_serve(args: argparse.Namespace) -> None:
     if args.parent_pid is not None:
         _start_parent_watch(args.parent_pid)
 
-    # Pre-bind so we can read the chosen port.
-    sock = _bind_socket(args.host, args.port)
-    bound_port = sock.getsockname()[1]
-
-    # When ``fd=`` is set uvicorn re-creates the socket from that fd and
-    # ignores ``host``/``port`` — pass only what's meaningful.
     config = uvicorn.Config(
         "app.server:app",
-        fd=sock.fileno(),
+        host=args.host,
+        port=args.port,
         log_config=None,  # let loguru handle it
         access_log=False,
     )
@@ -251,14 +237,10 @@ def cmd_serve(args: argparse.Namespace) -> None:
                     await serve_task
                     return
                 await asyncio.sleep(0.05)
-            _emit_handshake(port=bound_port, token=token, version=VERSION)
+            _emit_handshake(
+                port=_server_port(server, args.port), token=token, version=VERSION
+            )
         await serve_task
 
     # Run in this thread; KeyboardInterrupt / SIGTERM propagate naturally.
-    try:
-        asyncio.run(_serve_and_handshake())
-    finally:
-        try:
-            sock.close()
-        except OSError:
-            pass
+    asyncio.run(_serve_and_handshake())

--- a/app/scheduler/cron.py
+++ b/app/scheduler/cron.py
@@ -61,7 +61,7 @@ def next_fire(
         try:
             tz = ZoneInfo(timezone)
         except ZoneInfoNotFoundError:
-            tz = _utc_zi
+            tz = _utc
         from croniter import croniter
 
         base = now.astimezone(tz)
@@ -88,7 +88,6 @@ def validate_cron(expression: str) -> bool:
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 _utc = timezone.utc
-_utc_zi = ZoneInfo("UTC")
 
 
 def _ensure_utc(dt: datetime) -> datetime:

--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -305,7 +305,8 @@ def smoke_test(python_bin: Path, site_packages: Path) -> None:
         raise SystemExit(f"smoke test: missing CLI entry at {cli_entry}")
 
     bootstrap = (
-        "import sys, runpy, site; "
+        "import sys, runpy, site, faulthandler; "
+        "faulthandler.dump_traceback_later(55, repeat=False); "
         "_site = sys.argv.pop(1); "
         "_entry = sys.argv.pop(1); "
         "site.addsitedir(_site); "
@@ -333,10 +334,12 @@ def smoke_test(python_bin: Path, site_packages: Path) -> None:
             env=env,
         )
 
+    smoke_cmd = [str(python_bin), "-c", bootstrap, str(site_packages), str(cli_entry), "serve",
+                 "--host", "127.0.0.1", "--port", "0",
+                 "--handshake", "--generate-token"]
+    print(">> " + " ".join(smoke_cmd))
     proc = subprocess.Popen(
-        [str(python_bin), "-c", bootstrap, str(site_packages), str(cli_entry), "serve",
-         "--host", "127.0.0.1", "--port", "0",
-         "--handshake", "--generate-token"],
+        smoke_cmd,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         env=env, text=True,
         # Cross-platform process group so the smoke test can hard-kill
@@ -345,24 +348,49 @@ def smoke_test(python_bin: Path, site_packages: Path) -> None:
         creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,  # type: ignore[attr-defined]
     )
 
-    # Read stdout from a background thread so the main thread can
+    # Read output from background threads so the main thread can
     # enforce a real wall-clock timeout. ``subprocess.Popen.stdout`` is
     # buffered and blocking; without this scaffold, a child that goes
     # quiet hangs the smoke test indefinitely (observed on Windows GHA
-    # runners).
+    # runners). Drain stderr too so native/runtime warnings don't fill the
+    # pipe and so timeouts include a useful tail for debugging.
     import queue as _queue
     import threading as _threading
 
     stdout_queue: "_queue.Queue[str | None]" = _queue.Queue()
+    stdout_tail: list[str] = []
+    stderr_tail: list[str] = []
+
+    def _append_tail(buf: list[str], line: str, *, limit: int = 200) -> None:
+        buf.append(line.rstrip())
+        if len(buf) > limit:
+            del buf[: len(buf) - limit]
 
     def _drain_stdout() -> None:
         assert proc.stdout is not None
         for line in iter(proc.stdout.readline, ""):
+            _append_tail(stdout_tail, line)
             stdout_queue.put(line)
         stdout_queue.put(None)  # EOF sentinel
 
-    reader = _threading.Thread(target=_drain_stdout, daemon=True)
-    reader.start()
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in iter(proc.stderr.readline, ""):
+            _append_tail(stderr_tail, line)
+
+    stdout_reader = _threading.Thread(target=_drain_stdout, daemon=True)
+    stderr_reader = _threading.Thread(target=_drain_stderr, daemon=True)
+    stdout_reader.start()
+    stderr_reader.start()
+
+    def _timeout_message() -> str:
+        out = "\n".join(stdout_tail[-80:]) or "<empty>"
+        err = "\n".join(stderr_tail[-120:]) or "<empty>"
+        return (
+            "smoke test: handshake did not arrive in 60s\n"
+            f"stdout tail:\n{out}\n"
+            f"stderr tail:\n{err}"
+        )
 
     payload: dict | None = None
     try:
@@ -371,13 +399,13 @@ def smoke_test(python_bin: Path, site_packages: Path) -> None:
         while True:
             remaining = deadline - (time.monotonic() - start)
             if remaining <= 0:
-                raise SystemExit("smoke test: handshake did not arrive in 60s")
+                raise SystemExit(_timeout_message())
             try:
                 line = stdout_queue.get(timeout=remaining)
             except _queue.Empty:
-                raise SystemExit("smoke test: handshake did not arrive in 60s")
+                raise SystemExit(_timeout_message())
             if line is None:
-                err = proc.stderr.read() if proc.stderr else ""
+                err = "\n".join(stderr_tail)
                 raise SystemExit(
                     f"smoke test: sidecar exited before handshake.\nstderr:\n{err[-4000:]}"
                 )

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -12,12 +12,13 @@ import io
 import json
 import os
 from contextlib import redirect_stdout
+from types import SimpleNamespace
 
 from app.cli.commands.serve import (
-    _bind_socket,
     _configure_desktop_token,
     _emit_handshake,
     _pid_alive,
+    _server_port,
 )
 from app.cli.main import build_parser
 
@@ -54,22 +55,23 @@ class TestParserWiring:
         assert args.parent_pid == 12345
 
 
-class TestBindSocket:
-    def test_port_zero_picks_ephemeral(self):
-        sock = _bind_socket("127.0.0.1", 0)
-        try:
-            host, port = sock.getsockname()[:2]
-            assert host == "127.0.0.1"
-            assert 1024 < port < 65536
-        finally:
-            sock.close()
+class TestServerPort:
+    def test_reads_uvicorn_bound_port(self):
+        sock = SimpleNamespace(getsockname=lambda: ("127.0.0.1", 54321))
+        uvicorn_server = SimpleNamespace(servers=[SimpleNamespace(sockets=[sock])])
 
-    def test_inheritable_flag_set(self):
-        sock = _bind_socket("127.0.0.1", 0)
-        try:
-            assert sock.get_inheritable() is True
-        finally:
-            sock.close()
+        assert _server_port(uvicorn_server, fallback=0) == 54321
+
+    def test_falls_back_when_socket_unavailable(self):
+        uvicorn_server = SimpleNamespace(servers=[])
+
+        assert _server_port(uvicorn_server, fallback=8000) == 8000
+
+    def test_ignores_non_tcp_socket_address(self):
+        sock = SimpleNamespace(getsockname=lambda: "not-a-tcp-address")
+        uvicorn_server = SimpleNamespace(servers=[SimpleNamespace(sockets=[sock])])
+
+        assert _server_port(uvicorn_server, fallback=8000) == 8000
 
 
 class TestHandshakeFormat:

--- a/tests/scheduler/test_cron.py
+++ b/tests/scheduler/test_cron.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from zoneinfo import ZoneInfo
+from unittest.mock import patch
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.scheduler.cron import next_fire, validate_cron
 
@@ -196,6 +197,24 @@ class TestNextFireCron:
             after=after,
         )
         # Falls back to UTC, so next 00:00 UTC after 12:00 is the next day.
+        assert result == datetime(2030, 1, 2, 0, 0, tzinfo=_UTC)
+
+    def test_missing_tzdata_falls_back_to_builtin_utc(self):
+        """Windows sidecar builds may not have IANA tzdata available."""
+        after = datetime(2030, 1, 1, 12, 0, tzinfo=_UTC)
+        with patch(
+            "app.scheduler.cron.ZoneInfo",
+            side_effect=ZoneInfoNotFoundError("No time zone found with key UTC"),
+        ):
+            result = next_fire(
+                "cron",
+                cron_expression="0 0 * * *",
+                every_seconds=None,
+                at_datetime=None,
+                timezone="UTC",
+                after=after,
+            )
+
         assert result == datetime(2030, 1, 2, 0, 0, tzinfo=_UTC)
 
     def test_returns_none_when_cron_expression_missing(self):


### PR DESCRIPTION
## Summary
- add a platform selector for desktop release diagnostics while keeping publish limited to full releases
- improve sidecar smoke diagnostics for startup failures
- fix Windows sidecar startup without bundled tzdata and avoid Uvicorn fd handoff for desktop serve handshake

## Tests
- uv run ruff check app/ tests/ scripts/build_sidecar.py
- uv run ty check app/
- uv run pytest tests/cli/test_serve.py tests/scheduler/test_cron.py --no-cov -q
- Windows-only release-desktop workflow reached/passed the Python sidecar bundle smoke before cancellation: https://github.com/lthoangg/OpenAgentd/actions/runs/26356239613