### PR TITLE
perf(mobile): speed up local iOS device installs

### DIFF
--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev ios-init ios-icons ios-icons-force ios-dev ios-dev-device ios-install-device ios-build ios-clean build clean
+.PHONY: dev ios-init ios-icons ios-icons-force ios-web ios-dev ios-dev-device ios-install-device ios-install-device-fast ios-build ios-clean build clean
 
 IOS_DEVICE ?= $(word 2,$(MAKECMDGOALS))
 IOS_TEAM_FILE ?= ios-team.txt
@@ -9,6 +9,9 @@ IOS_DEV_PRODUCT_NAME ?= OpenAgentd Dev
 IOS_DEV_APP_CONFIG = --config '{"identifier":"$(IOS_DEV_IDENTIFIER)","productName":"$(IOS_DEV_PRODUCT_NAME)","plugins":{"deep-link":{"mobile":[{"scheme":["openagentd-dev"],"appLink":false}]}}}'
 IOS_APPICONSET = src-tauri/gen/apple/Assets.xcassets/AppIcon.appiconset
 IOS_ICON_STAMP = $(IOS_APPICONSET)/.openagentd-icons.stamp
+WEB_DIR = ../web
+WEB_DIST_INDEX = $(WEB_DIR)/dist/index.html
+WEB_BUILD_INPUTS = $(WEB_DIR)/index.html $(WEB_DIR)/package.json $(WEB_DIR)/bun.lock $(WEB_DIR)/tsconfig.json $(WEB_DIR)/tsconfig.app.json $(WEB_DIR)/tsconfig.node.json $(WEB_DIR)/vite.config.ts
 
 dev: ## Run the mobile shell against the web Vite dev server
 	cd src-tauri && cargo tauri dev
@@ -39,6 +42,23 @@ ios-icons-force: ## Force-regenerate iOS AppIcon assets from the shared OpenAgen
 		touch $(IOS_ICON_STAMP); \
 	fi
 
+ios-web: ## Build bundled Web assets only when their inputs changed
+	@needs_build=0; \
+	if [ ! -f "$(WEB_DIST_INDEX)" ]; then \
+		needs_build=1; \
+	elif find $(WEB_DIR)/src $(WEB_DIR)/public -type f -newer "$(WEB_DIST_INDEX)" -print -quit | grep -q .; then \
+		needs_build=1; \
+	else \
+		for input in $(WEB_BUILD_INPUTS); do \
+			if [ "$$input" -nt "$(WEB_DIST_INDEX)" ]; then needs_build=1; break; fi; \
+		done; \
+	fi; \
+	if [ "$$needs_build" -eq 1 ]; then \
+		cd $(WEB_DIR) && bun install --frozen-lockfile && bun run build; \
+	else \
+		echo "Web bundle is current; skipping build"; \
+	fi
+
 ios-dev: ## Run on an iOS simulator/device
 	cd src-tauri && cargo tauri ios dev --host
 
@@ -56,6 +76,15 @@ ios-install-device: ## Build and install the production iOS app on a device
 	fi
 	$(MAKE) ios-icons
 	cd src-tauri && cargo tauri ios build --archive-only $(IOS_TEAM_CONFIG)
+	xcrun devicectl device install app --device "$(IOS_DEVICE)" src-tauri/gen/apple/build/openagentd-mobile_iOS.xcarchive/Products/Applications/OpenAgentd.app
+
+ios-install-device-fast: ## Build and install a bundled debug iOS app on a device
+	@if [ -z "$(IOS_DEVICE)" ]; then \
+		echo "Usage: make ios-install-device-fast <device-name>"; \
+		exit 2; \
+	fi
+	$(MAKE) ios-icons
+	cd src-tauri && cargo tauri ios build --debug --archive-only $(IOS_TEAM_CONFIG)
 	xcrun devicectl device install app --device "$(IOS_DEVICE)" src-tauri/gen/apple/build/openagentd-mobile_iOS.xcarchive/Products/Applications/OpenAgentd.app
 
 %:

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -45,7 +45,13 @@ Run on simulator/device:
 make ios-dev
 ```
 
-Install a production build with bundled Web UI on a physical iPhone:
+Install a bundled debug build for faster iteration on a physical iPhone:
+
+```bash
+make ios-install-device-fast <device-name>
+```
+
+The fast target preserves Cargo and Xcode incremental build state and skips the Web build when `web/dist` is newer than its inputs. Before shipping, install a production build:
 
 ```bash
 make ios-install-device <device-name>

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
     "devUrl": "http://localhost:5173",
     "beforeBuildCommand": {
       "cwd": "../..",
-      "script": "cd web && bun install --frozen-lockfile && bun run build"
+      "script": "make -C mobile ios-web"
     },
     "frontendDist": "../../web/dist"
   },

--- a/tests/scripts/test_mobile_ios_makefile.py
+++ b/tests/scripts/test_mobile_ios_makefile.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOBILE_MAKEFILE = REPO_ROOT / "mobile" / "Makefile"
+TAURI_CONFIG = REPO_ROOT / "mobile" / "src-tauri" / "tauri.conf.json"
+
+
+def test_fast_device_install_uses_debug_archive_and_existing_installer_path():
+    makefile = MOBILE_MAKEFILE.read_text()
+
+    assert "ios-install-device-fast:" in makefile
+    assert "cargo tauri ios build --debug --archive-only" in makefile
+    assert "Products/Applications/OpenAgentd.app" in makefile
+
+
+def test_ios_web_build_is_skipped_when_dist_is_fresh():
+    makefile = MOBILE_MAKEFILE.read_text()
+    config = json.loads(TAURI_CONFIG.read_text())
+
+    assert "ios-web:" in makefile
+    assert "find $(WEB_DIR)/src $(WEB_DIR)/public" in makefile
+    assert "Web bundle is current; skipping build" in makefile
+    assert config["build"]["beforeBuildCommand"] == {
+        "cwd": "../..",
+        "script": "make -C mobile ios-web",
+    }


### PR DESCRIPTION
Speed up local physical-device iteration while preserving the production install path.

- Add `make ios-install-device-fast <device-name>` for a bundled debug archive that benefits from incremental Rust and Xcode builds.
- Add `ios-web`, which rebuilds `web/dist` only when Web source or build configuration inputs are newer.
- Route Tauri's `beforeBuildCommand` through the incremental Web target.
- Document when to use fast versus production device installation.
- Add contract tests for both targets and the Tauri build hook.

Validation:

- `uv run pytest --no-cov tests/scripts/test_mobile_ios_makefile.py -q`
- `make -C mobile ios-web`
- `make -C mobile -n ios-install-device-fast TestPhone`
- `make verify-docs`
