### PR TITLE
Fix Windows sidecar runtime root for v1.106.0

### DIFF
--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -252,6 +252,15 @@ def strip_bundle(site_packages: Path) -> int:
     return removed
 
 
+def _python_home_for(python_bin: Path) -> Path:
+    """Return the bundled runtime root for POSIX and flat Windows layouts."""
+    return (
+        python_bin.parent.parent
+        if python_bin.parent.name == "bin"
+        else python_bin.parent
+    )
+
+
 def smoke_test(python_bin: Path, site_packages: Path) -> None:
     """Invoke the sidecar briefly to prove the bundle actually works.
 
@@ -274,10 +283,10 @@ def smoke_test(python_bin: Path, site_packages: Path) -> None:
     import urllib.request
 
     smoke_root = site_packages.parent / "_smoke"
-    # PYTHONHOME must point at the python-build-standalone install root —
-    # the directory containing ``lib/``. The interpreter lives at
-    # ``<root>/bin/python3.X`` so the root is parent.parent.
-    python_home = python_bin.parent.parent
+    # PYTHONHOME must point at the python-build-standalone install root.
+    # POSIX places the interpreter under ``<root>/bin``; Windows keeps
+    # ``python.exe`` directly under ``<root>``.
+    python_home = _python_home_for(python_bin)
     env = {
         **os.environ,
         "PYTHONHOME": str(python_home),

--- a/tests/scripts/test_build_sidecar.py
+++ b/tests/scripts/test_build_sidecar.py
@@ -93,3 +93,17 @@ def test_normalise_posix_layout_still_preserves_bin_directory(tmp_path):
 
     assert normalised == target / "bin" / "python3.14"
     assert normalised.is_file()
+
+
+def test_python_home_matches_windows_flat_runtime_layout(tmp_path):
+    module = _load_module()
+    python_bin = tmp_path / "bundle" / "python" / "python.exe"
+
+    assert module._python_home_for(python_bin) == python_bin.parent
+
+
+def test_python_home_matches_posix_bin_runtime_layout(tmp_path):
+    module = _load_module()
+    python_bin = tmp_path / "bundle" / "python" / "bin" / "python3.14"
+
+    assert module._python_home_for(python_bin) == python_bin.parent.parent


### PR DESCRIPTION
The Windows leg of the v1.106.0 desktop release exited before its sidecar smoke-test handshake.

- Set `PYTHONHOME` to the flat runtime directory that contains `python.exe` on Windows.
- Preserve the existing `<runtime>/bin/python` behavior on macOS and Linux.
- Add regression coverage for both layouts.

Verification: `uv run pytest --no-cov -q tests/scripts/test_build_sidecar.py`; Ruff lint and format checks.