### PR TITLE
ci(cache): drop sccache and stop PR-scoped rust-cache saves

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -129,24 +129,24 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache & compiler env
+      # /FASTLINK speeds up MSVC linking; unrelated to any compiler cache.
+      - name: Configure compiler env
         shell: bash
         run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
           if [ "${{ matrix.platform }}" = "windows" ]; then
             echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> "$GITHUB_ENV"
           fi
 
       # ``Swatinem/rust-cache`` cleans the target/ tree (drops examples,
-      # tests, incremental artifacts) before saving, so the cached blob
-      # stays small (~200 MB instead of >1 GB). It also keys on
+      # tests, incremental artifacts) before saving, then keys on
       # ``rustc -Vv``, ``Cargo.lock``, and target triple so a Rust
       # toolchain bump or dependency change invalidates correctly.
+      #
+      # These blobs still measure ~0.5-1.5 GB each. The repo-wide GitHub
+      # cache budget is a hard 10 GB shared by every workflow, so keep an
+      # eye on ``gh api /repos/{owner}/{repo}/actions/cache/usage`` when
+      # adding cached paths — at the cap, GitHub evicts by LRU and every
+      # cache silently degrades to partial restores.
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -74,19 +74,15 @@ jobs:
         with:
           components: clippy
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache env
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
-
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop/src-tauri
+          # Only ``main`` writes cache entries. These blobs are ~0.5-1.5 GB
+          # each and the repo-wide GitHub cache budget is a hard 10 GB, so
+          # letting every PR run save would evict the warm ``main`` entries
+          # that PRs restore from. PR runs still read ``main``'s cache.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cargo check
         run: TAURI_CONFIG="$(cat tauri.dev.conf.json)" cargo check --locked
@@ -114,14 +110,9 @@ jobs:
         with:
           components: clippy
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache & compiler env
+      # /FASTLINK speeds up MSVC linking; unrelated to any compiler cache.
+      - name: Configure compiler env
         run: |
-          echo "RUSTC_WRAPPER=sccache" >> $env:GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $env:GITHUB_ENV
-          echo "SCCACHE_DIRECT=true" >> $env:GITHUB_ENV
           echo "RUSTFLAGS=-C link-arg=/FASTLINK" >> $env:GITHUB_ENV
 
       - name: Cache cargo registry + target
@@ -129,6 +120,8 @@ jobs:
         with:
           workspaces: desktop/src-tauri
           key: windows-x86_64
+          # See the desktop job: main-only saves protect the 10 GB budget.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cargo check
         run: $env:TAURI_CONFIG = Get-Content tauri.dev.conf.json -Raw; cargo check --locked
@@ -161,19 +154,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Configure sccache env
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "SCCACHE_DIRECT=true" >> "$GITHUB_ENV"
-
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: mobile/src-tauri
+          # See the desktop job: main-only saves protect the 10 GB budget.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cargo check
         run: TAURI_CONFIG='{"bundle":{"icon":["icons/icon.png"]}}' cargo check --locked


### PR DESCRIPTION
Repo was pinned at GitHub's hard 10 GB Actions cache cap (10.1 GB / 1,427 entries), so every save evicted older entries by LRU and all caches degraded to partial restores.

## Measured findings

**sccache never hit once.** Across every run inspected:

| run | hits | misses | writes |
|---|---|---|---|
| tauri 30346810874 (main) | 0 | 41 | 41 |
| tauri 30346810874 (main) | 0 | 11 | 11 |
| release-desktop linux | 0 | 62 | 62 |
| tauri PR 30523828099 | 0 | 152 | 0 |

It is structurally redundant with `rust-cache`, which restores `target/` so cargo never re-invokes rustc for cached crates. Cost: 1.17 GB and **1,409 of 1,432 cache entries**, plus `RUSTC_WRAPPER` overhead per rustc call.

**Cache budget by family (before):**

| family | count | total |
|---|---|---|
| rust-cache | 9 | 7.30 GB |
| setup-uv | 10 | 1.46 GB |
| sccache | 1,409 | 1.17 GB |
| bun | 1 | 0.15 GB |

**`tauri.yml` had no `save-if`**, so its three jobs saved ~3.4 GB of PR-scoped caches per PR run, evicting the warm `main` entries those PRs restore from. `release-desktop.yml` already gated saves on `main`; `tauri.yml` now matches.

## Notes

- Windows `/FASTLINK` RUSTFLAGS is a linker setting, not a compiler cache — preserved in both workflows.
- Removing `RUSTC_WRAPPER` changes rust-cache's env hash (`env-vars` matches the `RUST` prefix), so **the first run after merge is a cold build** for Rust jobs. Subsequent runs hit the new key.
- Also pruned superseded cache generations out-of-band: **10.1 GB -> 6.91 GB**, 1432 -> 1025 entries.
- Corrected the stale `~200 MB` comment in release-desktop.yml (actual blobs are 0.5-1.5 GB).