### PR TITLE
fix: restore mobile summarization access and queued handoff

### DIFF
--- a/app/agent/mode/team/team.py
+++ b/app/agent/mode/team/team.py
@@ -257,8 +257,8 @@ class AgentTeam:
         return self._user_message_lock
 
     def has_active_user_turn(self) -> bool:
-        """Return whether a user turn is active or the lead is already running."""
-        return self._has_active_turn or self.lead.state == "working"
+        """Return whether the lead is actively working on a user turn."""
+        return self.lead.state == "working"
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/app/agent/mode/team/team.py
+++ b/app/agent/mode/team/team.py
@@ -257,7 +257,11 @@ class AgentTeam:
         return self._user_message_lock
 
     def has_active_user_turn(self) -> bool:
-        """Return whether the lead is actively working on a user turn."""
+        """Return whether the team is still handling a user turn."""
+        return self._has_active_turn or self.lead.state == "working"
+
+    def has_active_lead_turn(self) -> bool:
+        """Return whether the lead itself is currently processing messages."""
         return self.lead.state == "working"
 
     # ------------------------------------------------------------------

--- a/app/api/routes/team/chat.py
+++ b/app/api/routes/team/chat.py
@@ -314,7 +314,7 @@ async def team_chat(
                 save_queued_user_message=save_queued_user_message,
                 save_message=save_message,
             )
-            if not team_obj.has_active_user_turn():
+            if not team_obj.has_active_lead_turn():
                 await team_obj._activate_queued_user_messages(session_id)
             return TeamChatResponse(
                 status="queued",

--- a/tests/api/routes/test_team.py
+++ b/tests/api/routes/test_team.py
@@ -358,39 +358,34 @@ class TestTeamChatRoute:
         assert response.json()["status"] == "queued"
         test_team._activate_queued_user_messages.assert_awaited_once_with(session_id)
 
-    def test_team_chat_queues_when_turn_active_before_lead_state_flips(
+    def test_team_chat_does_not_queue_when_lead_idle_members_running(
         self, app_with_team, test_team
     ):
-        """Quick follow-up POSTs must queue once a turn is active.
+        """When the lead is idle but members are still running, a new message
+        dispatches directly — the lead can accept a new turn.
 
-        Regression guard for two requests arriving close together: the first
-        request sets ``_has_active_turn`` before the lead activation task may
-        visibly flip ``lead.state`` to ``working``. The second request should
-        still persist as queued, not as an adjacent normal user row.
+        Previously ``has_active_user_turn`` checked ``_has_active_turn``
+        (which stays True until all members finish), causing messages to be
+        queued unnecessarily. With the fix it only checks lead state, so a
+        message goes straight to the idle lead.
         """
         session_id = str(uuid.uuid7())
         test_team.lead.state = "idle"
-        test_team._has_active_turn = True
-        test_team._activate_queued_user_messages = AsyncMock(return_value=False)
-
-        async def save_queue(_db, _session_id, _message, *, extra=None):
-            queued = AsyncMock()
-            queued.id = uuid.uuid7()
-            return queued
+        test_team._has_active_turn = True  # members still running
+        test_team.handle_user_message = AsyncMock(return_value=session_id)
 
         client = TestClient(app_with_team)
         try:
-            with patch("app.api.routes.team.chat.save_queued_user_message", save_queue):
-                response = client.post(
-                    "/api/team/chat",
-                    data={"message": "queued", "session_id": session_id},
-                )
+            response = client.post(
+                "/api/team/chat",
+                data={"message": "new message", "session_id": session_id},
+            )
         finally:
             test_team._has_active_turn = False
 
         assert response.status_code == 202
-        assert response.json()["status"] == "queued"
-        test_team._activate_queued_user_messages.assert_not_awaited()
+        assert response.json()["status"] == "accepted"
+        test_team.handle_user_message.assert_awaited_once()
 
     def test_team_chat_queued_message_persists_explicit_uploads(
         self, app_with_team, test_team

--- a/tests/api/routes/test_team.py
+++ b/tests/api/routes/test_team.py
@@ -358,34 +358,35 @@ class TestTeamChatRoute:
         assert response.json()["status"] == "queued"
         test_team._activate_queued_user_messages.assert_awaited_once_with(session_id)
 
-    def test_team_chat_does_not_queue_when_lead_idle_members_running(
+    def test_team_chat_activates_queue_when_lead_idle_members_running(
         self, app_with_team, test_team
     ):
-        """When the lead is idle but members are still running, a new message
-        dispatches directly — the lead can accept a new turn.
-
-        Previously ``has_active_user_turn`` checked ``_has_active_turn``
-        (which stays True until all members finish), causing messages to be
-        queued unnecessarily. With the fix it only checks lead state, so a
-        message goes straight to the idle lead.
-        """
+        """Keep durable ordering, but wake an idle lead without waiting for members."""
         session_id = str(uuid.uuid7())
         test_team.lead.state = "idle"
-        test_team._has_active_turn = True  # members still running
+        test_team._has_active_turn = True  # members from the prior lead turn still run
+        test_team._activate_queued_user_messages = AsyncMock(return_value=True)
         test_team.handle_user_message = AsyncMock(return_value=session_id)
+
+        async def save_queue(_db, _session_id, _message, *, extra=None):
+            queued = AsyncMock()
+            queued.id = uuid.uuid7()
+            return queued
 
         client = TestClient(app_with_team)
         try:
-            response = client.post(
-                "/api/team/chat",
-                data={"message": "new message", "session_id": session_id},
-            )
+            with patch("app.api.routes.team.chat.save_queued_user_message", save_queue):
+                response = client.post(
+                    "/api/team/chat",
+                    data={"message": "queued", "session_id": session_id},
+                )
         finally:
             test_team._has_active_turn = False
 
         assert response.status_code == 202
-        assert response.json()["status"] == "accepted"
-        test_team.handle_user_message.assert_awaited_once()
+        assert response.json()["status"] == "queued"
+        test_team._activate_queued_user_messages.assert_awaited_once_with(session_id)
+        test_team.handle_user_message.assert_not_awaited()
 
     def test_team_chat_queued_message_persists_explicit_uploads(
         self, app_with_team, test_team

--- a/web/src/__tests__/routes/settings.index.test.tsx
+++ b/web/src/__tests__/routes/settings.index.test.tsx
@@ -93,12 +93,14 @@ describe('SettingsHubPage — header', () => {
 // ── Mobile Preferences ─────────────────────────────────────────────────────
 
 describe('SettingsHubPage — mobile preferences', () => {
-  it('renders preferences links for sandbox, multimodal, title-generation, and notifications', () => {
+  it('renders preferences links for sandbox, multimodal, summarization, title-generation, notifications, and terminal', () => {
     renderHub({ status: 'ok', version: '1.2.3' })
 
     expect(screen.getByText(/sandbox settings/i)).toBeInTheDocument()
     expect(screen.getByText(/multimodal settings/i)).toBeInTheDocument()
+    expect(screen.getByText(/summarization settings/i)).toBeInTheDocument()
     expect(screen.getByText(/title generation settings/i)).toBeInTheDocument()
     expect(screen.getByText(/notification settings/i)).toBeInTheDocument()
+    expect(screen.getByText(/terminal settings/i)).toBeInTheDocument()
   })
 })

--- a/web/src/routes/settings.index.tsx
+++ b/web/src/routes/settings.index.tsx
@@ -11,6 +11,7 @@ import {
   Info,
   Shield,
   Image,
+  AlignLeft,
   Type,
   Bell,
   TerminalSquare,
@@ -219,6 +220,17 @@ export function SettingsHubPage() {
                 <div className="flex items-center gap-2.5">
                   <Image size={14} className="text-(--color-text-muted)" />
                   <span>Multimodal Settings</span>
+                </div>
+                <ChevronRight size={14} className="text-(--color-text-subtle)" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setSection('summarization')}
+                className="flex w-full items-center justify-between py-2.5 text-left text-xs text-(--color-text) hover:bg-(--bg-key)/20 focus:outline-none"
+              >
+                <div className="flex items-center gap-2.5">
+                  <AlignLeft size={14} className="text-(--color-text-muted)" />
+                  <span>Summarization Settings</span>
                 </div>
                 <ChevronRight size={14} className="text-(--color-text-subtle)" />
               </button>


### PR DESCRIPTION
## Summary

This PR contains two small fixes:

1. **Mobile settings navigation** — add the missing Summarization entry to the mobile Preferences list so the existing summarization settings are reachable on narrow screens.
2. **Queued follow-up handoff** — when members from a prior lead turn are still running but the lead is already idle, keep the new user message in the durable queue for FIFO ordering and activate that queue immediately instead of waiting for every member to finish.

## Why the queue fix works this way

`_has_active_turn` represents the whole team lifecycle and remains true while delegated members work. It must continue to guard scheduler dispatch and queue ordering. `lead.state`, however, determines whether queued user messages can be handed back to the lead now.

The route therefore:

- queues while the broader team turn is active;
- then immediately activates the durable queue when the lead itself is idle.

This avoids resetting shared SSE state or allowing a newer direct message to overtake an older queued message.

## Verification

- `make verify` — passed
- Backend queue activation, ordering, and scheduler guards — passed
- Web lint, app/test type checks, and tests — passed
- Mobile Preferences test covers the Summarization entry

No schema, migration, or configuration changes.
