### PR TITLE
fix(ci): enable SCCACHE_DIRECT=true for sccache compiler cache

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -137,6 +137,7 @@ jobs:
         run: |
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
           if [ "${{ matrix.platform }}" = "windows" ]; then
             echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
@@ -120,6 +121,7 @@ jobs:
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $env:GITHUB_ENV
           echo "SCCACHE_GHA_ENABLED=true" >> $env:GITHUB_ENV
+          echo "SCCACHE_DIRECT=true" >> $env:GITHUB_ENV
           echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> $env:GITHUB_ENV
 
       - name: Cache cargo registry + target
@@ -166,6 +168,7 @@ jobs:
         run: |
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Enables `SCCACHE_DIRECT=true` in `release-desktop.yml` and `tauri.yml` to allow `sccache` to use direct mode for hashing Rust inputs, skipping redundant preprocessing steps and improving compiler cache hit rates.