### PR TITLE
feat: add diagramming skill

### DIFF
--- a/.openagentd/skills/oad/diagram/SKILL.md
+++ b/.openagentd/skills/oad/diagram/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: oad/diagram
+description: Select and create accurate software architecture, workflow, interaction, data, state, and deployment diagrams.
+---
+
+# OAD Diagramming
+
+Use this skill to select a diagram type, then read only its reference.
+
+| Request | Reference |
+| --- | --- |
+| System/runtime architecture, integrations, components | [architecture](references/architecture.md) |
+| User, business, or operational process | [workflow](references/workflow.md) |
+| Requests, events, streaming, or cross-service interactions | [sequence](references/sequence.md) |
+| Lifecycle, retry, cancellation, or status transitions | [state](references/state.md) |
+| Persistent records and relationships | [data](references/data.md) |
+| Device, process, network, and trust topology | [deployment](references/deployment.md) |
+
+Before drawing, state the one question it answers and verify facts in code,
+tests, configuration, docs, and the nearest `AGENTS.md`. Use the smallest
+useful diagram; split crowded views. Label relationships and directions, mark
+proposals/unknowns, and keep open questions separate from facts. Do not expose
+secrets or private data, or add a renderer/dependency unless explicitly asked.

--- a/.openagentd/skills/oad/diagram/references/architecture.md
+++ b/.openagentd/skills/oad/diagram/references/architecture.md
@@ -1,0 +1,22 @@
+# Architecture diagrams
+
+Use a plain bounded system or runtime view; no formal notation is required.
+
+- **System context:** users, OpenAgentd, external systems, labeled integrations.
+- **Runtime architecture:** major runtime parts, responsibilities, protocols,
+  stores, and relevant boundaries.
+- **Component view:** one bounded subsystem only, when an implementation needs
+  more detail.
+
+Use role-oriented names and verb-oriented arrows. Start broad, then zoom in;
+do not mix all levels in one diagram. C4 is optional, not a default.
+
+## Example
+
+```mermaid
+flowchart LR
+  user[User] --> ui[Client UI]
+  ui -->|HTTP / SSE| api[Backend API]
+  api --> db[(SQLite)]
+  api --> agent[Agent runtime]
+```

--- a/.openagentd/skills/oad/diagram/references/data.md
+++ b/.openagentd/skills/oad/diagram/references/data.md
@@ -1,0 +1,17 @@
+# Data diagrams
+
+Use an ER diagram for persistent records and their relationships.
+
+Show entities, cardinality, important keys, and ownership. Use the storage
+schema as the source of truth. Do not add service methods or transient events;
+use an architecture or sequence diagram for those.
+
+## Example
+
+```mermaid
+erDiagram
+  SESSION ||--o{ MESSAGE : contains
+  SESSION { string id PK }
+  MESSAGE { string id PK
+            string session_id FK }
+```

--- a/.openagentd/skills/oad/diagram/references/deployment.md
+++ b/.openagentd/skills/oad/diagram/references/deployment.md
@@ -1,0 +1,20 @@
+# Deployment diagrams
+
+Use for where software executes and how runtime boundaries connect.
+
+Show device, process, storage, network, and trust boundaries relevant to the
+question. Label protocols and persistence. Distinguish browser, Tauri shell,
+and Python sidecar when applicable; do not imply a browser-only deployment
+passes through Tauri.
+
+## Example
+
+```mermaid
+flowchart TB
+  subgraph device[User device]
+    shell[Tauri shell] --> ui[React UI]
+    ui --> api[Python sidecar]
+    api --> db[(SQLite)]
+  end
+  api -->|MCP| server[Local MCP server]
+```

--- a/.openagentd/skills/oad/diagram/references/sequence.md
+++ b/.openagentd/skills/oad/diagram/references/sequence.md
@@ -1,0 +1,20 @@
+# Sequence diagrams
+
+Use for ordered interactions across people, UI, API, services, agents, tools,
+or external systems.
+
+Order messages top-to-bottom. Label calls, responses, events, and protocols;
+distinguish synchronous calls from async streams. Use `alt`/`opt` blocks for
+verified authorization, failure, cancellation, and retry paths. Omit internal
+method calls that do not affect the interaction contract.
+
+## Example
+
+```mermaid
+sequenceDiagram
+  actor User
+  User->>UI: Submit message
+  UI->>API: Create turn
+  API-->>UI: Stream events (SSE)
+  UI-->>User: Render result
+```

--- a/.openagentd/skills/oad/diagram/references/state.md
+++ b/.openagentd/skills/oad/diagram/references/state.md
@@ -1,0 +1,19 @@
+# State diagrams
+
+Use for a lifecycle with valid transitions, not for a linear process.
+
+Show initial and terminal states, transition triggers, and guards. Include
+retry, failure, cancellation, and recovery states only when they are real.
+Keep state names mutually exclusive and observable; a state is not an action.
+
+## Example
+
+```mermaid
+stateDiagram-v2
+  [*] --> queued
+  queued --> running: start
+  running --> completed: success
+  running --> failed: error
+  failed --> queued: retry
+  completed --> [*]
+```

--- a/.openagentd/skills/oad/diagram/references/workflow.md
+++ b/.openagentd/skills/oad/diagram/references/workflow.md
@@ -1,0 +1,18 @@
+# Workflow diagrams
+
+Use a flowchart for a decision or process; use swimlanes when ownership matters.
+
+Show the trigger, actions, decisions, responsible actor/system, and terminal
+outcomes. Label decision branches with their condition. Include an error,
+cancel, or retry path only when it changes the outcome. Do not use a workflow
+diagram to show message timing; use a sequence diagram instead.
+
+## Example
+
+```mermaid
+flowchart TD
+  start[Message submitted] --> validate{Valid?}
+  validate -->|yes| run[Run agent turn]
+  validate -->|no| error[Show validation error]
+  run --> done[Display result]
+```


### PR DESCRIPTION
## Summary
- add an indexed, project-local `oad/diagram` skill
- add concise references and Mermaid examples for architecture, workflow, sequence, state, data, and deployment diagrams
- keep diagram selection notation-agnostic and require fact verification

## Verification
- `uv run pytest tests/agent/tools/test_skill_loader.py -q`
- `git diff --check`