### PR TITLE
ci: add Tauri cargo checks

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -1,0 +1,66 @@
+name: Tauri
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "desktop/src-tauri/**"
+      - "mobile/src-tauri/**"
+      - ".github/workflows/tauri.yml"
+      - ".github/workflows/release-desktop.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "desktop/src-tauri/**"
+      - "mobile/src-tauri/**"
+      - ".github/workflows/tauri.yml"
+      - ".github/workflows/release-desktop.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Opt JS actions into Node.js 24 ahead of the June 2026 forced switch.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  cargo-check:
+    name: Cargo check (${{ matrix.package }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: desktop
+            working-directory: desktop/src-tauri
+          - package: mobile
+            working-directory: mobile/src-tauri
+    defaults:
+      run:
+        working-directory: ${{ matrix.working-directory }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Linux WebKitGTK deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.working-directory }}
+
+      - name: Cargo check
+        run: cargo check --locked

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -63,4 +63,9 @@ jobs:
           workspaces: ${{ matrix.working-directory }}
 
       - name: Cargo check
-        run: cargo check --locked
+        run: |
+          if [ "${{ matrix.package }}" = "desktop" ]; then
+            TAURI_CONFIG="$(cat tauri.dev.conf.json)" cargo check --locked
+          else
+            cargo check --locked
+          fi

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -28,27 +28,42 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  cargo-check:
-    name: Cargo check (${{ matrix.package }})
+  changes:
+    name: Detect Tauri changes
+    runs-on: ubuntu-latest
+    outputs:
+      desktop: ${{ steps.filter.outputs.desktop }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            desktop:
+              - 'desktop/src-tauri/**'
+              - '.github/workflows/tauri.yml'
+              - '.github/workflows/release-desktop.yml'
+            mobile:
+              - 'mobile/src-tauri/**'
+              - '.github/workflows/tauri.yml'
+
+  desktop:
+    name: Cargo check (desktop)
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - package: desktop
-            working-directory: desktop/src-tauri
-          - package: mobile
-            working-directory: mobile/src-tauri
     defaults:
       run:
-        working-directory: ${{ matrix.working-directory }}
+        working-directory: desktop/src-tauri
     steps:
       - uses: actions/checkout@v7
 
       - name: Install Linux WebKitGTK deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
@@ -60,12 +75,37 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ${{ matrix.working-directory }}
+          workspaces: desktop/src-tauri
 
       - name: Cargo check
+        run: TAURI_CONFIG="$(cat tauri.dev.conf.json)" cargo check --locked
+
+  mobile:
+    name: Cargo check (mobile)
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: mobile/src-tauri
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Linux WebKitGTK deps
         run: |
-          if [ "${{ matrix.package }}" = "desktop" ]; then
-            TAURI_CONFIG="$(cat tauri.dev.conf.json)" cargo check --locked
-          else
-            cargo check --locked
-          fi
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: mobile/src-tauri
+
+      - name: Cargo check
+        run: TAURI_CONFIG='{"bundle":{"icon":["icons/icon.png"]}}' cargo check --locked


### PR DESCRIPTION
## Summary
- add a Tauri workflow that runs cargo check --locked for desktop and mobile shells
- install the Linux WebKitGTK dependencies needed by Tauri on Ubuntu runners

## Validation
- cargo check --locked in desktop/src-tauri
- cargo check --locked in mobile/src-tauri