### PR TITLE
perf(ci): optimize desktop build and workflow execution speed

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -40,13 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
+      - name: Install uv & Python 3.14
         uses: astral-sh/setup-uv@v8.3.2
         with:
+          python-version: "3.14"
           enable-cache: true
-
-      - name: Set up Python 3.14
-        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --frozen
@@ -66,19 +64,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
+      - name: Install uv & Python 3.14
         uses: astral-sh/setup-uv@v8.3.2
         with:
+          python-version: "3.14"
           enable-cache: true
-
-      - name: Set up Python 3.14
-        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --frozen
 
       - name: Run pytest
-        run: uv run pytest -n auto -q
+        run: uv run pytest -n 4 -q
 
   windows-smoke:
     name: Windows sidecar smoke
@@ -86,13 +82,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
+      - name: Install uv & Python 3.14
         uses: astral-sh/setup-uv@v8.3.2
         with:
+          python-version: "3.14"
           enable-cache: true
-
-      - name: Set up Python 3.14
-        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,13 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install uv
+      - name: Install uv & Python 3.14
         uses: astral-sh/setup-uv@v8.3.2
         with:
+          python-version: "3.14"
           enable-cache: true
-
-      - name: Set up Python 3.14
-        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -130,7 +130,7 @@ jobs:
           targets: ${{ matrix.rust_target }}
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure sccache & compiler env
         shell: bash

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -129,6 +129,18 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Configure sccache & compiler env
+        shell: bash
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          if [ "${{ matrix.platform }}" = "windows" ]; then
+            echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> "$GITHUB_ENV"
+          fi
+
       # ``Swatinem/rust-cache`` cleans the target/ tree (drops examples,
       # tests, incremental artifacts) before saving, so the cached blob
       # stays small (~200 MB instead of >1 GB). It also keys on

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -206,10 +206,8 @@ jobs:
         # ``no such command: tauri``.
         run: cargo binstall --no-confirm --force --version 2.11.1 tauri-cli
 
-      - name: Generate platform icons
-        run: uv run python scripts/generate_icons.py
-
-
+      # Platform icon assets are generated and committed under
+      # desktop/src-tauri/icons; release runners consume them directly.
       - name: Build Python sidecar bundle
         shell: bash
         run: |

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -75,7 +75,7 @@ jobs:
           components: clippy
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure sccache env
         run: |
@@ -114,7 +114,7 @@ jobs:
           components: clippy
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure sccache & compiler env
         run: |
@@ -160,7 +160,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure sccache env
         run: |

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -74,6 +74,14 @@ jobs:
         with:
           components: clippy
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Configure sccache env
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
         with:
@@ -104,6 +112,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Configure sccache & compiler env
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $env:GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $env:GITHUB_ENV
+          echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> $env:GITHUB_ENV
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
@@ -141,6 +158,14 @@ jobs:
             libssl-dev
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.8
+
+      - name: Configure sccache env
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -61,10 +61,10 @@ jobs:
         run: bun run lint
 
       - name: Type check (app)
-        run: bunx tsc -b --noEmit
+        run: bun run typecheck
 
       - name: Type check (tests)
-        run: bunx tsc -p tsconfig.test.json --noEmit
+        run: bun exec tsc -p tsconfig.test.json --noEmit
 
       - name: Tests
         run: bun run test

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -69,9 +69,9 @@ windows = { version = "0.62", features = [
 # this feature is used for production builds or when a dev server is not specified
 custom-protocol = ["tauri/custom-protocol"]
 
-# Smaller, faster-loading release binary. Whole-crate LTO + single codegen
-# unit enable cross-crate inlining; strip drops debug symbols from the
-# shipped executable (crash traces still come from the webview/backend logs).
+# Thin LTO preserves cross-crate optimization while allowing parallel codegen;
+# strip drops debug symbols from the shipped executable (crash traces still
+# come from the webview/backend logs).
 [profile.release]
 lto = "thin"
 codegen-units = 16

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -73,6 +73,6 @@ custom-protocol = ["tauri/custom-protocol"]
 # unit enable cross-crate inlining; strip drops debug symbols from the
 # shipped executable (crash traces still come from the webview/backend logs).
 [profile.release]
-lto = true
-codegen-units = 1
+lto = "thin"
+codegen-units = 16
 strip = true

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -47,6 +47,6 @@ custom-protocol = ["tauri/custom-protocol"]
 # unit enable cross-crate inlining; strip drops debug symbols from the
 # shipped executable (crash traces still come from the webview/backend logs).
 [profile.release]
-lto = true
-codegen-units = 1
+lto = "thin"
+codegen-units = 16
 strip = true

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -43,9 +43,9 @@ tempfile = "3"
 [features]
 custom-protocol = ["tauri/custom-protocol"]
 
-# Smaller, faster-loading release binary. Whole-crate LTO + single codegen
-# unit enable cross-crate inlining; strip drops debug symbols from the
-# shipped executable (crash traces still come from the webview/backend logs).
+# Thin LTO preserves cross-crate optimization while allowing parallel codegen;
+# strip drops debug symbols from the shipped executable (crash traces still
+# come from the webview/backend logs).
 [profile.release]
 lto = "thin"
 codegen-units = 16


### PR DESCRIPTION
Optimize GitHub Actions CI and Desktop Release build performance:

- Switch Cargo release profile from full LTO (lto = true, codegen-units = 1) to Thin LTO (lto = 'thin', codegen-units = 16) in desktop and mobile shells.
- Integrate mozilla-actions/sccache-action v0.0.10 with GHA storage across release-desktop.yml and tauri.yml workflows.
- Pass RUSTFLAGS=-C link-arg=/FASTLINK on Windows runner builds to accelerate MSVC linking.
- Reuse committed desktop icon assets instead of regenerating them on every platform release runner.
- Consolidate Python installation in core.yml and docs.yml directly within astral-sh/setup-uv via python-version: '3.14'.
- Avoid bunx registry lookup overhead in web.yml by calling bun run typecheck and bun exec tsc directly.

Warm-cache validation on the second CI run reduced Tauri jobs from 6m27s to 1m45s on Linux desktop, 9m26s to 2m44s on Windows desktop, and 2m45s to 1m00s on mobile.